### PR TITLE
[Feature] Add `--body-file` CLI option to read input from files or stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/cli.rs
+++ b/crates/track/src/cli.rs
@@ -341,6 +341,9 @@ pub enum IssueCommands {
         /// Issue description
         #[arg(long, short = 'd', conflicts_with = "json", allow_hyphen_values = true)]
         description: Option<String>,
+        /// Read body text from a file ("-" for stdin), sets description
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["description", "json"])]
+        body_file: Option<PathBuf>,
         /// Custom field value (format: FIELD=VALUE, can be repeated)
         #[arg(
             long = "field",
@@ -371,13 +374,13 @@ pub enum IssueCommands {
         #[arg(long, requires = "validate")]
         dry_run: bool,
         /// JSON payload for issue creation
-        #[arg(long, conflicts_with_all = ["project", "summary", "description", "fields", "state", "priority", "assignee", "tags", "parent", "validate", "dry_run"], value_name = "JSON")]
+        #[arg(long, conflicts_with_all = ["project", "summary", "description", "body_file", "fields", "state", "priority", "assignee", "tags", "parent", "validate", "dry_run"], value_name = "JSON")]
         json: Option<String>,
     },
     /// Update existing issue(s) - supports comma-separated IDs for batch updates
     #[command(visible_alias = "u", group(
         ArgGroup::new("update_fields")
-            .args(["summary", "description", "fields", "state", "priority", "assignee", "tags", "parent", "json"])
+            .args(["summary", "description", "body_file", "fields", "state", "priority", "assignee", "tags", "parent", "json"])
             .required(true)
             .multiple(true)
     ))]
@@ -391,6 +394,9 @@ pub enum IssueCommands {
         /// New description
         #[arg(long, short = 'd', allow_hyphen_values = true)]
         description: Option<String>,
+        /// Read body text from a file ("-" for stdin), sets description
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["description", "json"])]
+        body_file: Option<PathBuf>,
         /// Custom field value (format: FIELD=VALUE, can be repeated)
         #[arg(
             long = "field",
@@ -421,7 +427,7 @@ pub enum IssueCommands {
         #[arg(long, requires = "validate")]
         dry_run: bool,
         /// JSON payload for issue update
-        #[arg(long, conflicts_with_all = ["summary", "description", "fields", "state", "priority", "assignee", "tags", "parent", "validate", "dry_run"], value_name = "JSON")]
+        #[arg(long, conflicts_with_all = ["summary", "description", "body_file", "fields", "state", "priority", "assignee", "tags", "parent", "validate", "dry_run"], value_name = "JSON")]
         json: Option<String>,
     },
     /// Search issues
@@ -462,8 +468,11 @@ pub enum IssueCommands {
         /// Issue ID (e.g., PROJ-123)
         id: String,
         /// Comment text
-        #[arg(short = 'm', long = "message")]
-        text: String,
+        #[arg(short = 'm', long = "message", required_unless_present = "body_file")]
+        text: Option<String>,
+        /// Read comment text from a file ("-" for stdin)
+        #[arg(long, value_name = "PATH", conflicts_with = "text")]
+        body_file: Option<PathBuf>,
     },
     /// List comments on an issue
     Comments {
@@ -544,6 +553,9 @@ pub enum ProjectCommands {
         /// Project description
         #[arg(long, short = 'd', allow_hyphen_values = true)]
         description: Option<String>,
+        /// Read body text from a file ("-" for stdin), sets description
+        #[arg(long, value_name = "PATH", conflicts_with = "description")]
+        body_file: Option<PathBuf>,
     },
     /// List custom fields for a project
     #[command(visible_alias = "f")]
@@ -663,6 +675,9 @@ pub enum TagCommands {
         /// Description
         #[arg(long, short = 'd', allow_hyphen_values = true)]
         description: Option<String>,
+        /// Read body text from a file ("-" for stdin), sets description
+        #[arg(long, value_name = "PATH", conflicts_with = "description")]
+        body_file: Option<PathBuf>,
     },
     /// Delete a tag/label
     #[command(visible_alias = "rm")]
@@ -684,6 +699,9 @@ pub enum TagCommands {
         /// New description
         #[arg(long, short = 'd', allow_hyphen_values = true)]
         description: Option<String>,
+        /// Read body text from a file ("-" for stdin), sets description
+        #[arg(long, value_name = "PATH", conflicts_with = "description")]
+        body_file: Option<PathBuf>,
     },
 }
 
@@ -738,8 +756,11 @@ pub enum ArticleCommands {
         /// Article content (Markdown)
         #[arg(long, short = 'c')]
         content: Option<String>,
-        /// Read content from file
-        #[arg(long, conflicts_with = "content")]
+        /// Read body text from a file ("-" for stdin), sets content
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["content", "content_file"])]
+        body_file: Option<PathBuf>,
+        /// Read content from file (hidden, use --body-file instead)
+        #[arg(long, conflicts_with_all = ["content", "body_file"], hide = true)]
         content_file: Option<PathBuf>,
         /// Parent article ID (for creating child articles)
         #[arg(long)]
