### PR TITLE
Add GitHub Wiki support as KnowledgeBase backend

### DIFF
--- a/crates/github-backend/Cargo.toml
+++ b/crates/github-backend/Cargo.toml
@@ -12,7 +12,11 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 urlencoding = "2.1"
+git2 = "0.18"
+walkdir = "2"
+serde_yaml = "0.9"
 
 [dev-dependencies]
 wiremock = { workspace = true }
 tokio = { workspace = true }
+tempfile = "3"

--- a/crates/github-backend/src/client.rs
+++ b/crates/github-backend/src/client.rs
@@ -3,6 +3,7 @@ use ureq::Agent;
 
 use crate::error::{GitHubError, Result};
 use crate::models::*;
+use crate::wiki::WikiManager;
 
 /// GitHub REST API client
 pub struct GitHubClient {
@@ -11,12 +12,23 @@ pub struct GitHubClient {
     owner: String,
     repo: String,
     token: String,
+    wiki_manager: WikiManager,
 }
 
 impl GitHubClient {
     /// Create a new GitHub client targeting api.github.com
     pub fn new(owner: &str, repo: &str, token: &str) -> Self {
         Self::with_base_url("https://api.github.com", owner, repo, token)
+    }
+
+    /// Get or initialize the wiki manager
+    pub fn get_or_init_wiki(&mut self) -> Result<&mut WikiManager> {
+        Ok(&mut self.wiki_manager)
+    }
+
+    /// Get wiki manager (read-only)
+    pub fn wiki(&self) -> &WikiManager {
+        &self.wiki_manager
     }
 
     /// Create a new GitHub client with a custom base URL (for GitHub Enterprise or testing)
@@ -27,12 +39,16 @@ impl GitHubClient {
             .build()
             .into();
 
+        let wiki_manager = WikiManager::new(owner, repo, token)
+            .unwrap_or_else(|_| panic!("Failed to initialize WikiManager"));
+
         Self {
             agent,
             base_url: base_url.trim_end_matches('/').to_string(),
             owner: owner.to_string(),
             repo: repo.to_string(),
             token: token.to_string(),
+            wiki_manager,
         }
     }
 

--- a/crates/github-backend/src/error.rs
+++ b/crates/github-backend/src/error.rs
@@ -26,6 +26,9 @@ pub enum GitHubError {
 
     #[error("API error ({status}): {message}")]
     Api { status: u16, message: String },
+
+    #[error("Wiki error: {0}")]
+    Wiki(String),
 }
 
 pub type Result<T> = std::result::Result<T, GitHubError>;
@@ -44,6 +47,7 @@ impl From<GitHubError> for TrackerError {
                 message: "GitHub API rate limit exceeded".to_string(),
             },
             GitHubError::Api { status, message } => TrackerError::Api { status, message },
+            GitHubError::Wiki(msg) => TrackerError::InvalidInput(format!("Wiki error: {}", msg)),
         }
     }
 }

--- a/crates/github-backend/src/lib.rs
+++ b/crates/github-backend/src/lib.rs
@@ -3,10 +3,15 @@ mod convert;
 pub mod error;
 pub mod models;
 mod trait_impl;
+mod wiki;
+
 
 #[cfg(test)]
 mod client_tests;
+#[cfg(test)]
+mod wiki_tests;
 
+pub use wiki::WikiManager;
 pub use client::GitHubClient;
 pub use error::{GitHubError, Result};
 pub use models::*;

--- a/crates/github-backend/src/trait_impl.rs
+++ b/crates/github-backend/src/trait_impl.rs
@@ -1,8 +1,9 @@
 //! Implementation of tracker-core traits for GitHubClient
 
 use tracker_core::{
-    Comment, CreateIssue, CreateProject, CreateTag, Issue, IssueLink, IssueTag, IssueTracker,
-    Project, ProjectCustomField, Result, TrackerError, UpdateIssue,
+    Article, ArticleAttachment, ArticleRef, Comment, CommentAuthor, CreateArticle, CreateIssue,
+    CreateProject, CreateTag, Issue, IssueLink, IssueTag, IssueTracker, KnowledgeBase, Project,
+    ProjectCustomField, ProjectRef, Result, Tag, TrackerError, UpdateArticle, UpdateIssue,
 };
 
 use crate::client::GitHubClient;
@@ -10,6 +11,7 @@ use crate::convert::{
     convert_query_to_github, create_issue_from_core, get_standard_custom_fields,
     github_issue_to_core, update_issue_from_core,
 };
+use crate::wiki::WikiPage;
 
 /// Parse an issue number from a string identifier.
 ///
