### PR TITLE
[Feature] Config Scoping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.5.3"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/agent-skills/SKILL.md
+++ b/agent-skills/SKILL.md
@@ -17,7 +17,7 @@ disable-model-invocation: false
 | **Backends** | YouTrack (default), Jira (`-b jira`/`-b j`), GitHub (`-b github`/`-b gh`), GitLab (`-b gitlab`/`-b gl`) |
 | **Output** | Text (default) or JSON (`-o json`) |
 | **Config** | `.track.toml` (local), `~/.tracker-cli/.track.toml` (global), env vars, or CLI flags |
-| **Cache** | `.tracker-cache/` - run `track cache refresh` for context |
+| **Cache** | `.tracker-cache/` (project) or `~/.tracker-cli/cache/` (global) - run `track cache refresh` for context |
 | **AI Context** | `track context` - aggregated context in single command |
 
 ## Backend Comparison
@@ -430,9 +430,13 @@ track context -p PROJ
 track cache refresh       # Fetch all cacheable data
 track cache show          # Display cached data
 track -o json cache show  # JSON format
-track cache path          # Cache file location
+track cache path          # Cache directory location
 track cache status        # Age, freshness, data counts
 ```
+
+**Cache location**: `.tracker-cache/` in project directory (when `.track.toml` exists), or `~/.tracker-cli/cache/` globally.
+
+**Project context**: When `default_project` is set, cache refresh only fetches detailed data (fields, users, workflows) for that project. Instance-level data (tags, link types, query templates) is always fetched.
 
 **Cache contents**: Backend metadata, projects, custom fields (with enum values), tags/labels, link types, query templates, project users, issue counts, recent issues, articles.
 

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.5.3"
+version = "1.6.0"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -610,14 +610,28 @@ impl TrackerCache {
         Ok(())
     }
 
-    /// Get cache directory path
+    /// Get cache directory path.
+    /// - If explicit cache_dir is provided, use it.
+    /// - If in project context (.track.toml exists), use ./.tracker-cache/
+    /// - Otherwise (global context), use ~/.tracker-cli/cache/
     fn cache_dir_path(cache_dir: Option<PathBuf>) -> Result<PathBuf> {
         if let Some(dir) = cache_dir {
             return Ok(dir.join(CACHE_DIR_NAME));
         }
 
-        // Default to current directory
-        Ok(PathBuf::from(CACHE_DIR_NAME))
+        if crate::config::is_project_context() {
+            // Project context: cache alongside .track.toml
+            Ok(PathBuf::from(CACHE_DIR_NAME))
+        } else {
+            // Global context: cache in ~/.tracker-cli/cache/
+            crate::config::global_cache_dir()
+                .ok_or_else(|| anyhow!("Could not determine home directory for global cache"))
+        }
+    }
+
+    /// Get the resolved cache directory path (for external use, e.g. `cache path` command)
+    pub fn resolved_cache_dir() -> Result<PathBuf> {
+        Self::cache_dir_path(None)
     }
 
     /// Atomic write helper: write temp -> fsync -> rename
@@ -680,8 +694,20 @@ impl TrackerCache {
             })
             .collect();
 
-        // Fetch custom fields for each project and build workflow hints
-        for project in &projects {
+        // Determine which projects to fetch detailed data for:
+        // - If default_project is set (project context), only fetch that project's details
+        // - Otherwise (global context), fetch details for all projects
+        let projects_for_details: Vec<&tracker_core::Project> = if let Some(dp) = default_project {
+            projects
+                .iter()
+                .filter(|p| p.short_name.eq_ignore_ascii_case(dp))
+                .collect()
+        } else {
+            projects.iter().collect()
+        };
+
+        // Fetch custom fields and build workflow hints for scoped projects
+        for project in &projects_for_details {
             if let Ok(fields) = client.get_project_custom_fields(&project.id) {
                 let cached_fields: Vec<CachedField> = fields
                     .iter()
@@ -709,7 +735,7 @@ impl TrackerCache {
             }
         }
 
-        // Fetch tags
+        // Fetch tags (instance-level, always fetch all)
         if let Ok(tags) = client.list_tags() {
             cache.tags = tags
                 .iter()
@@ -722,7 +748,7 @@ impl TrackerCache {
                 .collect();
         }
 
-        // Fetch link types
+        // Fetch link types (instance-level, always fetch all)
         if let Ok(link_types) = client.list_link_types() {
             cache.link_types = link_types
                 .iter()
@@ -736,8 +762,8 @@ impl TrackerCache {
                 .collect();
         }
 
-        // Fetch project users
-        for project in &projects {
+        // Fetch project users for scoped projects
+        for project in &projects_for_details {
             if let Ok(users) = client.list_project_users(&project.id) {
                 let cached_users: Vec<CachedUser> = users
                     .iter()

--- a/crates/track/src/cli.rs
+++ b/crates/track/src/cli.rs
@@ -157,10 +157,11 @@ pub enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
-    /// Initialize a local .track.toml config file
+    /// Initialize a .track.toml config file
     ///
-    /// Creates a configuration file in the current directory. Use 'track config keys' to see
-    /// all available configuration keys. You can later modify the file with 'track config set'.
+    /// Creates a configuration file in the current directory (or globally with --global).
+    /// Use 'track config keys' to see all available configuration keys.
+    /// You can later modify the file with 'track config set'.
     ///
     /// Use --skills to install agent skill files globally for Claude, Copilot, Cursor, and Gemini.
     Init {
@@ -182,6 +183,9 @@ pub enum Commands {
         /// Install agent skill files globally for Claude, Copilot, Cursor, and Gemini
         #[arg(long)]
         skills: bool,
+        /// Create config at global level (~/.tracker-cli/.track.toml) instead of local
+        #[arg(long, short = 'g')]
+        global: bool,
     },
     /// Open an issue or the tracker dashboard in your browser
     Open {
@@ -209,8 +213,11 @@ pub enum ConfigCommands {
         key: String,
         /// Value to set
         value: String,
+        /// Write to global config (~/.tracker-cli/.track.toml) instead of project config
+        #[arg(long, short = 'g')]
+        global: bool,
     },
-    /// Get a configuration value
+    /// Get a configuration value (shows effective value with source)
     Get {
         /// Configuration key to get
         key: String,
@@ -227,13 +234,17 @@ pub enum ConfigCommands {
         #[arg(value_enum)]
         backend: Backend,
     },
-    /// Show current local configuration
+    /// Show configuration from all sources with origin markers
     Show,
     /// List all available configuration keys
     Keys,
-    /// Clear local configuration (remove default project and backend)
-    Clear,
-    /// Show local config file path
+    /// Clear configuration (remove default project and backend)
+    Clear {
+        /// Clear global config instead of project config
+        #[arg(long, short = 'g')]
+        global: bool,
+    },
+    /// Show config file paths
     Path,
     /// Test connection to the tracker (validates URL and token)
     Test,
@@ -1326,6 +1337,7 @@ mod tests {
                 backend,
                 email,
                 skills,
+                global,
             } => {
                 assert_eq!(url.as_deref(), Some("https://youtrack.example.com"));
                 assert_eq!(token.as_deref(), Some("perm:xxx"));
@@ -1333,6 +1345,7 @@ mod tests {
                 assert!(matches!(backend, Backend::YouTrack)); // Default
                 assert!(email.is_none());
                 assert!(!skills);
+                assert!(!global);
             }
             _ => panic!("expected init command"),
         }
@@ -1513,9 +1526,10 @@ mod tests {
 
         match cli.command {
             Commands::Config { action } => match action {
-                ConfigCommands::Set { key, value } => {
+                ConfigCommands::Set { key, value, global } => {
                     assert_eq!(key, "jira.email");
                     assert_eq!(value, "test@example.com");
+                    assert!(!global);
                 }
                 _ => panic!("expected config set"),
             },

--- a/crates/track/src/commands/cache.rs
+++ b/crates/track/src/commands/cache.rs
@@ -360,7 +360,7 @@ pub fn handle_cache(
             Ok(())
         }
         CacheCommands::Path => {
-            let path = std::env::current_dir()?.join(".tracker-cache");
+            let path = cache::TrackerCache::resolved_cache_dir()?;
             println!("{}", path.display());
             Ok(())
         }

--- a/crates/track/src/commands/config.rs
+++ b/crates/track/src/commands/config.rs
@@ -271,26 +271,41 @@ pub fn handle_config_local(action: &cli::ConfigCommands, format: cli::OutputForm
             }
             Ok(())
         }
-        ConfigCommands::Set { key, value } => {
+        ConfigCommands::Set { key, value, global } => {
             let config_key = parse_config_key(key)?;
 
-            let config_path = config::local_track_config_path()?;
-            let mut cfg = Config::load_local_track_toml()?.unwrap_or_default();
+            let (config_path, mut cfg) = if *global {
+                let path = config::global_config_path_ensure()?;
+                let cfg = Config::load_global_track_toml()?.unwrap_or_default();
+                (path, cfg)
+            } else {
+                let path = config::local_track_config_path()?;
+                let cfg = Config::load_local_track_toml()?.unwrap_or_default();
+                (path, cfg)
+            };
             config_key.set_value(&mut cfg, value)?;
             cfg.save(&config_path)?;
 
+            let level = if *global { "global" } else { "project" };
             match format {
                 cli::OutputFormat::Json => {
                     output_json(&serde_json::json!({
                         "success": true,
                         "key": config_key.as_str(),
-                        "value": value
+                        "value": value,
+                        "level": level
                     }))?;
                 }
                 cli::OutputFormat::Text => {
                     use colored::Colorize;
+                    let tag = if *global {
+                        "[global]".yellow().to_string()
+                    } else {
+                        "[project]".cyan().to_string()
+                    };
                     println!(
-                        "Set {} = {}",
+                        "{} Set {} = {}",
+                        tag,
                         config_key.as_str().cyan().bold(),
                         value.green()
                     );
@@ -300,28 +315,51 @@ pub fn handle_config_local(action: &cli::ConfigCommands, format: cli::OutputForm
         }
         ConfigCommands::Get { key } => {
             let config_key = parse_config_key(key)?;
-            let cfg = Config::load_local_track_toml()?.unwrap_or_default();
-            let value = config_key.get_value(&cfg);
+
+            // Check both levels to determine source
+            let global_cfg = Config::load_global_track_toml()?.unwrap_or_default();
+            let project_cfg = Config::load_local_track_toml()?.unwrap_or_default();
+
+            let global_val = config_key.get_value(&global_cfg);
+            let project_val = config_key.get_value(&project_cfg);
+
+            // Effective value: project overrides global
+            let (effective_val, source) = match (&project_val, &global_val) {
+                (Some(_), _) => (&project_val, "project"),
+                (None, Some(_)) => (&global_val, "global"),
+                (None, None) => (&None, ""),
+            };
 
             match format {
                 cli::OutputFormat::Json => {
-                    let is_set = value.is_some();
-                    let output = serde_json::json!({
+                    output_json(&serde_json::json!({
                         "key": config_key.as_str(),
-                        "value": value,
-                        "is_set": is_set
-                    });
-                    println!("{}", serde_json::to_string_pretty(&output)?);
+                        "value": effective_val,
+                        "source": if source.is_empty() { serde_json::Value::Null } else { serde_json::Value::String(source.to_string()) },
+                        "is_set": effective_val.is_some(),
+                        "global_value": global_val,
+                        "project_value": project_val,
+                    }))?;
                 }
                 cli::OutputFormat::Text => {
                     use colored::Colorize;
-                    if let Some(v) = &value {
+                    if let Some(v) = effective_val {
                         let display_value = if config_key.is_secret() {
                             "(set - hidden)".to_string()
                         } else {
                             v.to_string()
                         };
-                        println!("{} = {}", config_key.as_str().cyan(), display_value.green());
+                        let tag = match source {
+                            "project" => "[project]".cyan().to_string(),
+                            "global" => "[global]".yellow().to_string(),
+                            _ => String::new(),
+                        };
+                        println!(
+                            "{} {} = {}",
+                            tag,
+                            config_key.as_str().cyan(),
+                            display_value.green()
+                        );
                     } else {
                         println!("{} is not set", config_key.as_str().cyan());
                     }
@@ -330,142 +368,253 @@ pub fn handle_config_local(action: &cli::ConfigCommands, format: cli::OutputForm
             Ok(())
         }
         ConfigCommands::Show => {
-            let config = Config::load_local_track_toml()?;
-            match format {
-                cli::OutputFormat::Json => {
-                    if let Some(cfg) = &config {
-                        let output = serde_json::json!({
-                            "backend": cfg.backend,
-                            "default_project": cfg.default_project,
-                            "url": cfg.url,
-                            "has_token": cfg.token.is_some(),
-                            "has_email": cfg.email.is_some(),
-                            "youtrack": {
-                                "url": cfg.youtrack.url,
-                                "has_token": cfg.youtrack.token.is_some()
-                            },
-                            "jira": {
-                                "url": cfg.jira.url,
-                                "email": cfg.jira.email,
-                                "has_token": cfg.jira.token.is_some()
-                            },
-                            "github": {
-                                "owner": cfg.github.owner,
-                                "repo": cfg.github.repo,
-                                "api_url": cfg.github.api_url,
-                                "has_token": cfg.github.token.is_some()
-                            },
-                            "gitlab": {
-                                "url": cfg.gitlab.url,
-                                "project_id": cfg.gitlab.project_id,
-                                "namespace": cfg.gitlab.namespace,
-                                "has_token": cfg.gitlab.token.is_some()
-                            }
-                        });
-                        println!("{}", serde_json::to_string_pretty(&output)?);
-                    } else {
+            use colored::Colorize;
+
+            let global_cfg = Config::load_global_track_toml()?.unwrap_or_default();
+            let project_cfg = Config::load_local_track_toml()?;
+            let has_global = config::global_config_path()
+                .map(|p| p.exists())
+                .unwrap_or(false);
+            let has_project = project_cfg.is_some();
+            let project_cfg = project_cfg.unwrap_or_default();
+
+            if !has_global && !has_project {
+                match format {
+                    cli::OutputFormat::Json => {
                         println!("{{}}");
                     }
-                }
-                cli::OutputFormat::Text => {
-                    use colored::Colorize;
-                    if let Some(cfg) = config {
-                        let config_path = config::local_track_config_path()?;
-                        println!("{}:", "Configuration".white().bold());
-                        println!("  {}: {}", "File".dimmed(), config_path.display());
-                        let backend_name = cfg.backend.unwrap_or_default().to_string();
-                        println!("  {}: {}", "Backend".dimmed(), backend_name.cyan().bold());
-                        if let Some(url) = &cfg.url {
-                            println!("  {}: {}", "URL".dimmed(), url.cyan());
-                        }
-                        if cfg.email.is_some() {
-                            println!("  {}: {}", "Email".dimmed(), "(set)".green());
-                        }
-                        if cfg.token.is_some() {
-                            println!("  {}: {}", "Token".dimmed(), "(set)".green());
-                        }
-                        if let Some(project) = &cfg.default_project {
-                            println!(
-                                "  {}: {}",
-                                "Default project".dimmed(),
-                                project.cyan().bold()
-                            );
-                        }
-
-                        // Show backend-specific config if set
-                        if !cfg.youtrack.is_empty() {
-                            println!();
-                            println!("  {}:", "[youtrack]".white().bold());
-                            if let Some(url) = &cfg.youtrack.url {
-                                println!("    {}: {}", "url".dimmed(), url.cyan());
-                            }
-                            if cfg.youtrack.token.is_some() {
-                                println!("    {}: {}", "token".dimmed(), "(set)".green());
-                            }
-                        }
-
-                        if !cfg.jira.is_empty() {
-                            println!();
-                            println!("  {}:", "[jira]".white().bold());
-                            if let Some(url) = &cfg.jira.url {
-                                println!("    {}: {}", "url".dimmed(), url.cyan());
-                            }
-                            if let Some(email) = &cfg.jira.email {
-                                println!("    {}: {}", "email".dimmed(), email.cyan());
-                            }
-                            if cfg.jira.token.is_some() {
-                                println!("    {}: {}", "token".dimmed(), "(set)".green());
-                            }
-                        }
-
-                        if !cfg.github.is_empty() {
-                            println!();
-                            println!("  {}:", "[github]".white().bold());
-                            if let Some(owner) = &cfg.github.owner {
-                                println!("    {}: {}", "owner".dimmed(), owner.cyan());
-                            }
-                            if let Some(repo) = &cfg.github.repo {
-                                println!("    {}: {}", "repo".dimmed(), repo.cyan());
-                            }
-                            if let Some(api_url) = &cfg.github.api_url {
-                                println!("    {}: {}", "api_url".dimmed(), api_url.cyan());
-                            }
-                            if cfg.github.token.is_some() {
-                                println!("    {}: {}", "token".dimmed(), "(set)".green());
-                            }
-                        }
-
-                        if !cfg.gitlab.is_empty() {
-                            println!();
-                            println!("  {}:", "[gitlab]".white().bold());
-                            if let Some(url) = &cfg.gitlab.url {
-                                println!("    {}: {}", "url".dimmed(), url.cyan());
-                            }
-                            if let Some(project_id) = &cfg.gitlab.project_id {
-                                println!("    {}: {}", "project_id".dimmed(), project_id.cyan());
-                            }
-                            if let Some(namespace) = &cfg.gitlab.namespace {
-                                println!("    {}: {}", "namespace".dimmed(), namespace.cyan());
-                            }
-                            if cfg.gitlab.token.is_some() {
-                                println!("    {}: {}", "token".dimmed(), "(set)".green());
-                            }
-                        }
-                    } else {
-                        println!("No .track.toml configuration found.");
+                    cli::OutputFormat::Text => {
+                        println!("No configuration found.");
                         println!(
-                            "Run '{}' to create one.",
-                            "track init --url <URL> --token <TOKEN>".cyan()
+                            "Run '{}' or '{}' to create one.",
+                            "track init --url <URL> --token <TOKEN>".cyan(),
+                            "track init --global --url <URL> --token <TOKEN>".cyan()
                         );
                     }
+                }
+                return Ok(());
+            }
+
+            match format {
+                cli::OutputFormat::Json => {
+                    let mut entries = Vec::new();
+                    for key in ConfigKey::ALL {
+                        let global_val = key.get_value(&global_cfg);
+                        let project_val = key.get_value(&project_cfg);
+                        let (effective, source) = match (&project_val, &global_val) {
+                            (Some(_), _) => (&project_val, "project"),
+                            (None, Some(_)) => (&global_val, "global"),
+                            (None, None) => continue,
+                        };
+                        let display_val = if key.is_secret() {
+                            Some("(set - hidden)".to_string())
+                        } else {
+                            effective.clone()
+                        };
+                        entries.push(serde_json::json!({
+                            "key": key.as_str(),
+                            "value": display_val,
+                            "source": source,
+                        }));
+                    }
+                    output_json(&serde_json::json!({ "config": entries }))?;
+                }
+                cli::OutputFormat::Text => {
+                    // Show file paths
+                    println!("{}:", "Configuration".white().bold());
+                    if let Some(global_path) = config::global_config_path() {
+                        let status = if has_global {
+                            "(exists)".green().to_string()
+                        } else {
+                            "(not found)".dimmed().to_string()
+                        };
+                        println!(
+                            "  {} {} {}",
+                            "[global]".yellow(),
+                            global_path.display(),
+                            status
+                        );
+                    }
+                    let project_path = config::local_track_config_path()?;
+                    let status = if has_project {
+                        "(exists)".green().to_string()
+                    } else {
+                        "(not found)".dimmed().to_string()
+                    };
+                    println!(
+                        "  {} {} {}",
+                        "[project]".cyan(),
+                        project_path.display(),
+                        status
+                    );
+                    println!();
+
+                    // Helper to show a value with source tag
+                    let show_value = |label: &str,
+                                      global_val: &Option<String>,
+                                      project_val: &Option<String>,
+                                      is_secret: bool| {
+                        let (val, tag) = match (project_val, global_val) {
+                            (Some(v), _) => (Some(v.as_str()), "[project]".cyan().to_string()),
+                            (None, Some(v)) => (Some(v.as_str()), "[global]".yellow().to_string()),
+                            (None, None) => return,
+                        };
+                        if let Some(v) = val {
+                            let display = if is_secret {
+                                "(set)".green().to_string()
+                            } else {
+                                v.cyan().to_string()
+                            };
+                            println!("  {} {}: {}", tag, label.dimmed(), display);
+                        }
+                    };
+
+                    // Top-level keys
+                    show_value(
+                        "backend",
+                        &global_cfg.backend.map(|b| b.to_string()),
+                        &project_cfg.backend.map(|b| b.to_string()),
+                        false,
+                    );
+                    show_value("url", &global_cfg.url, &project_cfg.url, false);
+                    show_value("token", &global_cfg.token, &project_cfg.token, true);
+                    show_value("email", &global_cfg.email, &project_cfg.email, false);
+                    show_value(
+                        "default_project",
+                        &global_cfg.default_project,
+                        &project_cfg.default_project,
+                        false,
+                    );
+
+                    // Backend-specific sections
+                    let show_backend_section = |name: &str,
+                                                pairs: Vec<(
+                        &str,
+                        &Option<String>,
+                        &Option<String>,
+                        bool,
+                    )>| {
+                        let any_set = pairs.iter().any(|(_, g, p, _)| g.is_some() || p.is_some());
+                        if !any_set {
+                            return;
+                        }
+                        println!();
+                        println!("  {}:", format!("[{}]", name).white().bold());
+                        for (label, global_val, project_val, is_secret) in pairs {
+                            show_value(&format!("  {}", label), global_val, project_val, is_secret);
+                        }
+                    };
+
+                    show_backend_section(
+                        "youtrack",
+                        vec![
+                            (
+                                "url",
+                                &global_cfg.youtrack.url,
+                                &project_cfg.youtrack.url,
+                                false,
+                            ),
+                            (
+                                "token",
+                                &global_cfg.youtrack.token,
+                                &project_cfg.youtrack.token,
+                                true,
+                            ),
+                        ],
+                    );
+                    show_backend_section(
+                        "jira",
+                        vec![
+                            ("url", &global_cfg.jira.url, &project_cfg.jira.url, false),
+                            (
+                                "email",
+                                &global_cfg.jira.email,
+                                &project_cfg.jira.email,
+                                false,
+                            ),
+                            (
+                                "token",
+                                &global_cfg.jira.token,
+                                &project_cfg.jira.token,
+                                true,
+                            ),
+                        ],
+                    );
+                    show_backend_section(
+                        "github",
+                        vec![
+                            (
+                                "token",
+                                &global_cfg.github.token,
+                                &project_cfg.github.token,
+                                true,
+                            ),
+                            (
+                                "owner",
+                                &global_cfg.github.owner,
+                                &project_cfg.github.owner,
+                                false,
+                            ),
+                            (
+                                "repo",
+                                &global_cfg.github.repo,
+                                &project_cfg.github.repo,
+                                false,
+                            ),
+                            (
+                                "api_url",
+                                &global_cfg.github.api_url,
+                                &project_cfg.github.api_url,
+                                false,
+                            ),
+                        ],
+                    );
+                    show_backend_section(
+                        "gitlab",
+                        vec![
+                            (
+                                "token",
+                                &global_cfg.gitlab.token,
+                                &project_cfg.gitlab.token,
+                                true,
+                            ),
+                            (
+                                "url",
+                                &global_cfg.gitlab.url,
+                                &project_cfg.gitlab.url,
+                                false,
+                            ),
+                            (
+                                "project_id",
+                                &global_cfg.gitlab.project_id,
+                                &project_cfg.gitlab.project_id,
+                                false,
+                            ),
+                            (
+                                "namespace",
+                                &global_cfg.gitlab.namespace,
+                                &project_cfg.gitlab.namespace,
+                                false,
+                            ),
+                        ],
+                    );
                 }
             }
             Ok(())
         }
-        ConfigCommands::Clear => {
-            // Clear default_project and backend from .track.toml (keep url/token)
-            let config_path = config::local_track_config_path()?;
-            if let Some(mut cfg) = Config::load_local_track_toml()? {
+        ConfigCommands::Clear { global } => {
+            let (config_path, loaded) = if *global {
+                let path = config::global_config_path_ensure()?;
+                let cfg = Config::load_global_track_toml()?;
+                (path, cfg)
+            } else {
+                let path = config::local_track_config_path()?;
+                let cfg = Config::load_local_track_toml()?;
+                (path, cfg)
+            };
+            let level = if *global { "global" } else { "project" };
+
+            if let Some(mut cfg) = loaded {
                 cfg.default_project = None;
                 cfg.backend = None;
                 cfg.save(&config_path)?;
@@ -473,12 +622,18 @@ pub fn handle_config_local(action: &cli::ConfigCommands, format: cli::OutputForm
                     cli::OutputFormat::Json => {
                         output_json(&serde_json::json!({
                             "success": true,
+                            "level": level,
                             "message": "Configuration cleared"
                         }))?;
                     }
                     cli::OutputFormat::Text => {
                         use colored::Colorize;
-                        println!("{}", "Default project and backend cleared.".green());
+                        let tag = if *global {
+                            "[global]".yellow().to_string()
+                        } else {
+                            "[project]".cyan().to_string()
+                        };
+                        println!("{} {}", tag, "Default project and backend cleared.".green());
                     }
                 }
             } else {
@@ -486,19 +641,54 @@ pub fn handle_config_local(action: &cli::ConfigCommands, format: cli::OutputForm
                     cli::OutputFormat::Json => {
                         output_json(&serde_json::json!({
                             "success": true,
+                            "level": level,
                             "message": "No configuration to clear"
                         }))?;
                     }
                     cli::OutputFormat::Text => {
-                        println!("No .track.toml configuration found.");
+                        use colored::Colorize;
+                        let file_name = if *global {
+                            "~/.tracker-cli/.track.toml"
+                        } else {
+                            ".track.toml"
+                        };
+                        println!("No {} configuration found.", file_name.cyan());
                     }
                 }
             }
             Ok(())
         }
         ConfigCommands::Path => {
-            let path = config::local_track_config_path()?;
-            println!("{}", path.display());
+            match format {
+                cli::OutputFormat::Json => {
+                    let global = config::global_config_path();
+                    let project = config::local_track_config_path().ok();
+                    output_json(&serde_json::json!({
+                        "global": global.as_ref().map(|p| p.display().to_string()),
+                        "global_exists": global.as_ref().map(|p| p.exists()).unwrap_or(false),
+                        "project": project.as_ref().map(|p| p.display().to_string()),
+                        "project_exists": project.as_ref().map(|p| p.exists()).unwrap_or(false),
+                    }))?;
+                }
+                cli::OutputFormat::Text => {
+                    use colored::Colorize;
+                    if let Some(global) = config::global_config_path() {
+                        let status = if global.exists() {
+                            "(exists)".green().to_string()
+                        } else {
+                            "(not found)".dimmed().to_string()
+                        };
+                        println!("Global:  {} {}", global.display(), status);
+                    }
+                    let project = config::local_track_config_path()?;
+                    let status = if project.exists() {
+                        "(exists)".green().to_string()
+                    } else {
+                        "(not found)".dimmed().to_string()
+                    };
+                    println!("Project: {} {}", project.display(), status);
+                }
+            }
             Ok(())
         }
         ConfigCommands::Project { .. } | ConfigCommands::Test | ConfigCommands::Backend { .. } => {
@@ -575,7 +765,7 @@ pub fn handle_config(
         }
         // These are handled elsewhere before API validation
         ConfigCommands::Show
-        | ConfigCommands::Clear
+        | ConfigCommands::Clear { .. }
         | ConfigCommands::Path
         | ConfigCommands::Keys
         | ConfigCommands::Set { .. }

--- a/crates/track/src/commands/init.rs
+++ b/crates/track/src/commands/init.rs
@@ -66,6 +66,7 @@ fn install_agent_skills(format: cli::OutputFormat) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn handle_init(
     url: Option<&str>,
     token: Option<&str>,
@@ -74,6 +75,7 @@ pub fn handle_init(
     format: cli::OutputFormat,
     backend: Backend,
     skills: bool,
+    global: bool,
 ) -> Result<()> {
     use colored::Colorize;
 
@@ -93,7 +95,11 @@ pub fn handle_init(
         ));
     }
 
-    let config_path = config::local_track_config_path()?;
+    let config_path = if global {
+        config::global_config_path_ensure()?
+    } else {
+        config::local_track_config_path()?
+    };
 
     // Check if config already exists
     if config_path.exists() {
@@ -196,42 +202,60 @@ pub fn handle_init(
 
     config.save(&config_path)?;
 
-    // Write agent guide to the same directory as the config
-    let guide_path = config_path
-        .parent()
-        .map(|p| p.join("AGENT_GUIDE.md"))
-        .unwrap_or_else(|| std::path::PathBuf::from("AGENT_GUIDE.md"));
-    std::fs::write(&guide_path, AGENT_GUIDE)?;
+    // Write agent guide to the same directory as the config (skip for global init)
+    let guide_path = if !global {
+        let path = config_path
+            .parent()
+            .map(|p| p.join("AGENT_GUIDE.md"))
+            .unwrap_or_else(|| std::path::PathBuf::from("AGENT_GUIDE.md"));
+        std::fs::write(&path, AGENT_GUIDE)?;
+        Some(path)
+    } else {
+        None
+    };
 
     // If --skills was also passed, install skill files too
     if skills {
         install_agent_skills(format)?;
     }
 
+    let level = if global { "global" } else { "project" };
     match format {
         cli::OutputFormat::Json => {
             let mut result = serde_json::json!({
                 "success": true,
+                "level": level,
                 "backend": backend.to_string(),
                 "config_path": config_path.display().to_string(),
-                "guide_path": guide_path.display().to_string()
             });
+            if let Some(guide) = &guide_path {
+                result["guide_path"] = serde_json::json!(guide.display().to_string());
+            }
             if let Some((_, name)) = &validated_project {
                 result["default_project"] = serde_json::json!(name);
             }
             output_json(&result)?;
         }
         cli::OutputFormat::Text => {
+            let tag = if global {
+                "[global]".yellow().to_string()
+            } else {
+                "[project]".cyan().to_string()
+            };
             println!(
-                "{} {}",
-                "Created config file:".green(),
+                "{} {} {}",
+                tag,
+                "Created config:".green(),
                 config_path.display()
             );
-            println!(
-                "{} {}",
-                "Created agent guide:".green(),
-                guide_path.display()
-            );
+            if let Some(guide) = &guide_path {
+                println!(
+                    "{} {} {}",
+                    tag,
+                    "Created agent guide:".green(),
+                    guide.display()
+                );
+            }
             println!(
                 "  {}: {}",
                 "Backend".dimmed(),
@@ -244,10 +268,6 @@ pub fn handle_init(
             println!(
                 "{}",
                 "You can now use track commands without --url, --token, and -b flags.".dimmed()
-            );
-            println!(
-                "{}",
-                "AI agents can reference AGENT_GUIDE.md for CLI usage patterns.".dimmed()
             );
         }
     }

--- a/crates/track/src/config.rs
+++ b/crates/track/src/config.rs
@@ -1,6 +1,5 @@
 use crate::cli::Backend;
 use anyhow::{Result, anyhow};
-use directories::{BaseDirs, ProjectDirs};
 use figment::{
     Figment,
     providers::{Env, Format, Serialized, Toml},
@@ -290,10 +289,22 @@ impl Config {
     /// Load config from only the local .track.toml file (for updating it)
     pub fn load_local_track_toml() -> Result<Option<Self>> {
         let path = local_track_config_path()?;
+        Self::load_from_path(&path)
+    }
+
+    /// Load config from only the global ~/.tracker-cli/.track.toml file (for updating it)
+    pub fn load_global_track_toml() -> Result<Option<Self>> {
+        let path = global_config_path()
+            .ok_or_else(|| anyhow!("Could not determine home directory for global config"))?;
+        Self::load_from_path(&path)
+    }
+
+    /// Load config from a specific path
+    fn load_from_path(path: &Path) -> Result<Option<Self>> {
         if !path.exists() {
             return Ok(None);
         }
-        let content = fs::read_to_string(&path)
+        let content = fs::read_to_string(path)
             .map_err(|e| anyhow!("Failed to read {}: {}", path.display(), e))?;
         let config: Config = toml::from_str(&content)
             .map_err(|e| anyhow!("Failed to parse {}: {}", path.display(), e))?;
@@ -344,58 +355,23 @@ fn config_paths(explicit: Option<&Path>) -> Vec<PathBuf> {
 
     // Load configs from lowest to highest priority
     // Later entries override earlier ones in figment merge
-    if let Some(path) = get_project_config_path() {
-        push_unique(&mut paths, path);
+    // 1. Global: ~/.tracker-cli/.track.toml (lowest file priority)
+    if let Some(path) = get_global_config_path() {
+        paths.push(path);
     }
-    if let Some(path) = get_xdg_config_path() {
-        push_unique(&mut paths, path);
-    }
-    if let Some(path) = get_install_dir_config_path() {
-        push_unique(&mut paths, path);
-    }
-    if let Some(path) = get_local_config_path() {
-        push_unique(&mut paths, path);
-    }
-    // .track.toml has highest priority (project-specific)
-    if let Some(path) = get_local_track_config_path() {
-        push_unique(&mut paths, path);
+    // 2. Project: ./.track.toml (highest file priority)
+    if let Some(path) = get_local_track_config_path()
+        && !paths.contains(&path)
+    {
+        paths.push(path);
     }
 
     paths
 }
 
-fn push_unique(paths: &mut Vec<PathBuf>, path: PathBuf) {
-    if !paths.contains(&path) {
-        paths.push(path);
-    }
-}
-
-fn get_project_config_path() -> Option<PathBuf> {
-    ProjectDirs::from("", "", "track").map(|d| d.config_dir().join("config.toml"))
-}
-
-fn get_xdg_config_path() -> Option<PathBuf> {
-    if let Some(dir) = std::env::var_os("XDG_CONFIG_HOME") {
-        return Some(PathBuf::from(dir).join("track").join("config.toml"));
-    }
-
-    BaseDirs::new().map(|dirs| {
-        dirs.home_dir()
-            .join(".config")
-            .join("track")
-            .join("config.toml")
-    })
-}
-
-fn get_local_config_path() -> Option<PathBuf> {
-    std::env::current_dir()
-        .ok()
-        .map(|dir| dir.join("config.toml"))
-}
-
-/// Returns the path to the global install directory config (~/.tracker-cli/.track.toml)
-fn get_install_dir_config_path() -> Option<PathBuf> {
-    BaseDirs::new().map(|dirs| dirs.home_dir().join(".tracker-cli").join(".track.toml"))
+/// Returns the path to the global config (~/.tracker-cli/.track.toml)
+fn get_global_config_path() -> Option<PathBuf> {
+    home_dir().map(|home| home.join(".tracker-cli").join(".track.toml"))
 }
 
 /// Returns the path to the local .track.toml file in the current directory
@@ -405,11 +381,63 @@ fn get_local_track_config_path() -> Option<PathBuf> {
         .map(|dir| dir.join(".track.toml"))
 }
 
+/// Returns the user's home directory
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
 /// Returns the path where `track init` will create the config file
 pub fn local_track_config_path() -> Result<PathBuf> {
     std::env::current_dir()
         .map(|dir| dir.join(".track.toml"))
         .map_err(|e| anyhow!("Failed to get current directory: {}", e))
+}
+
+/// Returns the global config path (~/.tracker-cli/.track.toml)
+pub fn global_config_path() -> Option<PathBuf> {
+    get_global_config_path()
+}
+
+/// Returns the global config path, creating the parent directory if needed
+pub fn global_config_path_ensure() -> Result<PathBuf> {
+    let path = global_config_path()
+        .ok_or_else(|| anyhow!("Could not determine home directory for global config"))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| anyhow!("Failed to create directory {}: {}", parent.display(), e))?;
+    }
+    Ok(path)
+}
+
+/// Returns true if a .track.toml exists in the current directory (project context)
+pub fn is_project_context() -> bool {
+    get_local_track_config_path()
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+/// Returns the global cache directory (~/.tracker-cli/cache/)
+pub fn global_cache_dir() -> Option<PathBuf> {
+    home_dir().map(|home| home.join(".tracker-cli").join("cache"))
+}
+
+/// Load backend from the full config chain (global -> project -> env)
+/// without requiring a backend argument.
+pub fn resolve_backend() -> Backend {
+    let mut figment = Figment::new().merge(Serialized::defaults(Config::default()));
+    for path in config_paths(None) {
+        if path.exists() {
+            figment = figment.merge(Toml::file(path));
+        }
+    }
+    figment = figment.merge(Env::prefixed("TRACKER_"));
+    figment
+        .extract::<Config>()
+        .ok()
+        .and_then(|c| c.backend)
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/crates/track/src/main.rs
+++ b/crates/track/src/main.rs
@@ -52,6 +52,7 @@ fn run(cli: Cli) -> Result<()> {
         backend,
         email,
         skills,
+        global,
     } = &cli.command
     {
         return commands::init::handle_init(
@@ -62,6 +63,7 @@ fn run(cli: Cli) -> Result<()> {
             cli.format,
             *backend,
             *skills,
+            *global,
         );
     }
 
@@ -70,7 +72,7 @@ fn run(cli: Cli) -> Result<()> {
         use cli::ConfigCommands;
         match action {
             ConfigCommands::Show
-            | ConfigCommands::Clear
+            | ConfigCommands::Clear { .. }
             | ConfigCommands::Path
             | ConfigCommands::Keys
             | ConfigCommands::Set { .. }
@@ -103,15 +105,8 @@ fn run(cli: Cli) -> Result<()> {
         }
     }
 
-    // Determine effective backend: CLI flag takes precedence, then config, then default
-    let effective_backend = cli.backend.unwrap_or_else(|| {
-        // Try to get backend from config file
-        Config::load_local_track_toml()
-            .ok()
-            .flatten()
-            .map(|c| c.get_backend())
-            .unwrap_or(Backend::YouTrack)
-    });
+    // Determine effective backend: CLI flag > config chain (project > global > env) > default
+    let effective_backend = cli.backend.unwrap_or_else(config::resolve_backend);
 
     let mut config = Config::load(cli.config.clone(), effective_backend)?;
     config.merge_with_cli(cli.url.clone(), cli.token.clone());

--- a/crates/track/tests/cache_integration_tests.rs
+++ b/crates/track/tests/cache_integration_tests.rs
@@ -48,9 +48,19 @@ fn temp_dir() -> PathBuf {
     dir
 }
 
+/// Ensure a .track.toml exists in the temp directory so the cache resolves locally.
+fn ensure_project_context(dir: &PathBuf) {
+    let track_toml = dir.join(".track.toml");
+    if !track_toml.exists() {
+        fs::write(&track_toml, "# test project context\n").unwrap();
+    }
+}
+
 /// Build a track command pointed at a temp directory with mock backend enabled.
 /// Passes dummy --url and --token since config validation runs before mock activation.
+/// Creates a .track.toml to ensure project context (local cache).
 fn track_in(dir: &PathBuf) -> Command {
+    ensure_project_context(dir);
     let mut cmd = cargo_bin_cmd!("track");
     cmd.current_dir(dir)
         .env("TRACK_MOCK_DIR", cache_scenario().to_str().unwrap())
@@ -60,7 +70,9 @@ fn track_in(dir: &PathBuf) -> Command {
 
 /// Build a track command pointed at a temp directory WITHOUT mock (for reading cache only).
 /// Uses a dummy config so validation doesn't require a real server.
+/// Creates a .track.toml to ensure project context (local cache).
 fn track_in_no_mock(dir: &PathBuf) -> Command {
+    ensure_project_context(dir);
     let mut cmd = cargo_bin_cmd!("track");
     cmd.current_dir(dir)
         .args(["--url", "https://mock.test", "--token", "mock-token"]);

--- a/crates/track/tests/command_integration_tests.rs
+++ b/crates/track/tests/command_integration_tests.rs
@@ -317,7 +317,7 @@ fn test_config_show_no_config() {
         .args(["config", "show"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("No .track.toml"));
+        .stdout(predicate::str::contains("No configuration found"));
 
     let _ = fs::remove_dir_all(&dir);
 }
@@ -336,9 +336,22 @@ fn test_config_show_json_output() {
         .unwrap();
     assert!(output.status.success());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["backend"], "jira");
-    assert_eq!(json["default_project"], "SMS");
-    assert_eq!(json["url"], "https://jira.example.com");
+    // New format: { "config": [{ "key": "...", "value": "...", "source": "..." }, ...] }
+    let config = json["config"]
+        .as_array()
+        .expect("config should be an array");
+    let find_val = |key: &str| -> Option<String> {
+        config
+            .iter()
+            .find(|e| e["key"] == key)
+            .and_then(|e| e["value"].as_str().map(|s| s.to_string()))
+    };
+    assert_eq!(find_val("backend"), Some("jira".to_string()));
+    assert_eq!(find_val("default_project"), Some("SMS".to_string()));
+    assert_eq!(
+        find_val("url"),
+        Some("https://jira.example.com".to_string())
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }
@@ -403,9 +416,15 @@ fn test_config_path_output() {
     let output = track_in(&dir).args(["config", "path"]).output().unwrap();
     assert!(output.status.success());
     let path_str = String::from_utf8(output.stdout).unwrap();
+    // Output now shows both global and project paths
     assert!(
-        path_str.trim().ends_with(".track.toml"),
-        "config path should end with .track.toml, got: {}",
+        path_str.contains("Global:") && path_str.contains("Project:"),
+        "config path should show Global and Project lines, got: {}",
+        path_str.trim()
+    );
+    assert!(
+        path_str.contains(".track.toml"),
+        "config path should reference .track.toml, got: {}",
         path_str.trim()
     );
 
@@ -911,10 +930,20 @@ token = "ghp_tok"
         .unwrap();
     assert!(output.status.success());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["backend"], "github");
-    assert_eq!(json["github"]["owner"], "org");
-    assert_eq!(json["github"]["repo"], "repo");
-    assert_eq!(json["github"]["has_token"], true);
+    // New format: { "config": [{ "key": "...", "value": "...", "source": "..." }, ...] }
+    let config = json["config"]
+        .as_array()
+        .expect("config should be an array");
+    let find_entry =
+        |key: &str| -> Option<&serde_json::Value> { config.iter().find(|e| e["key"] == key) };
+    assert_eq!(find_entry("backend").unwrap()["value"], "github");
+    assert_eq!(find_entry("github.owner").unwrap()["value"], "org");
+    assert_eq!(find_entry("github.repo").unwrap()["value"], "repo");
+    // Token should be hidden
+    assert_eq!(
+        find_entry("github.token").unwrap()["value"],
+        "(set - hidden)"
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -9,8 +9,8 @@
 | **Binary** | `track` (or `target/release/track` if not installed) |
 | **Backends** | YouTrack (default), Jira (`-b jira`/`-b j`), GitHub (`-b github`/`-b gh`), GitLab (`-b gitlab`/`-b gl`) |
 | **Output** | Text (default) or JSON (`-o json`) |
-| **Config** | `.track.toml` in project dir, env vars, or CLI flags |
-| **Cache** | `.tracker-cache/` - run `track cache refresh` for context |
+| **Config** | `.track.toml` (project), `~/.tracker-cli/.track.toml` (global), env vars, or CLI flags |
+| **Cache** | `.tracker-cache/` (project) or `~/.tracker-cli/cache/` (global) - run `track cache refresh` for context |
 | **AI Context** | `track context` - aggregated context in single command |
 
 ## Backend Comparison
@@ -849,10 +849,16 @@ The cache stores comprehensive tracker context locally for fast lookups and AI c
 track cache refresh       # Fetch and store all cacheable data
 track cache show          # Display cached data (text)
 track -o json cache show  # JSON format (for programmatic use)
-track cache path          # Show cache file location
+track cache path          # Show cache directory location
 ```
 