@@ -759,8 +780,11 @@ pub enum ArticleCommands {
         /// New content (Markdown)
         #[arg(long, short = 'c')]
         content: Option<String>,
-        /// Read content from file
-        #[arg(long, conflicts_with = "content")]
+        /// Read body text from a file ("-" for stdin), sets content
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["content", "content_file"])]
+        body_file: Option<PathBuf>,
+        /// Read content from file (hidden, use --body-file instead)
+        #[arg(long, conflicts_with_all = ["content", "body_file"], hide = true)]
         content_file: Option<PathBuf>,
         /// Tag name (can be repeated)
         #[arg(long = "tag", short = 't')]
@@ -796,8 +820,11 @@ pub enum ArticleCommands {
         /// Article ID
         id: String,
         /// Comment text
-        #[arg(short = 'm', long = "message")]
-        text: String,
+        #[arg(short = 'm', long = "message", required_unless_present = "body_file")]
+        text: Option<String>,
+        /// Read comment text from a file ("-" for stdin)
+        #[arg(long, value_name = "PATH", conflicts_with = "text")]
+        body_file: Option<PathBuf>,
     },
     /// List comments on an article
     Comments {
@@ -1110,9 +1137,9 @@ mod tests {
 
         match cli.command {
             Commands::Issue { action } => match action {
-                IssueCommands::Comment { id, text } => {
+                IssueCommands::Comment { id, text, .. } => {
                     assert_eq!(id, "PROJ-123");
-                    assert_eq!(text, "This is a comment");
+                    assert_eq!(text.as_deref(), Some("This is a comment"));
                 }
                 _ => panic!("expected issue comment"),
             },
@@ -1936,6 +1963,420 @@ mod tests {
             Commands::Issue { action } => match action {
                 IssueCommands::Update { ids, .. } => {
                     assert_eq!(ids, vec!["PROJ-1"]);
+                }
+                _ => panic!("expected issue update"),
+            },
+            _ => panic!("expected issue command"),
+        }
+    }
+
+    // =========================================================================
+    // --body-file Tests
+    // =========================================================================
+
+    #[test]
+    fn parses_issue_create_with_body_file() {
+        let cli = Cli::parse_from([
+            "track",
+            "issue",
+            "create",
+            "-p",
+            "PROJ",
+            "-s",
+            "Title",
+            "--body-file",
+            "/tmp/desc.md",
+        ]);
+
+        match cli.command {
+            Commands::Issue { action } => match action {
+                IssueCommands::Create {
+                    body_file,
+                    description,
+                    ..
+                } => {
+                    assert_eq!(body_file, Some(PathBuf::from("/tmp/desc.md")));
+                    assert!(description.is_none());
+                }
+                _ => panic!("expected issue create"),
+            },
+            _ => panic!("expected issue command"),
+        }
+    }
+
+    #[test]
+    fn parses_issue_update_with_body_file() {
+        let cli = Cli::parse_from([
+            "track",
+            "issue",
+            "update",
+            "PROJ-1",
+            "--body-file",
+            "desc.md",
+        ]);
+
+        match cli.command {
+            Commands::Issue { action } => match action {
+                IssueCommands::Update {
+                    ids,
+                    body_file,
+                    description,
+                    ..
+                } => {
+                    assert_eq!(ids, vec!["PROJ-1"]);
+                    assert_eq!(body_file, Some(PathBuf::from("desc.md")));
+                    assert!(description.is_none());
+                }
+                _ => panic!("expected issue update"),
+            },
+            _ => panic!("expected issue command"),
+        }
+    }
+
+    #[test]
+    fn parses_issue_update_body_file_satisfies_required_group() {
+        // --body-file alone should satisfy the update_fields requirement
+        let result = Cli::try_parse_from([
+            "track",
+            "issue",
+            "update",
+            "PROJ-1",
+            "--body-file",
+            "desc.md",
+        ]);
+        assert!(
+            result.is_ok(),
+            "body-file should satisfy update_fields group"
+        );
+    }
+
+    #[test]
+    fn rejects_issue_create_body_file_with_description() {
+        let result = Cli::try_parse_from([
+            "track",
+            "issue",
+            "create",
+            "-p",
+            "PROJ",
+            "-s",
+            "Title",
+            "--description",
+            "inline",
+            "--body-file",
+            "file.md",
+        ]);
+        assert!(result.is_err(), "body-file and description should conflict");
+    }
+
+    #[test]
+    fn rejects_issue_create_body_file_with_json() {
+        let result = Cli::try_parse_from([
+            "track",
+            "issue",
+            "create",
+            "--json",
+            "{\"summary\":\"Test\"}",
+            "--body-file",
+            "file.md",
+        ]);
+        assert!(result.is_err(), "body-file and json should conflict");
+    }
+
+    #[test]
+    fn rejects_issue_update_body_file_with_description() {
+        let result = Cli::try_parse_from([
+            "track",
+            "issue",
+            "update",
+            "PROJ-1",
+            "-d",
+            "inline",
+            "--body-file",
+            "file.md",
+        ]);
+        assert!(result.is_err(), "body-file and description should conflict");
+    }
+
+    #[test]
+    fn rejects_issue_update_body_file_with_json() {
+        let result = Cli::try_parse_from([
+            "track",
+            "issue",
+            "update",
+            "PROJ-1",
+            "--json",
+            "{\"summary\":\"Test\"}",
+            "--body-file",
+            "file.md",
+        ]);
+        assert!(result.is_err(), "body-file and json should conflict");
+    }
+
+    #[test]
+    fn parses_issue_comment_with_body_file() {
+        let cli = Cli::parse_from([
+            "track",
+            "issue",
+            "comment",
+            "PROJ-1",
+            "--body-file",
+            "comment.md",
+        ]);
+
+        match cli.command {
+            Commands::Issue { action } => match action {
+                IssueCommands::Comment {
+                    id,
+                    text,
+                    body_file,
+                } => {
+                    assert_eq!(id, "PROJ-1");
+                    assert!(text.is_none());
+                    assert_eq!(body_file, Some(PathBuf::from("comment.md")));
+                }
+                _ => panic!("expected issue comment"),
+            },
+            _ => panic!("expected issue command"),
+        }
+    }
+
+    #[test]
+    fn rejects_issue_comment_without_message_or_body_file() {
+        let result = Cli::try_parse_from(["track", "issue", "comment", "PROJ-1"]);
+        assert!(
+            result.is_err(),
+            "comment requires either --message or --body-file"
+        );
+    }
+
+    #[test]
+    fn rejects_issue_comment_with_both_message_and_body_file() {
+        let result = Cli::try_parse_from([
+            "track",
+            "issue",
+            "comment",
+            "PROJ-1",
+            "-m",
+            "inline",
+            "--body-file",
+            "file.md",
+        ]);
+        assert!(result.is_err(), "message and body-file should conflict");
+    }
+
+    #[test]
+    fn parses_project_create_with_body_file() {
+        let cli = Cli::parse_from([
+            "track",
+            "project",
+            "create",
+            "-n",
+            "My Project",
+            "-s",
+            "PROJ",
+            "--body-file",
+            "desc.md",
+        ]);
+
+        match cli.command {
+            Commands::Project { action } => match action {
+                ProjectCommands::Create {
+                    body_file,
+                    description,
+                    ..
+                } => {
+                    assert_eq!(body_file, Some(PathBuf::from("desc.md")));
+                    assert!(description.is_none());
+                }
+                _ => panic!("expected project create"),
+            },
+            _ => panic!("expected project command"),
+        }
+    }
+
+    #[test]
+    fn parses_tag_create_with_body_file() {
+        let cli = Cli::parse_from(["track", "tags", "create", "bug", "--body-file", "desc.md"]);
+
+        match cli.command {
+            Commands::Tags { action } => match action {
+                TagCommands::Create {
+                    name,
+                    body_file,
+                    description,
+                    ..
+                } => {
+                    assert_eq!(name, "bug");
+                    assert_eq!(body_file, Some(PathBuf::from("desc.md")));
+                    assert!(description.is_none());
+                }
+                _ => panic!("expected tag create"),
+            },
+            _ => panic!("expected tag command"),
+        }
+    }
+
+    #[test]
+    fn parses_tag_update_with_body_file() {
+        let cli = Cli::parse_from(["track", "tags", "update", "bug", "--body-file", "desc.md"]);
+
+        match cli.command {
+            Commands::Tags { action } => match action {
+                TagCommands::Update {
+                    name,
+                    body_file,
+                    description,
+                    ..
+                } => {
+                    assert_eq!(name, "bug");
+                    assert_eq!(body_file, Some(PathBuf::from("desc.md")));
+                    assert!(description.is_none());
+                }
+                _ => panic!("expected tag update"),
+            },
+            _ => panic!("expected tag command"),
+        }
+    }
+
+    #[test]
+    fn parses_article_create_with_body_file() {
+        let cli = Cli::parse_from([
+            "track",
+            "article",
+            "create",
+            "-p",
+            "PROJ",
+            "-s",
+            "Title",
+            "--body-file",
+            "article.md",
+        ]);
+
+        match cli.command {
+            Commands::Article { action } => match action {
+                ArticleCommands::Create {
+                    body_file,
+                    content,
+                    content_file,
+                    ..
+                } => {
+                    assert_eq!(body_file, Some(PathBuf::from("article.md")));
+                    assert!(content.is_none());
+                    assert!(content_file.is_none());
+                }
+                _ => panic!("expected article create"),
+            },
+            _ => panic!("expected article command"),
+        }
+    }
+
+    #[test]
+    fn parses_article_create_with_content_file_backward_compat() {
+        let cli = Cli::parse_from([
+            "track",
+            "article",
+            "create",
+            "-p",
+            "PROJ",
+            "-s",
+            "Title",
+            "--content-file",
+            "article.md",
+        ]);
+
+        match cli.command {
+            Commands::Article { action } => match action {
+                ArticleCommands::Create {
+                    content_file,
+                    body_file,
+                    content,
+                    ..
+                } => {
+                    assert_eq!(content_file, Some(PathBuf::from("article.md")));
+                    assert!(body_file.is_none());
+                    assert!(content.is_none());
+                }
+                _ => panic!("expected article create"),
+            },
+            _ => panic!("expected article command"),
+        }
+    }
+
+    #[test]
+    fn rejects_article_create_body_file_with_content() {
+        let result = Cli::try_parse_from([
+            "track",
+            "article",
+            "create",
+            "-p",
+            "PROJ",
+            "-s",
+            "Title",
+            "-c",
+            "inline content",
+            "--body-file",
+            "file.md",
+        ]);
+        assert!(result.is_err(), "body-file and content should conflict");
+    }
+
+    #[test]
+    fn rejects_article_create_body_file_with_content_file() {
+        let result = Cli::try_parse_from([
+            "track",
+            "article",
+            "create",
+            "-p",
+            "PROJ",
+            "-s",
+            "Title",
+            "--content-file",
+            "old.md",
+            "--body-file",
+            "new.md",
+        ]);
+        assert!(
+            result.is_err(),
+            "body-file and content-file should conflict"
+        );
+    }
+
+    #[test]
+    fn parses_article_comment_with_body_file() {
+        let cli = Cli::parse_from([
+            "track",
+            "article",
+            "comment",
+            "ART-1",
+            "--body-file",
+            "comment.md",
+        ]);
+
+        match cli.command {
+            Commands::Article { action } => match action {
+                ArticleCommands::Comment {
+                    id,
+                    text,
+                    body_file,
+                } => {
+                    assert_eq!(id, "ART-1");
+                    assert!(text.is_none());
+                    assert_eq!(body_file, Some(PathBuf::from("comment.md")));
+                }
+                _ => panic!("expected article comment"),
+            },
+            _ => panic!("expected article command"),
+        }
+    }
+
+    #[test]
+    fn parses_issue_update_body_file_stdin_sentinel() {
+        let cli = Cli::parse_from(["track", "issue", "update", "PROJ-1", "--body-file", "-"]);
+
+        match cli.command {
+            Commands::Issue { action } => match action {
+                IssueCommands::Update { body_file, .. } => {
+                    assert_eq!(body_file, Some(PathBuf::from("-")));
                 }
                 _ => panic!("expected issue update"),
             },

--- a/crates/track/src/commands/article.rs
+++ b/crates/track/src/commands/article.rs
@@ -1,7 +1,6 @@
 use crate::cli::{ArticleCommands, OutputFormat};
 use crate::output::{output_list, output_page_hint, output_progress, output_result};
-use anyhow::{Context, Result};
-use std::fs;
+use anyhow::{Context, Result, anyhow};
 use tracker_core::{CreateArticle, IssueTracker, KnowledgeBase, UpdateArticle, fetch_all_pages};
 
 pub fn handle_article(
@@ -28,42 +27,58 @@ pub fn handle_article(
             project,
             summary,
             content,
+            body_file,
             content_file,
             parent,
             tags,
-        } => handle_create(
-            issue_client,
-            kb_client,
-            project,
-            summary,
-            content.as_deref(),
-            content_file.as_deref(),
-            parent.as_deref(),
-            tags,
-            format,
-        ),
+        } => {
+            let file = body_file.as_deref().or(content_file.as_deref());
+            let resolved_content = super::resolve_body(content.as_deref(), file)?;
+            handle_create(
+                issue_client,
+                kb_client,
+                project,
+                summary,
+                resolved_content.as_deref(),
+                parent.as_deref(),
+                tags,
+                format,
+            )
+        }
         ArticleCommands::Update {
             id,
             summary,
             content,
+            body_file,
             content_file,
             tags,
-        } => handle_update(
-            kb_client,
-            id,
-            summary.as_deref(),
-            content.as_deref(),
-            content_file.as_deref(),
-            tags,
-            format,
-        ),
+        } => {
+            let file = body_file.as_deref().or(content_file.as_deref());
+            let resolved_content = super::resolve_body(content.as_deref(), file)?;
+            handle_update(
+                kb_client,
+                id,
+                summary.as_deref(),
+                resolved_content.as_deref(),
+                tags,
+                format,
+            )
+        }
         ArticleCommands::Delete { id } => handle_delete(kb_client, id),
         ArticleCommands::Tree { id } => handle_tree(kb_client, id, format),
         ArticleCommands::Move { id, parent } => {
             handle_move(kb_client, id, parent.as_deref(), format)
         }
         ArticleCommands::Attachments { id } => handle_attachments(kb_client, id, format),
-        ArticleCommands::Comment { id, text } => handle_comment(kb_client, id, text, format),
+        ArticleCommands::Comment {
+            id,
+            text,
+            body_file,
+        } => {
+            let resolved_text = super::resolve_body(text.as_deref(), body_file.as_deref())?
+                .ok_or_else(|| anyhow!("Comment text is required"))?;
+            handle_comment(kb_client, id, &resolved_text, format)
+        }
         ArticleCommands::Comments { id, limit, all } => {
             handle_comments(kb_client, id, *limit, *all, format)
         }
@@ -151,7 +166,6 @@ fn handle_create(
     project: &str,
     summary: &str,
     content: Option<&str>,
-    content_file: Option<&std::path::Path>,
     parent: Option<&str>,
     tags: &[String],
     format: OutputFormat,
@@ -178,20 +192,10 @@ fn handle_create(
         None
     };
 
-    // Read content from file if specified
-    let content =
-        if let Some(file_path) = content_file {
-            Some(fs::read_to_string(file_path).with_context(|| {
-                format!("Failed to read content from '{}'", file_path.display())
-            })?)
-        } else {
-            content.map(String::from)
-        };
-
     let create = CreateArticle {
         project_id,
         summary: summary.to_string(),
-        content,
+        content: content.map(String::from),
         parent_article_id,
         tags: tags.to_vec(),
     };
@@ -209,23 +213,12 @@ fn handle_update(
     id: &str,
     summary: Option<&str>,
     content: Option<&str>,
-    content_file: Option<&std::path::Path>,
     tags: &[String],
     format: OutputFormat,
 ) -> Result<()> {
-    // Read content from file if specified
-    let content =
-        if let Some(file_path) = content_file {
-            Some(fs::read_to_string(file_path).with_context(|| {
-                format!("Failed to read content from '{}'", file_path.display())
-            })?)
-        } else {
-            content.map(String::from)
-        };
-
     let update = UpdateArticle {
         summary: summary.map(String::from),
-        content,
+        content: content.map(String::from),
         tags: tags.to_vec(),
     };
 

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -45,6 +45,7 @@ pub fn handle_issue(
             project,
             summary,
             description,
+            body_file,
             fields,
             state,
             priority,
@@ -55,9 +56,10 @@ pub fn handle_issue(
             dry_run,
             json,
         } => {
+            let resolved_desc = super::resolve_body(description.as_deref(), body_file.as_deref())?;
             let args = IssueFieldArgs {
                 summary: summary.as_deref(),
-                description: description.as_deref(),
+                description: resolved_desc.as_deref(),
                 fields,
                 state: state.as_deref(),
                 priority: priority.as_deref(),
@@ -81,6 +83,7 @@ pub fn handle_issue(
             ids,
             summary,
             description,
+            body_file,
             fields,
             state,
             priority,
@@ -91,9 +94,10 @@ pub fn handle_issue(
             dry_run,
             json,
         } => {
+            let resolved_desc = super::resolve_body(description.as_deref(), body_file.as_deref())?;
             let args = IssueFieldArgs {
                 summary: summary.as_deref(),
-                description: description.as_deref(),
+                description: resolved_desc.as_deref(),
                 fields,
                 state: state.as_deref(),
                 priority: priority.as_deref(),
@@ -125,7 +129,15 @@ pub fn handle_issue(
             handle_search(client, &args, format, default_project)
         }
         IssueCommands::Delete { ids } => handle_delete_batch(client, ids, format),
-        IssueCommands::Comment { id, text } => handle_comment(client, id, text, format),
+        IssueCommands::Comment {
+            id,
+            text,
+            body_file,
+        } => {
+            let resolved_text = super::resolve_body(text.as_deref(), body_file.as_deref())?
+                .ok_or_else(|| anyhow!("Comment text is required"))?;
+            handle_comment(client, id, &resolved_text, format)
+        }
         IssueCommands::Comments { id, limit, all } => {
             handle_comments(client, id, *limit, *all, format)
         }

--- a/crates/track/src/commands/mod.rs
+++ b/crates/track/src/commands/mod.rs
@@ -10,3 +10,154 @@ pub mod issue;
 pub mod open;
 pub mod project;
 pub mod tags;
+
+use anyhow::{Context, Result};
+use std::io::Read;
+use std::path::Path;
+
+/// Resolve text content from an inline string or a file path.
+///
+/// If `body_file` is `Some`, reads from the given path (use `"-"` for stdin).
+/// Otherwise returns `inline` as-is. Trims a single trailing newline from
+/// file/stdin content so that the editor-appended newline isn't sent to the API.
+pub(crate) fn resolve_body(
+    inline: Option<&str>,
+    body_file: Option<&Path>,
+) -> Result<Option<String>> {
+    if let Some(path) = body_file {
+        let content = if path.as_os_str() == "-" {
+            let mut buf = String::new();
+            std::io::stdin()
+                .lock()
+                .read_to_string(&mut buf)
+                .context("Failed to read from stdin")?;
+            buf
+        } else {
+            std::fs::read_to_string(path)
+                .with_context(|| format!("Failed to read '{}'", path.display()))?
+        };
+        Ok(Some(content.trim_end_matches('\n').to_string()))
+    } else {
+        Ok(inline.map(String::from))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn resolve_body_returns_none_when_both_none() {
+        let result = resolve_body(None, None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_body_returns_inline_when_no_file() {
+        let result = resolve_body(Some("hello world"), None).unwrap();
+        assert_eq!(result.as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn resolve_body_reads_file_content() {
+        let dir = std::env::temp_dir().join("track-test-resolve-body");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("desc.md");
+        std::fs::write(&file, "## Title\n\nBody text\n").unwrap();
+
+        let result = resolve_body(None, Some(&file)).unwrap();
+        assert_eq!(result.as_deref(), Some("## Title\n\nBody text"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn resolve_body_trims_trailing_newline_from_file() {
+        let dir = std::env::temp_dir().join("track-test-resolve-trim");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("body.txt");
+        std::fs::write(&file, "content\n").unwrap();
+
+        let result = resolve_body(None, Some(&file)).unwrap();
+        assert_eq!(result.as_deref(), Some("content"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn resolve_body_trims_multiple_trailing_newlines() {
+        let dir = std::env::temp_dir().join("track-test-resolve-multi-nl");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("body.txt");
+        std::fs::write(&file, "content\n\n\n").unwrap();
+
+        let result = resolve_body(None, Some(&file)).unwrap();
+        assert_eq!(result.as_deref(), Some("content"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn resolve_body_preserves_internal_newlines() {
+        let dir = std::env::temp_dir().join("track-test-resolve-internal");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("body.txt");
+        std::fs::write(&file, "line1\nline2\nline3\n").unwrap();
+
+        let result = resolve_body(None, Some(&file)).unwrap();
+        assert_eq!(result.as_deref(), Some("line1\nline2\nline3"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn resolve_body_file_takes_precedence_over_inline() {
+        let dir = std::env::temp_dir().join("track-test-resolve-precedence");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("body.txt");
+        std::fs::write(&file, "from file\n").unwrap();
+
+        let result = resolve_body(Some("from inline"), Some(&file)).unwrap();
+        assert_eq!(result.as_deref(), Some("from file"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn resolve_body_errors_on_missing_file() {
+        let path = PathBuf::from("/tmp/track-test-nonexistent-file-xyz.md");
+        let result = resolve_body(None, Some(&path));
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("Failed to read"),
+            "error should mention file read failure"
+        );
+    }
+
+    #[test]
+    fn resolve_body_handles_empty_file() {
+        let dir = std::env::temp_dir().join("track-test-resolve-empty");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("empty.txt");
+        std::fs::write(&file, "").unwrap();
+
+        let result = resolve_body(None, Some(&file)).unwrap();
+        assert_eq!(result.as_deref(), Some(""));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn resolve_body_handles_file_with_only_newlines() {
+        let dir = std::env::temp_dir().join("track-test-resolve-only-nl");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("newlines.txt");
+        std::fs::write(&file, "\n\n\n").unwrap();
+
+        let result = resolve_body(None, Some(&file)).unwrap();
+        assert_eq!(result.as_deref(), Some(""));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/track/src/commands/project.rs
+++ b/crates/track/src/commands/project.rs
@@ -15,7 +15,11 @@ pub fn handle_project(
             name,
             short_name,
             description,
-        } => handle_create(client, name, short_name, description.clone(), format),
+            body_file,
+        } => {
+            let resolved_desc = super::resolve_body(description.as_deref(), body_file.as_deref())?;
+            handle_create(client, name, short_name, resolved_desc, format)
+        }
         ProjectCommands::Fields { id } => handle_fields(client, id, format),
         ProjectCommands::AttachField {
             project,

--- a/crates/track/src/commands/tags.rs
+++ b/crates/track/src/commands/tags.rs
@@ -14,27 +14,35 @@ pub fn handle_tags(
             name,
             tag_color,
             description,
-        } => handle_create(
-            client,
-            name,
-            tag_color.as_deref(),
-            description.as_deref(),
-            format,
-        ),
+            body_file,
+        } => {
+            let resolved_desc = super::resolve_body(description.as_deref(), body_file.as_deref())?;
+            handle_create(
+                client,
+                name,
+                tag_color.as_deref(),
+                resolved_desc.as_deref(),
+                format,
+            )
+        }
         TagCommands::Delete { name } => handle_delete(client, name),
         TagCommands::Update {
             name,
             new_name,
             tag_color,
             description,
-        } => handle_update(
-            client,
-            name,
-            new_name.as_deref(),
-            tag_color.as_deref(),
-            description.as_deref(),
-            format,
-        ),
+            body_file,
+        } => {
+            let resolved_desc = super::resolve_body(description.as_deref(), body_file.as_deref())?;
+            handle_update(
+                client,
+                name,
+                new_name.as_deref(),
+                tag_color.as_deref(),
+                resolved_desc.as_deref(),
+                format,
+            )
+        }
     }
 }
 

--- a/crates/track/tests/command_integration_tests.rs
+++ b/crates/track/tests/command_integration_tests.rs
@@ -972,3 +972,311 @@ fn test_config_clear_json_output() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+// =============================================================================
+// --body-file Tests
+// =============================================================================
+
+#[test]
+fn test_body_file_appears_in_issue_create_help() {
+    cargo_bin_cmd!("track")
+        .args(["issue", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"))
+        .stdout(predicate::str::contains("stdin"));
+}
+
+#[test]
+fn test_body_file_appears_in_issue_update_help() {
+    cargo_bin_cmd!("track")
+        .args(["issue", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"));
+}
+
+#[test]
+fn test_body_file_appears_in_issue_comment_help() {
+    cargo_bin_cmd!("track")
+        .args(["issue", "comment", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"));
+}
+
+#[test]
+fn test_body_file_appears_in_project_create_help() {
+    cargo_bin_cmd!("track")
+        .args(["project", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"));
+}
+
+#[test]
+fn test_body_file_appears_in_tag_create_help() {
+    cargo_bin_cmd!("track")
+        .args(["tags", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"));
+}
+
+#[test]
+fn test_body_file_appears_in_tag_update_help() {
+    cargo_bin_cmd!("track")
+        .args(["tags", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"));
+}
+
+#[test]
+fn test_body_file_appears_in_article_create_help() {
+    cargo_bin_cmd!("track")
+        .args(["article", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"));
+}
+
+#[test]
+fn test_body_file_appears_in_article_update_help() {
+    cargo_bin_cmd!("track")
+        .args(["article", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"));
+}
+
+#[test]
+fn test_body_file_appears_in_article_comment_help() {
+    cargo_bin_cmd!("track")
+        .args(["article", "comment", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--body-file"));
+}
+
+#[test]
+fn test_content_file_hidden_from_article_help() {
+    // --content-file should be hidden (backward compat only)
+    cargo_bin_cmd!("track")
+        .args(["article", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--content-file").not());
+}
+
+#[test]
+fn test_body_file_conflicts_with_description() {
+    cargo_bin_cmd!("track")
+        .args([
+            "issue",
+            "create",
+            "-p",
+            "PROJ",
+            "-s",
+            "Title",
+            "-d",
+            "inline desc",
+            "--body-file",
+            "/tmp/desc.md",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_body_file_conflicts_with_json_on_update() {
+    cargo_bin_cmd!("track")
+        .args([
+            "issue",
+            "update",
+            "PROJ-1",
+            "--json",
+            "{\"summary\":\"test\"}",
+            "--body-file",
+            "/tmp/desc.md",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_comment_requires_message_or_body_file() {
+    cargo_bin_cmd!("track")
+        .args(["issue", "comment", "PROJ-1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--message").or(predicate::str::contains("--body-file")));
+}
+
+#[test]
+fn test_body_file_reads_file_via_mock() {
+    let dir = temp_dir();
+    let scenario = fixtures_path().join("basic-workflow");
+
+    // Write a body file
+    let body = dir.join("comment.md");
+    fs::write(&body, "Comment from file\n").unwrap();
+
+    // Use mock mode to test the full flow — comment command reads the file
+    // and sends it to the mock backend
+    let mut cmd = cargo_bin_cmd!("track");
+    cmd.current_dir(&dir)
+        .env("TRACK_MOCK_DIR", scenario.to_str().unwrap())
+        .args(["--url", "https://mock.test", "--token", "mock-token"])
+        .args([
+            "issue",
+            "comment",
+            "DEMO-1",
+            "--body-file",
+            body.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Comment"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_body_file_error_on_missing_file() {
+    let dir = temp_dir();
+    let scenario = fixtures_path().join("basic-workflow");
+
+    let mut cmd = cargo_bin_cmd!("track");
+    cmd.current_dir(&dir)
+        .env("TRACK_MOCK_DIR", scenario.to_str().unwrap())
+        .args(["--url", "https://mock.test", "--token", "mock-token"])
+        .args([
+            "issue",
+            "update",
+            "DEMO-1",
+            "--body-file",
+            "/tmp/track-nonexistent-file-xyz.md",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to read"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_body_file_reads_multiline_markdown() {
+    let dir = temp_dir();
+    let scenario = fixtures_path().join("basic-workflow");
+
+    // Write complex markdown with code blocks, angle brackets, etc.
+    let body = dir.join("complex.md");
+    fs::write(
+        &body,
+        "## Overview\n\n```rust\nfn main() -> Result<String> {\n    Ok(\"hello\".into())\n}\n```\n\n- Item 1\n- Item 2\n",
+    )
+    .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("track");
+    cmd.current_dir(&dir)
+        .env("TRACK_MOCK_DIR", scenario.to_str().unwrap())
+        .args(["--url", "https://mock.test", "--token", "mock-token"])
+        .args([
+            "issue",
+            "comment",
+            "DEMO-1",
+            "--body-file",
+            body.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_body_file_stdin_via_pipe() {
+    let dir = temp_dir();
+    let scenario = fixtures_path().join("basic-workflow");
+
+    // Test that --body-file - reads from stdin
+    let mut cmd = cargo_bin_cmd!("track");
+    cmd.current_dir(&dir)
+        .env("TRACK_MOCK_DIR", scenario.to_str().unwrap())
+        .args(["--url", "https://mock.test", "--token", "mock-token"])
+        .args(["issue", "comment", "DEMO-1", "--body-file", "-"])
+        .write_stdin("Comment from stdin")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Comment"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_body_file_update_satisfies_required_fields() {
+    let dir = temp_dir();
+    let scenario = fixtures_path().join("basic-workflow");
+
+    let body = dir.join("desc.md");
+    fs::write(&body, "Updated description\n").unwrap();
+
+    // --body-file alone should satisfy the "at least one field" requirement
+    let mut cmd = cargo_bin_cmd!("track");
+    cmd.current_dir(&dir)
+        .env("TRACK_MOCK_DIR", scenario.to_str().unwrap())
+        .args(["--url", "https://mock.test", "--token", "mock-token"])
+        .args([
+            "issue",
+            "update",
+            "DEMO-1",
+            "--body-file",
+            body.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_content_file_backward_compat_still_parses() {
+    // --content-file should still be accepted on article commands (hidden alias).
+    // We verify the CLI does not reject the flag at parse time.
+    // The actual API call may fail (mock may not support update_article),
+    // so we only check that the error is NOT a parse/usage error.
+    let dir = temp_dir();
+    let scenario = fixtures_path().join("basic-workflow");
+
+    let body = dir.join("article.md");
+    fs::write(&body, "Article content from file\n").unwrap();
+
+    let output = cargo_bin_cmd!("track")
+        .current_dir(&dir)
+        .env("TRACK_MOCK_DIR", scenario.to_str().unwrap())
+        .args(["--url", "https://mock.test", "--token", "mock-token"])
+        .args([
+            "article",
+            "update",
+            "DEMO-A-1",
+            "--content-file",
+            body.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Should NOT be a CLI parse error — any API-level error is fine
+    assert!(
+        !stderr.contains("unrecognized")
+            && !stderr.contains("not expected in this context")
+            && !stderr.contains("invalid value"),
+        "--content-file should be accepted as a hidden flag, got: {}",
+        stderr
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/track/tests/youtrack_integration_tests.rs
+++ b/crates/track/tests/youtrack_integration_tests.rs
@@ -618,7 +618,7 @@ fn test_article_create_command_format() {
         .stdout(predicate::str::contains("--project"))
         .stdout(predicate::str::contains("--summary"))
         .stdout(predicate::str::contains("--content"))
-        .stdout(predicate::str::contains("--content-file"))
+        .stdout(predicate::str::contains("--body-file"))
         .stdout(predicate::str::contains("--parent"))
         .stdout(predicate::str::contains("--tag"));
 }
@@ -631,7 +631,7 @@ fn test_article_update_command_format() {
         .success()
         .stdout(predicate::str::contains("--summary"))
         .stdout(predicate::str::contains("--content"))
-        .stdout(predicate::str::contains("--content-file"));
+        .stdout(predicate::str::contains("--body-file"));
 }
 
 // ============================================================================

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -539,6 +539,12 @@ track -b gh i new -s "Subtask" --parent 10   # Sub-issue of #10
 # GitLab (project implicit from project_id config)
 track -b gl i new -s "Bug title" -d "Description"
 track -b gl i new -s "Subtask" --parent 10   # Child of #10
+
+# Description from file (avoids terminal escaping for complex content)
+track i new -p PROJ -s "Bug title" --body-file description.md
+
+# Description from stdin
+cat spec.md | track i new -p PROJ -s "Feature" --body-file -
 ```
 
 ### Update Issue
@@ -590,6 +596,12 @@ track i cmt PROJ-123 -m "Started implementation"
 track -b j i cmt PROJ-123 -m "Started implementation"
 track -b gh i cmt PROJ-42 -m "Started implementation"
 track -b gl i cmt PROJ-42 -m "Started implementation"
+
+# Comment from file (avoids terminal escaping issues)
+track i cmt PROJ-123 --body-file notes.md
+
+# Comment from stdin
+echo "Automated comment" | track i cmt PROJ-123 --body-file -
 
 # List comments
 track i comments PROJ-123
@@ -880,7 +892,7 @@ Replace `{PROJECT}` with the actual project key (e.g., `PROJ`)
 - **GitHub/GitLab**: No knowledge base support -- article commands return errors
 - **Confluence IDs**: Numeric for both pages (`123456`) and spaces (`65957`)
 - **Discover space IDs**: Run `track -b j a ls` to see existing pages with their space IDs
-- **Content**: Supports `--content "text"` or `--content-file ./doc.md`
+- **Content**: Supports `--content "text"` or `--body-file ./doc.md` (also accepts legacy `--content-file`)
 
 ---
 
@@ -1061,3 +1073,4 @@ namespace = "mygroup"
 16. **GitLab IIDs**: Project-scoped issue numbers; the client strips `#` prefix automatically
 17. **Pagination**: Use `--all` to fetch all results; `--limit`/`--skip` for manual paging. Safety cap at 1000 results (override with `TRACK_MAX_RESULTS`)
 18. **Issue counts**: `track context` and `track cache show` include per-project issue counts for each query template
+19. **`--body-file`**: All commands accepting text body input (`-d`, `-m`, `--content`) also accept `--body-file <path>` to read from a file, or `--body-file -` to read from stdin. Useful for complex content with special characters, code blocks, or markdown that would be difficult to pass as CLI arguments


### PR DESCRIPTION
Adds new feature to support reading input from file for all commands which require text-based input for things like comments, descriptions, articles, etc. 

This closes #171 