### PR TITLE
Bump version to 1.0.1 and always overwrite skill files on install

### DIFF
--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "0.1.0"
+version = "1.0.1"
 edition = "2021"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/homebrew/Formula/track.rb
+++ b/homebrew/Formula/track.rb
@@ -64,7 +64,7 @@ class Track < Formula
     %w[.claude .copilot .cursor .gemini].each do |tool_dir|
       skill_dir = Pathname.new(Dir.home)/tool_dir/"skills"/"track"
       skill_dir.mkpath
-      cp skill_src, skill_dir/"SKILL.md" unless (skill_dir/"SKILL.md").exist?
+      cp skill_src, skill_dir/"SKILL.md"
     end
   end
 


### PR DESCRIPTION
## Summary

- Bump `crates/track` version to `1.0.1` so `track --version` correctly reports the release version (was hardcoded `0.1.0` despite the binary being released as `v1.0.0`)
- Remove the `unless exist?` guard in the Homebrew formula's `post_install` so skill files are always overwritten on reinstall/upgrade (ensures users always get the latest `SKILL.md` alongside new binary versions)

## Test plan

- [x] `track --version` reports `1.0.1` after build
- [x] `brew reinstall track` overwrites `~/.claude/skills/track/SKILL.md` even when it already exists
- [x] `brew test track` passes (`assert_match version.to_s, shell_output("#{bin}/track --version")`)