@@ -236,5 +238,228 @@ impl IssueTracker for GitHubClient {
         self.get_comments(number)
             .map(|cs| cs.into_iter().map(Into::into).collect())
             .map_err(TrackerError::from)
+    }
+}
+
+// ============================================================================
+// KnowledgeBase Implementation
+// ============================================================================
+
+/// Convert a WikiPage to an Article
+fn wiki_page_to_article(page: WikiPage, owner: &str, repo: &str) -> Article {
+    Article {
+        id: page.slug.clone(),
+        id_readable: format!("{}/{}#{}", owner, repo, page.slug),
+        summary: page.title,
+        content: Some(page.content),
+        project: ProjectRef {
+            id: format!("{}/{}", owner, repo),
+            name: Some(repo.to_string()),
+            short_name: Some(format!("{}/{}", owner, repo)),
+        },
+        parent_article: page.parent.map(|p| ArticleRef {
+            id: p.clone(),
+            id_readable: Some(format!("{}/{}#{}", owner, repo, p)),
+            summary: Some(p.replace('-', " ")),
+        }),
+        has_children: false, // Will be set by caller if needed
+        tags: page
+            .tags
+            .into_iter()
+            .map(|t| Tag {
+                id: t.clone(),
+                name: t,
+            })
+            .collect(),
+        created: page.created,
+        updated: page.updated,
+        reporter: page.author.map(|name| CommentAuthor {
+            login: name.clone(),
+            name: Some(name),
+        }),
+    }
+}
+
+impl KnowledgeBase for GitHubClient {
+    fn get_article(&self, id: &str) -> Result<Article> {
+        let wiki = self.wiki();
+        let page = wiki.get_page(id).map_err(TrackerError::from)?;
+        let mut article = wiki_page_to_article(page, self.owner(), self.repo());
+
+        // Check if this page has children
+        if let Ok(children) = wiki.get_child_pages(id) {
+            article.has_children = !children.is_empty();
+        }
+
+        Ok(article)
+    }
+
+    fn list_articles(
+        &self,
+        project_id: Option<&str>,
+        limit: usize,
+        skip: usize,
+    ) -> Result<Vec<Article>> {
+        // Filter by project if specified
+        if let Some(proj) = project_id {
+            let expected_project = format!("{}/{}", self.owner(), self.repo());
+            if proj != expected_project {
+                return Ok(Vec::new()); // Project doesn't match
+            }
+        }
+
+        let wiki = self.wiki();
+        let pages = wiki.list_pages().map_err(TrackerError::from)?;
+        
+        // Check children for each page
+        let mut articles: Vec<Article> = pages
+            .into_iter()
+            .map(|page| {
+                let slug = page.slug.clone();
+                let mut article = wiki_page_to_article(page, self.owner(), self.repo());
+                
+                if let Ok(children) = wiki.get_child_pages(&slug) {
+                    article.has_children = !children.is_empty();
+                }
+                
+                article
+            })
+            .collect();
+
+        // Apply pagination
+        let total = articles.len();
+        let start = skip.min(total);
+        let end = (skip + limit).min(total);
+        
+        Ok(articles.drain(start..end).collect())
+    }
+
+    fn search_articles(&self, query: &str, limit: usize, skip: usize) -> Result<Vec<Article>> {
+        let wiki = self.wiki();
+        let pages = wiki.search_pages(query).map_err(TrackerError::from)?;
+        
+        let mut articles: Vec<Article> = pages
+            .into_iter()
+            .map(|page| {
+                let slug = page.slug.clone();
+                let mut article = wiki_page_to_article(page, self.owner(), self.repo());
+                
+                if let Ok(children) = wiki.get_child_pages(&slug) {
+                    article.has_children = !children.is_empty();
+                }
+                
+                article
+            })
+            .collect();
+
+        // Apply pagination
+        let total = articles.len();
+        let start = skip.min(total);
+        let end = (skip + limit).min(total);
+        
+        Ok(articles.drain(start..end).collect())
+    }
+
+    fn create_article(&self, article: &CreateArticle) -> Result<Article> {
+        // Verify project matches
+        let expected_project = format!("{}/{}", self.owner(), self.repo());
+        if article.project_id != expected_project
+            && article.project_id != self.repo()
+            && article.project_id != self.owner()
+        {
+            return Err(TrackerError::InvalidInput(format!(
+                "Project '{}' does not match current repository '{}'",
+                article.project_id, expected_project
+            )));
+        }
+
+        let wiki = self.wiki();
+
+        // Generate slug from title
+        let slug = if let Some(parent) = &article.parent_article_id {
+            format!(
+                "{}/{}",
+                parent,
+                article.summary.to_lowercase().replace(' ', "-")
+            )
+        } else {
+            article.summary.to_lowercase().replace(' ', "-")
+        };
+
+        let content = article.content.as_deref().unwrap_or("");
+        
+        let page = wiki
+            .create_page(&slug, &article.summary, content, article.tags.clone())
+            .map_err(TrackerError::from)?;
+
+        Ok(wiki_page_to_article(page, self.owner(), self.repo()))
+    }
+
+    fn update_article(&self, id: &str, update: &UpdateArticle) -> Result<Article> {
+        let wiki = self.wiki();
+
+        let page = wiki
+            .update_page(
+                id,
+                update.summary.as_deref(),
+                update.content.as_deref(),
+                if update.tags.is_empty() {
+                    None
+                } else {
+                    Some(update.tags.clone())
+                },
+            )
+            .map_err(TrackerError::from)?;
+
+        Ok(wiki_page_to_article(page, self.owner(), self.repo()))
+    }
+
+    fn delete_article(&self, id: &str) -> Result<()> {
+        let wiki = self.wiki();
+
+        wiki.delete_page(id).map_err(TrackerError::from)
+    }
+
+    fn get_child_articles(&self, parent_id: &str) -> Result<Vec<Article>> {
+        let wiki = self.wiki();
+
+        let pages = wiki
+            .get_child_pages(parent_id)
+            .map_err(TrackerError::from)?;
+
+        let articles = pages
+            .into_iter()
+            .map(|page| wiki_page_to_article(page, self.owner(), self.repo()))
+            .collect();
+
+        Ok(articles)
+    }
+
+    fn move_article(&self, article_id: &str, new_parent_id: Option<&str>) -> Result<Article> {
+        let wiki = self.wiki();
+
+        let page = wiki
+            .move_page(article_id, new_parent_id)
+            .map_err(TrackerError::from)?;
+
+        Ok(wiki_page_to_article(page, self.owner(), self.repo()))
+    }
+
+    fn list_article_attachments(&self, _article_id: &str) -> Result<Vec<ArticleAttachment>> {
+        // GitHub wikis don't have native attachment support
+        // Could potentially scan for images in the markdown, but for now return empty
+        Ok(Vec::new())
+    }
+
+    fn get_article_comments(&self, _article_id: &str) -> Result<Vec<Comment>> {
+        // GitHub wikis don't support comments
+        Ok(Vec::new())
+    }
+
+    fn add_article_comment(&self, _article_id: &str, _text: &str) -> Result<Comment> {
+        // GitHub wikis don't support comments
+        Err(TrackerError::InvalidInput(
+            "GitHub wikis do not support comments".to_string(),
+        ))
     }
 }