-**Cache file** (`.tracker-cache/`) contains:
+**Cache location**:
+- **Project context** (`.track.toml` exists): `.tracker-cache/` in the current directory
+- **Global context** (no `.track.toml`): `~/.tracker-cli/cache/`
+
+**Project-scoped refresh**: When `default_project` is set, cache refresh only fetches detailed data (fields, users, workflows) for that project. Instance-level data (tags, link types, query templates) is always fetched in full.
+
+**Cache directory** contains:
 
 | Data | Description |
 |------|-------------|


### PR DESCRIPTION
### Summary
This PR fixes some existing bugs around config resolution, but also adds the ability to `scope` the context of the tool based on the configuration. If the config exists at a `project` level inside your working directory and you set the default project in the config to be your project, it will only pull context related to that project.

At a global level, you can configure the tool and it will pull data from `all` projects, like it does today. This cache will live/persist outside the project directory in its own `global` space alongside the global configuration.

This will allow users to scope the cache/context for their working directory more easily while still allowing for multi-project interactions at a global level.

#### Changes
- Enhance cache directory resolution to distinguish between project and global contexts.
- Improve configuration structure, adding support for separate project/global scopes.
- Refactor `Config` and integration tests to reflect updated priorities and new CLI options.
- Update CLI commands for better configuration management, introducing `--global` flag.
- Improve test cases for `config` and `cache` commands to validate changes.