### PR TITLE
fix: scope GitHub cache refresh to configured repo

### DIFF
--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -682,8 +682,19 @@ impl TrackerCache {
             ..Self::default()
         };
 
-        // Fetch projects
-        let projects = client.list_projects().context("Failed to fetch projects")?;
+        // Fetch projects:
+        // - If default_project is set (project context), only fetch that project to avoid
+        //   pulling all repos visible to the token (which can include org repos and
+        //   waste API quota on backends like GitHub with broad token scopes)
+        // - Otherwise (global context), fetch all projects
+        let projects = if let Some(dp) = default_project {
+            match client.get_project(dp) {
+                Ok(p) => vec![p],
+                Err(_) => client.list_projects().context("Failed to fetch projects")?,
+            }
+        } else {
+            client.list_projects().context("Failed to fetch projects")?
+        };
         cache.projects = projects
             .iter()
             .map(|p| CachedProject {
@@ -694,9 +705,7 @@ impl TrackerCache {
             })
             .collect();
 
-        // Determine which projects to fetch detailed data for:
-        // - If default_project is set (project context), only fetch that project's details
-        // - Otherwise (global context), fetch details for all projects
+        // Determine which projects to fetch detailed data for
         let projects_for_details: Vec<&tracker_core::Project> = if let Some(dp) = default_project {
             projects
                 .iter()

--- a/crates/track/src/main.rs
+++ b/crates/track/src/main.rs
@@ -158,6 +158,12 @@ fn run(cli: Cli) -> Result<()> {
                         "GitHub repo not configured. Set via 'track config set github.repo <REPO>' or GITHUB_REPO env var"
                     )
                 })?;
+            // Auto-derive default_project from owner/repo when not explicitly set.
+            // This scopes cache refresh to just this repo instead of fetching all
+            // repos visible to the token (which can include org repos).
+            if config.default_project.is_none() {
+                config.default_project = Some(format!("{}/{}", owner, repo));
+            }
             let token = config.token.as_ref().unwrap();
             let client = if let Some(api_url) = config.url.as_deref() {
                 GitHubClient::with_base_url(api_url, owner, repo, token)


### PR DESCRIPTION
## Problem

When using the GitHub backend with a token that has `read:org` scope,
`cache refresh` calls `/user/repos` which returns ALL repos visible to
the token (personal + org repos). For users belonging to large orgs,
this pollutes the cache with irrelevant projects and wastes API quota
on issue count queries (one search API call per query template per
cached project).

The GitHub search API has a 30 req/min limit. With 6 query templates
and 100+ cached repos, the search quota is exhausted quickly, causing
429 errors on subsequent `track issue search` and `track context` calls.

## Fix

1. **main.rs**: Auto-derive `default_project` as `"{owner}/{repo}"` from
   the GitHub config when not explicitly set. This gives the cache a
   project scope without requiring users to change their config.

2. **cache.rs**: When `default_project` is set, use `get_project()` to
   fetch just that repo instead of `list_projects()` which fetches all
   visible repos. Falls back to `list_projects()` if `get_project()`
   fails.

## What's preserved

- `track project list` still returns all visible repos (uses
  `list_projects()` directly, not through cache)
- `track config project` discovery still works
- `track init` token validation still works
- Global context (no `.track.toml`) still fetches all projects
- Explicit `default_project` in config takes precedence