--- a/crates/github-backend/src/wiki.rs
+++ b/crates/github-backend/src/wiki.rs
@@ -1,0 +1,628 @@
+use crate::error::{GitHubError, Result};
+use chrono::{DateTime, Utc};
+use git2::{Cred, RemoteCallbacks, Repository, Signature};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use walkdir::WalkDir;
+
+/// YAML front matter for wiki pages
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct FrontMatter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<String>,
+}
+
+/// Represents a wiki page on disk
+#[derive(Debug, Clone)]
+pub struct WikiPage {
+    /// Page slug (filename without .md extension)
+    pub slug: String,
+    /// Page title (from front matter or filename)
+    pub title: String,
+    /// Markdown content (without front matter)
+    pub content: String,
+    /// Parent directory (if nested)
+    pub parent: Option<String>,
+    /// Tags from front matter
+    pub tags: Vec<String>,
+    /// Creation timestamp (first commit)
+    pub created: DateTime<Utc>,
+    /// Last update timestamp (last commit)
+    pub updated: DateTime<Utc>,
+    /// Author (from last commit)
+    pub author: Option<String>,
+}
+
+/// Manages a GitHub wiki as a Git repository
+pub struct WikiManager {
+    owner: String,
+    repo: String,
+    token: String,
+    cache_dir: PathBuf,
+    initialized: AtomicBool,
+}
+
+impl WikiManager {
+    /// Create a new WikiManager
+    pub fn new(owner: &str, repo: &str, token: &str) -> Result<Self> {
+        let cache_dir = Self::get_cache_dir(owner, repo)?;
+        
+        Ok(Self {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            token: token.to_string(),
+            cache_dir,
+            initialized: AtomicBool::new(false),
+        })
+    }
+
+    /// Get cache directory for this wiki
+    fn get_cache_dir(owner: &str, repo: &str) -> Result<PathBuf> {
+        let base_dir = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| std::env::temp_dir());
+
+        let cache_dir = base_dir
+            .join(".cache")
+            .join("track")
+            .join("wikis")
+            .join(owner)
+            .join(repo);
+
+        Ok(cache_dir)
+    }
+
+    /// Get wiki repository URL with authentication
+    fn wiki_url(&self) -> String {
+        format!(
+            "https://{}@github.com/{}/{}.wiki.git",
+            self.token, self.owner, self.repo
+        )
+    }
+
+    /// Initialize wiki repository (clone or fetch)
+    pub fn ensure_initialized(&self) -> Result<()> {
+        if self.initialized.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        if self.cache_dir.exists() {
+            // Repository exists, fetch latest
+            self.fetch_and_merge()?;
+        } else {
+            // Clone wiki repository
+            self.clone_wiki()?;
+        }
+
+        self.initialized.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Clone the wiki repository
+    fn clone_wiki(&self) -> Result<()> {
+        // Create parent directories
+        if let Some(parent) = self.cache_dir.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                GitHubError::Wiki(format!("Failed to create cache directory: {}", e))
+            })?;
+        }
+
+        let mut callbacks = RemoteCallbacks::new();
+        callbacks.credentials(|_url, _username, _allowed| {
+            Cred::userpass_plaintext(&self.token, "x-oauth-basic")
+        });
+
+        let mut fetch_opts = git2::FetchOptions::new();
+        fetch_opts.remote_callbacks(callbacks);
+
+        let mut builder = git2::build::RepoBuilder::new();
+        builder.fetch_options(fetch_opts);
+
+        builder
+            .clone(&self.wiki_url(), &self.cache_dir)
+            .map_err(|e| {
+                GitHubError::Wiki(format!(
+                    "Failed to clone wiki (wiki may not exist or may be disabled): {}",
+                    e
+                ))
+            })?;
+
+        Ok(())
+    }
+
+    /// Fetch and merge latest changes
+    fn fetch_and_merge(&self) -> Result<()> {
+        let repo = Repository::open(&self.cache_dir).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to open wiki repository: {}", e))
+        })?;
+
+        let mut remote = repo.find_remote("origin").map_err(|e| {
+            GitHubError::Wiki(format!("Failed to find origin remote: {}", e))
+        })?;
+
+        let mut callbacks = RemoteCallbacks::new();
+        callbacks.credentials(|_url, _username, _allowed| {
+            Cred::userpass_plaintext(&self.token, "x-oauth-basic")
+        });
+
+        let mut fetch_opts = git2::FetchOptions::new();
+        fetch_opts.remote_callbacks(callbacks);
+
+        remote
+            .fetch(&["master", "main"], Some(&mut fetch_opts), None)
+            .map_err(|e| GitHubError::Wiki(format!("Failed to fetch: {}", e)))?;
+
+        // Merge FETCH_HEAD into current branch
+        let fetch_head = repo.find_reference("FETCH_HEAD").map_err(|e| {
+            GitHubError::Wiki(format!("Failed to find FETCH_HEAD: {}", e))
+        })?;
+        let fetch_commit = repo.reference_to_annotated_commit(&fetch_head).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to get fetch commit: {}", e))
+        })?;
+
+        let analysis = repo.merge_analysis(&[&fetch_commit]).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to analyze merge: {}", e))
+        })?;
+
+        if analysis.0.is_fast_forward() {
+            let mut reference = repo.find_reference("HEAD").map_err(|e| {
+                GitHubError::Wiki(format!("Failed to find HEAD: {}", e))
+            })?;
+            let name = reference
+                .name()
+                .ok_or_else(|| GitHubError::Wiki("Invalid reference name".to_string()))?
+                .to_string();
+            let msg = format!("Fast-forward merge");
+            reference
+                .set_target(fetch_commit.id(), &msg)
+                .map_err(|e| GitHubError::Wiki(format!("Failed to fast-forward: {}", e)))?;
+            repo.set_head(&name)
+                .map_err(|e| GitHubError::Wiki(format!("Failed to set HEAD: {}", e)))?;
+            repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
+                .map_err(|e| GitHubError::Wiki(format!("Failed to checkout: {}", e)))?;
+        }
+
+        Ok(())
+    }
+
+    /// List all wiki pages
+    pub fn list_pages(&self) -> Result<Vec<WikiPage>> {
+        self.ensure_initialized()?;
+
+        let mut pages = Vec::new();
+
+        for entry in WalkDir::new(&self.cache_dir)
+            .follow_links(false)
+            .min_depth(1)
+        {
+            let entry = entry.map_err(|e| {
+                GitHubError::Wiki(format!("Failed to read directory: {}", e))
+            })?;
+
+            let path = entry.path();
+            
+            // Skip special pages, git directory, and non-markdown files
+            if self.should_skip_path(path) {
+                continue;
+            }
+
+            if path.extension().and_then(|s| s.to_str()) == Some("md") {
+                if let Ok(page) = self.read_page(path) {
+                    pages.push(page);
+                }
+            }
+        }
+
+        Ok(pages)
+    }
+
+    /// Check if path should be skipped
+    fn should_skip_path(&self, path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+        
+        // Skip .git directory
+        if path_str.contains("/.git/") || path_str.ends_with("/.git") {
+            return true;
+        }
+
+        // Skip special GitHub wiki pages
+        if let Some(filename) = path.file_name() {
+            let filename_str = filename.to_string_lossy();
+            if filename_str.starts_with('_') {
+                return true; // _Sidebar.md, _Header.md, _Footer.md
+            }
+        }
+
+        false
+    }
+
+    /// Read a wiki page from disk
+    fn read_page(&self, path: &Path) -> Result<WikiPage> {
+        let content = fs::read_to_string(path).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to read file: {}", e))
+        })?;
+
+        // Parse front matter and content
+        let (front_matter, content) = self.parse_markdown_with_frontmatter(&content);
+
+        // Get slug from filename
+        let relative_path = path
+            .strip_prefix(&self.cache_dir)
+            .map_err(|_| GitHubError::Wiki("Invalid path".to_string()))?;
+
+        let slug = relative_path
+            .with_extension("")
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        // Extract parent from path
+        let parent = relative_path
+            .parent()
+            .and_then(|p| {
+                if p == Path::new("") {
+                    None
+                } else {
+                    Some(p.to_string_lossy().replace('\\', "/"))
+                }
+            });
+
+        // Get title from front matter or filename
+        let title = front_matter
+            .title
+            .clone()
+            .or_else(|| {
+                path.file_stem()
+                    .map(|s| s.to_string_lossy().replace('-', " "))
+            })
+            .unwrap_or_else(|| slug.clone());
+
+        // Get timestamps from git
+        let (created, updated, author) = self.get_file_timestamps(path)?;
+
+        Ok(WikiPage {
+            slug,
+            title,
+            content,
+            parent,
+            tags: front_matter.tags,
+            created,
+            updated,
+            author,
+        })
+    }
+
+    /// Parse markdown with YAML front matter
+    fn parse_markdown_with_frontmatter(&self, content: &str) -> (FrontMatter, String) {
+        let lines: Vec<&str> = content.lines().collect();
+        
+        if lines.first() == Some(&"---") {
+            // Find closing ---
+            if let Some(end_idx) = lines.iter().skip(1).position(|&line| line == "---") {
+                let yaml_lines = &lines[1..end_idx + 1];
+                let yaml_str = yaml_lines.join("\n");
+                
+                if let Ok(front_matter) = serde_yaml::from_str::<FrontMatter>(&yaml_str) {
+                    let content_lines = &lines[end_idx + 2..];
+                    let content = content_lines.join("\n");
+                    return (front_matter, content);
+                }
+            }
+        }
+
+        (FrontMatter::default(), content.to_string())
+    }
+
+    /// Get file timestamps from git history
+    fn get_file_timestamps(&self, path: &Path) -> Result<(DateTime<Utc>, DateTime<Utc>, Option<String>)> {
+        let repo = Repository::open(&self.cache_dir).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to open repository: {}", e))
+        })?;
+
+        let relative_path = path
+            .strip_prefix(&self.cache_dir)
+            .map_err(|_| GitHubError::Wiki("Invalid path".to_string()))?;
+
+        let mut revwalk = repo.revwalk().map_err(|e| {
+            GitHubError::Wiki(format!("Failed to walk commits: {}", e))
+        })?;
+        revwalk.push_head().ok();
+
+        let mut first_commit_time = None;
+        let mut last_commit_time = None;
+        let mut last_author = None;
+
+        for oid in revwalk {
+            if let Ok(oid) = oid {
+                if let Ok(commit) = repo.find_commit(oid) {
+                    if let Ok(tree) = commit.tree() {
+                        if tree.get_path(relative_path).is_ok() {
+                            let time = commit.time();
+                            let timestamp = DateTime::from_timestamp(time.seconds(), 0)
+                                .unwrap_or_else(|| Utc::now());
+                            
+                            if last_commit_time.is_none() {
+                                last_commit_time = Some(timestamp);
+                                last_author = Some(commit.author().name().unwrap_or("Unknown").to_string());
+                            }
+                            first_commit_time = Some(timestamp);
+                        }
+                    }
+                }
+            }
+        }
+
+        let created = first_commit_time.unwrap_or_else(|| Utc::now());
+        let updated = last_commit_time.unwrap_or(created);
+
+        Ok((created, updated, last_author))
+    }
+
+    /// Get a specific page by slug
+    pub fn get_page(&self, slug: &str) -> Result<WikiPage> {
+        self.ensure_initialized()?;
+
+        let page_path = self.cache_dir.join(format!("{}.md", slug));
+        
+        if !page_path.exists() {
+            return Err(GitHubError::Wiki(format!("Page '{}' not found", slug)));
+        }
+
+        self.read_page(&page_path)
+    }
+
+    /// Create a new wiki page
+    pub fn create_page(&self, slug: &str, title: &str, content: &str, tags: Vec<String>) -> Result<WikiPage> {
+        self.ensure_initialized()?;
+
+        let page_path = self.cache_dir.join(format!("{}.md", slug));
+        
+        if page_path.exists() {
+            return Err(GitHubError::Wiki(format!("Page '{}' already exists", slug)));
+        }
+
+        // Create parent directories if needed
+        if let Some(parent) = page_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                GitHubError::Wiki(format!("Failed to create directory: {}", e))
+            })?;
+        }
+
+        // Generate markdown with front matter
+        let markdown = self.generate_markdown_with_frontmatter(title, content, &tags);
+        
+        fs::write(&page_path, markdown).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to write file: {}", e))
+        })?;
+
+        // Commit and push
+        self.commit_and_push(&format!("Create {}", slug), &[&page_path])?;
+
+        self.read_page(&page_path)
+    }
+
+    /// Update an existing wiki page
+    pub fn update_page(&self, slug: &str, title: Option<&str>, content: Option<&str>, tags: Option<Vec<String>>) -> Result<WikiPage> {
+        self.ensure_initialized()?;
+
+        let page_path = self.cache_dir.join(format!("{}.md", slug));
+        
+        if !page_path.exists() {
+            return Err(GitHubError::Wiki(format!("Page '{}' not found", slug)));
+        }
+
+        // Read existing page
+        let existing = self.read_page(&page_path)?;
+        
+        let new_title = title.unwrap_or(&existing.title);
+        let new_content = content.unwrap_or(&existing.content);
+        let new_tags = tags.unwrap_or(existing.tags);
+
+        // Generate updated markdown
+        let markdown = self.generate_markdown_with_frontmatter(new_title, new_content, &new_tags);
+        
+        fs::write(&page_path, markdown).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to write file: {}", e))
+        })?;
+
+        // Commit and push
+        self.commit_and_push(&format!("Update {}", slug), &[&page_path])?;
+
+        self.read_page(&page_path)
+    }
+
+    /// Delete a wiki page
+    pub fn delete_page(&self, slug: &str) -> Result<()> {
+        self.ensure_initialized()?;
+
+        let page_path = self.cache_dir.join(format!("{}.md", slug));
+        
+        if !page_path.exists() {
+            return Err(GitHubError::Wiki(format!("Page '{}' not found", slug)));
+        }
+
+        fs::remove_file(&page_path).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to delete file: {}", e))
+        })?;
+
+        // Commit and push
+        self.commit_and_push(&format!("Delete {}", slug), &[&page_path])?;
+
+        Ok(())
+    }
+
+    /// Move a page to a new location
+    pub fn move_page(&self, slug: &str, new_parent: Option<&str>) -> Result<WikiPage> {
+        self.ensure_initialized()?;
+
+        let old_path = self.cache_dir.join(format!("{}.md", slug));
+        
+        if !old_path.exists() {
+            return Err(GitHubError::Wiki(format!("Page '{}' not found", slug)));
+        }
+
+        // Extract filename from slug
+        let filename = Path::new(slug)
+            .file_name()
+            .ok_or_else(|| GitHubError::Wiki("Invalid slug".to_string()))?;
+
+        // Build new path
+        let new_path = if let Some(parent) = new_parent {
+            self.cache_dir.join(parent).join(filename).with_extension("md")
+        } else {
+            self.cache_dir.join(filename).with_extension("md")
+        };
+
+        // Create parent directory if needed
+        if let Some(parent) = new_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                GitHubError::Wiki(format!("Failed to create directory: {}", e))
+            })?;
+        }
+
+        // Move file
+        fs::rename(&old_path, &new_path).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to move file: {}", e))
+        })?;
+
+        // Commit and push
+        self.commit_and_push(
+            &format!("Move {} to {:?}", slug, new_parent),
+            &[&old_path, &new_path],
+        )?;
+
+        self.read_page(&new_path)
+    }
+
+    /// Generate markdown with YAML front matter
+    fn generate_markdown_with_frontmatter(&self, title: &str, content: &str, tags: &[String]) -> String {
+        let front_matter = FrontMatter {
+            title: Some(title.to_string()),
+            tags: tags.to_vec(),
+        };
+
+        let yaml = serde_yaml::to_string(&front_matter).unwrap_or_default();
+        let yaml = yaml.trim_start_matches("---\n").trim();
+
+        format!("---\n{}\n---\n\n{}", yaml, content)
+    }
+
+    /// Commit changes and push to remote
+    fn commit_and_push(&self, message: &str, paths: &[&Path]) -> Result<()> {
+        let repo = Repository::open(&self.cache_dir).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to open repository: {}", e))
+        })?;
+
+        let mut index = repo.index().map_err(|e| {
+            GitHubError::Wiki(format!("Failed to get index: {}", e))
+        })?;
+
+        // Add or remove files
+        for path in paths {
+            let relative_path = path
+                .strip_prefix(&self.cache_dir)
+                .map_err(|_| GitHubError::Wiki("Invalid path".to_string()))?;
+
+            if path.exists() {
+                index.add_path(relative_path).map_err(|e| {
+                    GitHubError::Wiki(format!("Failed to add file to index: {}", e))
+                })?;
+            } else {
+                index.remove_path(relative_path).map_err(|e| {
+                    GitHubError::Wiki(format!("Failed to remove file from index: {}", e))
+                })?;
+            }
+        }
+
+        index.write().map_err(|e| {
+            GitHubError::Wiki(format!("Failed to write index: {}", e))
+        })?;
+
+        let tree_id = index.write_tree().map_err(|e| {
+            GitHubError::Wiki(format!("Failed to write tree: {}", e))
+        })?;
+
+        let tree = repo.find_tree(tree_id).map_err(|e| {
+            GitHubError::Wiki(format!("Failed to find tree: {}", e))
+        })?;
+
+        let signature = Signature::now("track-cli", "track@example.com").map_err(|e| {
+            GitHubError::Wiki(format!("Failed to create signature: {}", e))
+        })?;
+
+        let parent_commit = repo.head()
+            .and_then(|head| head.peel_to_commit())
+            .ok();
+
+        let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
+
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            message,
+            &tree,
+            &parents,
+        )
+        .map_err(|e| GitHubError::Wiki(format!("Failed to commit: {}", e)))?;
+
+        // Push to remote
+        let mut remote = repo.find_remote("origin").map_err(|e| {
+            GitHubError::Wiki(format!("Failed to find remote: {}", e))
+        })?;
+
+        let mut callbacks = RemoteCallbacks::new();
+        callbacks.credentials(|_url, _username, _allowed| {
+            Cred::userpass_plaintext(&self.token, "x-oauth-basic")
+        });
+
+        let mut push_opts = git2::PushOptions::new();
+        push_opts.remote_callbacks(callbacks);
+
+        // Try both master and main branches
+        let refspecs = ["refs/heads/master:refs/heads/master", "refs/heads/main:refs/heads/main"];
+        
+        for refspec in &refspecs {
+            if remote.push(&[*refspec], Some(&mut push_opts)).is_ok() {
+                return Ok(());
+            }
+        }
+
+        Err(GitHubError::Wiki("Failed to push changes".to_string()))
+    }
+
+    /// Search pages by content
+    pub fn search_pages(&self, query: &str) -> Result<Vec<WikiPage>> {
+        let pages = self.list_pages()?;
+        let query_lower = query.to_lowercase();
+
+        let filtered: Vec<WikiPage> = pages
+            .into_iter()
+            .filter(|page| {
+                page.title.to_lowercase().contains(&query_lower)
+                    || page.content.to_lowercase().contains(&query_lower)
+                    || page.tags.iter().any(|t| t.to_lowercase().contains(&query_lower))
+            })
+            .collect();
+
+        Ok(filtered)
+    }
+
+    /// Get child pages of a parent directory
+    pub fn get_child_pages(&self, parent_slug: &str) -> Result<Vec<WikiPage>> {
+        let pages = self.list_pages()?;
+
+        let children: Vec<WikiPage> = pages
+            .into_iter()
+            .filter(|page| {
+                page.parent.as_deref() == Some(parent_slug)
+            })
+            .collect();
+
+        Ok(children)
+    }
+}

--- a/crates/github-backend/src/wiki_tests.rs
+++ b/crates/github-backend/src/wiki_tests.rs
@@ -1,0 +1,169 @@
+//! Unit tests for GitHub WikiManager
+
+#[cfg(test)]
+mod tests {
+    use crate::WikiManager;
+    use git2::{Repository, Signature};
+    use std::env;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    struct EnvGuard {
+        key: String,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &str, value: &str) -> Self {
+            let previous = env::var(key).ok();
+            env::set_var(key, value);
+            Self {
+                key: key.to_string(),
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                env::set_var(&self.key, value);
+            } else {
+                env::remove_var(&self.key);
+            }
+        }
+    }
+
+    fn commit_all(repo: &Repository, message: &str) -> git2::Oid {
+        let mut index = repo.index().expect("index");
+        index.add_all(["*"] , git2::IndexAddOption::DEFAULT, None).expect("add");
+        index.write().expect("index write");
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        let signature = Signature::now("tester", "tester@example.com").expect("signature");
+
+        let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+        let parents = parent.iter().collect::<Vec<_>>();
+
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            message,
+            &tree,
+            &parents,
+        )
+        .expect("commit")
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("mkdir");
+        }
+        fs::write(path, content).expect("write");
+    }
+
+    fn setup_bare_repo(root: &Path) -> (PathBuf, PathBuf) {
+        let bare_path = root.join("bare.git");
+        let work_path = root.join("work");
+
+        let _bare = Repository::init_bare(&bare_path).expect("init bare");
+        let work = Repository::init(&work_path).expect("init work");
+
+        write_file(
+            &work_path.join("Home.md"),
+            "# Home\nWelcome",
+        );
+        write_file(
+            &work_path.join("_Sidebar.md"),
+            "# Sidebar",
+        );
+        write_file(
+            &work_path.join("Tutorials/Getting-Started.md"),
+            "---\ntitle: Getting Started\ntags:\n  - intro\n  - setup\n---\n\n# Hello",
+        );
+
+        let first_commit = commit_all(&work, "Initial wiki");
+
+        if work.find_reference("refs/heads/main").is_err() {
+            work.branch(
+                "main",
+                &work.find_commit(first_commit).expect("find commit"),
+                false,
+            )
+            .expect("branch main");
+        }
+
+        work.remote("origin", bare_path.to_str().expect("bare path"))
+            .expect("remote");
+
+        let mut remote = work.find_remote("origin").expect("find remote");
+        let mut refspecs = Vec::new();
+        if work.find_reference("refs/heads/master").is_ok() {
+            refspecs.push("refs/heads/master:refs/heads/master");
+        }
+        if work.find_reference("refs/heads/main").is_ok() {
+            refspecs.push("refs/heads/main:refs/heads/main");
+        }
+        remote.push(&refspecs, None).expect("push");
+
+        (bare_path, work_path)
+    }
+
+    #[test]
+    fn wiki_manager_crud_and_listing() {
+        let temp = TempDir::new().expect("tempdir");
+        let _home = EnvGuard::set("HOME", temp.path().to_str().expect("home"));
+
+        let (bare_path, _work_path) = setup_bare_repo(temp.path());
+
+        let cache_dir = temp
+            .path()
+            .join(".cache")
+            .join("track")
+            .join("wikis")
+            .join("owner")
+            .join("repo");
+
+        Repository::clone(bare_path.to_str().expect("bare path"), &cache_dir)
+            .expect("clone to cache");
+
+        let wiki = WikiManager::new("owner", "repo", "token").expect("wiki manager");
+
+        let pages = wiki.list_pages().expect("list pages");
+        assert!(pages.iter().any(|p| p.slug == "Home"));
+        assert!(!pages.iter().any(|p| p.slug.contains("_Sidebar")));
+        assert!(pages.iter().any(|p| p.slug == "Tutorials/Getting-Started"));
+
+        let page = wiki.get_page("Tutorials/Getting-Started").expect("get page");
+        assert_eq!(page.title, "Getting Started");
+        assert_eq!(page.tags, vec!["intro".to_string(), "setup".to_string()]);
+        assert_eq!(page.parent, Some("Tutorials".to_string()));
+
+        let created = wiki
+            .create_page("New-Page", "New Page", "Body", vec!["tag1".to_string()])
+            .expect("create page");
+        assert_eq!(created.title, "New Page");
+
+        let updated = wiki
+            .update_page(
+                "New-Page",
+                Some("New Title"),
+                Some("Updated"),
+                Some(vec!["tag2".to_string()]),
+            )
+            .expect("update page");
+        assert_eq!(updated.title, "New Title");
+        assert_eq!(updated.tags, vec!["tag2".to_string()]);
+
+        let moved = wiki
+            .move_page("New-Page", Some("Guides"))
+            .expect("move page");
+        assert_eq!(moved.slug, "Guides/New-Page");
+        assert_eq!(moved.parent, Some("Guides".to_string()));
+
+        wiki.delete_page("Guides/New-Page").expect("delete page");
+        assert!(wiki.get_page("Guides/New-Page").is_err());
+    }
+}


### PR DESCRIPTION
Here’s the same change summary in English:

- Added GitHub Wiki manager implementation (clone/pull, CRUD, search, hierarchy, git commit/push, front matter parsing) in wiki.rs
- Implemented GitHub `KnowledgeBase` trait mapping Articles to Wiki pages in trait_impl.rs
- Added wiki manager field and read-only accessor in GitHubClient in client.rs
- Added wiki-specific error variant in error.rs
- Added Wiki unit tests and registered the test module in wiki_tests.rs and lib.rs
- Updated tests to push only existing branch refs (avoids missing `master` refspec) in wiki_tests.rs
- Added dependencies `git2`, `walkdir`, `serde_yaml`, and `tempfile` in Cargo.toml

Tests: `cargo test -p github-backend` now passes.