### PR TITLE
fix(jira): surface custom fields on issue get and search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/jira-backend/src/client.rs
+++ b/crates/jira-backend/src/client.rs
@@ -171,13 +171,6 @@ impl JiraClient {
         Ok(issue)
     }
 
-    /// Count issues matching a JQL query without fetching issue data.
-    /// Uses maxResults=0 to get only the total count.
-    pub fn count_issues(&self, jql: &str) -> Result<usize> {
-        let result = self.search_issues(jql, 0, 0)?;
-        Ok(result.total)
-    }
-
     /// Search issues using JQL
     pub fn search_issues(
         &self,
@@ -185,10 +178,11 @@ impl JiraClient {
         max_results: usize,
         start_at: usize,
     ) -> Result<JiraSearchResult> {
-        // Note: Jira Cloud now uses /search/jql with GET request (as of 2024)
+        // Jira Cloud uses GET /search/jql (the old POST /search was removed).
+        // `fields=*all` is required — without it the endpoint returns only issue IDs.
         let jql_encoded = urlencoding::encode(jql);
         let url = format!(
-            "{}?jql={}&startAt={}&maxResults={}",
+            "{}?jql={}&startAt={}&maxResults={}&fields=*all",
             self.api_url("/search/jql"),
             jql_encoded,
             start_at,

--- a/crates/jira-backend/src/client.rs
+++ b/crates/jira-backend/src/client.rs
@@ -6,24 +6,6 @@ use ureq::Agent;
 use crate::error::{JiraError, Result};
 use crate::models::*;
 
-/// Default fields to request for issues
-const DEFAULT_ISSUE_FIELDS: &[&str] = &[
-    "summary",
-    "description",
-    "status",
-    "priority",
-    "issuetype",
-    "project",
-    "assignee",
-    "reporter",
-    "labels",
-    "created",
-    "updated",
-    "subtasks",
-    "parent",
-    "issuelinks",
-];
-
 /// Jira REST API client
 pub struct JiraClient {
     agent: Agent,
@@ -174,12 +156,7 @@ impl JiraClient {
 
     /// Get an issue by key or ID
     pub fn get_issue(&self, key: &str) -> Result<JiraIssue> {
-        let fields = DEFAULT_ISSUE_FIELDS.join(",");
-        let url = format!(
-            "{}?fields={}",
-            self.api_url(&format!("/issue/{}", key)),
-            fields
-        );
+        let url = self.api_url(&format!("/issue/{}", key));
 
         let response = self
             .agent
@@ -209,15 +186,13 @@ impl JiraClient {
         start_at: usize,
     ) -> Result<JiraSearchResult> {
         // Note: Jira Cloud now uses /search/jql with GET request (as of 2024)
-        let fields = DEFAULT_ISSUE_FIELDS.join(",");
         let jql_encoded = urlencoding::encode(jql);
         let url = format!(
-            "{}?jql={}&startAt={}&maxResults={}&fields={}",
+            "{}?jql={}&startAt={}&maxResults={}",
             self.api_url("/search/jql"),
             jql_encoded,
             start_at,
             max_results,
-            fields
         );
 
         let response = self

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -206,13 +206,11 @@ mod tests {
                 "Basic dGVzdEB0ZXN0LmNvbTp0ZXN0LXRva2Vu",
             ))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "startAt": 0,
-                "maxResults": 20,
-                "total": 2,
                 "issues": [
                     mock_jira_issue("TEST-123", "First issue"),
                     mock_jira_issue("TEST-124", "Second issue")
-                ]
+                ],
+                "isLast": true
             })))
             .mount(&mock_server)
             .await;
@@ -220,36 +218,10 @@ mod tests {
         let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
         let result = client.search_issues("project = TEST", 20, 0).unwrap();
 
-        assert_eq!(result.total, 2);
+        assert!(result.is_last);
         assert_eq!(result.issues.len(), 2);
         assert_eq!(result.issues[0].key, "TEST-123");
         assert_eq!(result.issues[1].key, "TEST-124");
-    }
-
-    #[tokio::test]
-    async fn test_count_issues() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("GET"))
-            .and(path("/rest/api/3/search/jql"))
-            .and(header(
-                "Authorization",
-                "Basic dGVzdEB0ZXN0LmNvbTp0ZXN0LXRva2Vu",
-            ))
-            .and(wiremock::matchers::query_param("maxResults", "0"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "startAt": 0,
-                "maxResults": 0,
-                "total": 847,
-                "issues": []
-            })))
-            .mount(&mock_server)
-            .await;
-
-        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
-        let count = client.count_issues("project = TEST").unwrap();
-
-        assert_eq!(count, 847);
     }
 
     #[tokio::test]
@@ -632,16 +604,14 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/rest/api/3/search/jql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "startAt": 10,
-                "maxResults": 5,
-                "total": 25,
                 "issues": [
                     mock_jira_issue("TEST-11", "Issue 11"),
                     mock_jira_issue("TEST-12", "Issue 12"),
                     mock_jira_issue("TEST-13", "Issue 13"),
                     mock_jira_issue("TEST-14", "Issue 14"),
                     mock_jira_issue("TEST-15", "Issue 15")
-                ]
+                ],
+                "isLast": false
             })))
             .mount(&mock_server)
             .await;
@@ -649,9 +619,7 @@ mod tests {
         let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
         let result = client.search_issues("project = TEST", 5, 10).unwrap();
 
-        assert_eq!(result.start_at, 10);
-        assert_eq!(result.max_results, 5);
-        assert_eq!(result.total, 25);
+        assert!(!result.is_last);
         assert_eq!(result.issues.len(), 5);
     }
 

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -897,11 +897,12 @@ mod tests {
 
         let mut issue_json = mock_jira_issue("TEST-500", "Issue with custom fields");
         // Add custom fields to the mock response
-        let fields = issue_json.get_mut("fields").unwrap().as_object_mut().unwrap();
-        fields.insert(
-            "customfield_10016".to_string(),
-            serde_json::json!(5.0),
-        );
+        let fields = issue_json
+            .get_mut("fields")
+            .unwrap()
+            .as_object_mut()
+            .unwrap();
+        fields.insert("customfield_10016".to_string(), serde_json::json!(5.0));
         fields.insert(
             "customfield_10020".to_string(),
             serde_json::json!([{"id": 1, "name": "Sprint 1"}]),
@@ -910,10 +911,7 @@ mod tests {
             "customfield_11000".to_string(),
             serde_json::json!({"value": "Option A"}),
         );
-        fields.insert(
-            "customfield_11001".to_string(),
-            serde_json::Value::Null,
-        );
+        fields.insert("customfield_11001".to_string(), serde_json::Value::Null);
 
         Mock::given(method("GET"))
             .and(path("/rest/api/3/issue/TEST-500"))
@@ -933,7 +931,10 @@ mod tests {
         assert_eq!(issue.fields.summary, "Issue with custom fields");
 
         // Custom fields captured in extra HashMap
-        assert_eq!(issue.fields.extra.get("customfield_10016").unwrap(), &serde_json::json!(5.0));
+        assert_eq!(
+            issue.fields.extra.get("customfield_10016").unwrap(),
+            &serde_json::json!(5.0)
+        );
         assert_eq!(
             issue.fields.extra.get("customfield_10020").unwrap(),
             &serde_json::json!([{"id": 1, "name": "Sprint 1"}])

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -924,6 +924,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_issue_captures_custom_fields_in_extra() {
+        let mock_server = MockServer::start().await;
+
+        let mut issue_json = mock_jira_issue("TEST-500", "Issue with custom fields");
+        // Add custom fields to the mock response
+        let fields = issue_json.get_mut("fields").unwrap().as_object_mut().unwrap();
+        fields.insert(
+            "customfield_10016".to_string(),
+            serde_json::json!(5.0),
+        );
+        fields.insert(
+            "customfield_10020".to_string(),
+            serde_json::json!([{"id": 1, "name": "Sprint 1"}]),
+        );
+        fields.insert(
+            "customfield_11000".to_string(),
+            serde_json::json!({"value": "Option A"}),
+        );
+        fields.insert(
+            "customfield_11001".to_string(),
+            serde_json::Value::Null,
+        );
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-500"))
+            .and(header(
+                "Authorization",
+                "Basic dGVzdEB0ZXN0LmNvbTp0ZXN0LXRva2Vu",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(issue_json))
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+        let issue = client.get_issue("TEST-500").unwrap();
+
+        // Standard fields still work
+        assert_eq!(issue.key, "TEST-500");
+        assert_eq!(issue.fields.summary, "Issue with custom fields");
+
+        // Custom fields captured in extra HashMap
+        assert_eq!(issue.fields.extra.get("customfield_10016").unwrap(), &serde_json::json!(5.0));
+        assert_eq!(
+            issue.fields.extra.get("customfield_10020").unwrap(),
+            &serde_json::json!([{"id": 1, "name": "Sprint 1"}])
+        );
+        assert_eq!(
+            issue.fields.extra.get("customfield_11000").unwrap(),
+            &serde_json::json!({"value": "Option A"})
+        );
+        // Null fields are still captured in the map (filtering happens during conversion)
+        assert!(issue.fields.extra.contains_key("customfield_11001"));
+    }
+
+    #[tokio::test]
     async fn test_update_issue_with_state_calls_transitions_endpoint() {
         let mock_server = MockServer::start().await;
 

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
+use serde_json::Value;
 use tracker_core::{
     Comment, CommentAuthor, CreateIssue, CustomField, CustomFieldUpdate, Issue, IssueLink,
     IssueLinkType, LinkedIssue, Project, ProjectCustomField, ProjectRef, StateValueInfo, Tag,
@@ -11,80 +12,244 @@ use tracker_core::{
 
 use crate::models::*;
 
-impl From<JiraIssue> for Issue {
-    fn from(j: JiraIssue) -> Self {
-        let description = j
-            .fields
-            .description
-            .as_ref()
-            .map(adf_to_text)
-            .filter(|s| !s.is_empty());
+/// Convert a Jira issue to a tracker-core Issue.
+///
+/// When `jira_fields` metadata is provided, custom field names and types are
+/// resolved from the metadata. Without it, field IDs are used as names and
+/// types are inferred from the JSON value shape.
+pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
+    let description = j
+        .fields
+        .description
+        .as_ref()
+        .map(adf_to_text)
+        .filter(|s| !s.is_empty());
 
-        let is_resolved = j
-            .fields
-            .status
-            .status_category
-            .as_ref()
-            .map(|c| c.key == "done")
-            .unwrap_or(false);
+    let is_resolved = j
+        .fields
+        .status
+        .status_category
+        .as_ref()
+        .map(|c| c.key == "done")
+        .unwrap_or(false);
 
-        let mut custom_fields = Vec::new();
+    let mut custom_fields = Vec::new();
 
-        // Map status as a State custom field
-        custom_fields.push(CustomField::State {
-            name: "Status".to_string(),
-            value: Some(j.fields.status.name.clone()),
-            is_resolved,
-        });
+    // Map status as a State custom field
+    custom_fields.push(CustomField::State {
+        name: "Status".to_string(),
+        value: Some(j.fields.status.name.clone()),
+        is_resolved,
+    });
 
-        // Map priority as a SingleEnum custom field
-        if let Some(ref priority) = j.fields.priority {
-            custom_fields.push(CustomField::SingleEnum {
-                name: "Priority".to_string(),
-                value: Some(priority.name.clone()),
-            });
-        }
-
-        // Map assignee as a SingleUser custom field
-        custom_fields.push(CustomField::SingleUser {
-            name: "Assignee".to_string(),
-            login: j
-                .fields
-                .assignee
-                .as_ref()
-                .and_then(|u| u.account_id.clone()),
-            display_name: j
-                .fields
-                .assignee
-                .as_ref()
-                .and_then(|u| u.display_name.clone()),
-        });
-
-        // Map issue type
+    // Map priority as a SingleEnum custom field
+    if let Some(ref priority) = j.fields.priority {
         custom_fields.push(CustomField::SingleEnum {
-            name: "Type".to_string(),
-            value: Some(j.fields.issuetype.name.clone()),
+            name: "Priority".to_string(),
+            value: Some(priority.name.clone()),
         });
+    }
 
-        Self {
-            id: j.id,
-            id_readable: j.key,
-            summary: j.fields.summary,
-            description,
-            project: j.fields.project.into(),
-            custom_fields,
-            tags: j
-                .fields
-                .labels
-                .into_iter()
-                .map(|label| Tag {
-                    id: label.clone(),
-                    name: label,
-                })
-                .collect(),
-            created: parse_jira_datetime(&j.fields.created).unwrap_or_else(Utc::now),
-            updated: parse_jira_datetime(&j.fields.updated).unwrap_or_else(Utc::now),
+    // Map assignee as a SingleUser custom field
+    custom_fields.push(CustomField::SingleUser {
+        name: "Assignee".to_string(),
+        login: j
+            .fields
+            .assignee
+            .as_ref()
+            .and_then(|u| u.account_id.clone()),
+        display_name: j
+            .fields
+            .assignee
+            .as_ref()
+            .and_then(|u| u.display_name.clone()),
+    });
+
+    // Map issue type
+    custom_fields.push(CustomField::SingleEnum {
+        name: "Type".to_string(),
+        value: Some(j.fields.issuetype.name.clone()),
+    });
+
+    // Map extra custom fields from the flattened HashMap
+    let id_to_name: HashMap<&str, &str> = jira_fields
+        .iter()
+        .map(|f| (f.id.as_str(), f.name.as_str()))
+        .collect();
+    let id_to_schema: HashMap<&str, &JiraFieldSchema> = jira_fields
+        .iter()
+        .filter_map(|f| f.schema.as_ref().map(|s| (f.id.as_str(), s)))
+        .collect();
+
+    for (key, value) in &j.fields.extra {
+        if !key.starts_with("customfield_") {
+            continue;
         }
+        if value.is_null() {
+            continue;
+        }
+        let name = id_to_name
+            .get(key.as_str())
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| key.clone());
+        let schema = id_to_schema.get(key.as_str()).copied();
+        if let Some(cf) = json_value_to_custom_field(name, value, schema) {
+            custom_fields.push(cf);
+        }
+    }
+
+    Issue {
+        id: j.id,
+        id_readable: j.key,
+        summary: j.fields.summary,
+        description,
+        project: j.fields.project.into(),
+        custom_fields,
+        tags: j
+            .fields
+            .labels
+            .into_iter()
+            .map(|label| Tag {
+                id: label.clone(),
+                name: label,
+            })
+            .collect(),
+        created: parse_jira_datetime(&j.fields.created).unwrap_or_else(Utc::now),
+        updated: parse_jira_datetime(&j.fields.updated).unwrap_or_else(Utc::now),
+    }
+}
+
+/// Convert a Jira JSON custom field value to a core CustomField.
+///
+/// Uses schema type when available, falls back to value-shape heuristics.
+fn json_value_to_custom_field(
+    name: String,
+    value: &Value,
+    schema: Option<&JiraFieldSchema>,
+) -> Option<CustomField> {
+    match (schema.map(|s| s.field_type.as_str()), value) {
+        (_, Value::Null) => None,
+
+        // Schema-driven mapping
+        (Some("number"), Value::Number(n)) => Some(CustomField::Text {
+            name,
+            value: Some(format_number(n)),
+        }),
+        (Some("string"), Value::String(s)) => Some(CustomField::Text {
+            name,
+            value: Some(s.clone()),
+        }),
+        (Some("option"), Value::Object(obj)) => {
+            let val = obj.get("value").and_then(|v| v.as_str()).map(String::from);
+            Some(CustomField::SingleEnum { name, value: val })
+        }
+        (Some("user"), Value::Object(obj)) => {
+            let login = obj
+                .get("accountId")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let display_name = obj
+                .get("displayName")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            Some(CustomField::SingleUser {
+                name,
+                login,
+                display_name,
+            })
+        }
+        (Some("array"), Value::Array(arr)) => convert_array_field(name, arr, schema),
+
+        // Heuristic fallbacks when no schema is available
+        (None, Value::Number(n)) => Some(CustomField::Text {
+            name,
+            value: Some(format_number(n)),
+        }),
+        (None, Value::String(s)) => Some(CustomField::Text {
+            name,
+            value: Some(s.clone()),
+        }),
+        (None, Value::Bool(b)) => Some(CustomField::Text {
+            name,
+            value: Some(b.to_string()),
+        }),
+        (None, Value::Object(obj)) => {
+            if let Some(v) = obj.get("value").and_then(|v| v.as_str()) {
+                Some(CustomField::SingleEnum {
+                    name,
+                    value: Some(v.to_string()),
+                })
+            } else if let Some(dn) = obj.get("displayName").and_then(|v| v.as_str()) {
+                let login = obj
+                    .get("accountId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                Some(CustomField::SingleUser {
+                    name,
+                    login,
+                    display_name: Some(dn.to_string()),
+                })
+            } else if let Some(n) = obj.get("name").and_then(|v| v.as_str()) {
+                Some(CustomField::SingleEnum {
+                    name,
+                    value: Some(n.to_string()),
+                })
+            } else {
+                Some(CustomField::Unknown { name })
+            }
+        }
+        (None, Value::Array(arr)) => convert_array_field(name, arr, None),
+
+        _ => Some(CustomField::Unknown { name }),
+    }
+}
+
+/// Convert a JSON array field value to a core CustomField.
+fn convert_array_field(
+    name: String,
+    arr: &[Value],
+    schema: Option<&JiraFieldSchema>,
+) -> Option<CustomField> {
+    if arr.is_empty() {
+        return None;
+    }
+
+    let _items_type = schema.and_then(|s| s.items.as_deref());
+
+    let values: Vec<String> = arr
+        .iter()
+        .filter_map(|item| match item {
+            Value::String(s) => Some(s.clone()),
+            Value::Object(obj) => obj
+                .get("value")
+                .and_then(|v| v.as_str())
+                .or_else(|| obj.get("name").and_then(|v| v.as_str()))
+                .or_else(|| obj.get("displayName").and_then(|v| v.as_str()))
+                .map(String::from),
+            Value::Number(n) => Some(format_number(n)),
+            _ => None,
+        })
+        .collect();
+
+    if values.is_empty() {
+        None
+    } else {
+        Some(CustomField::MultiEnum { name, values })
+    }
+}
+
+/// Format a JSON number, stripping `.0` from integers.
+fn format_number(n: &serde_json::Number) -> String {
+    if let Some(i) = n.as_i64() {
+        i.to_string()
+    } else if let Some(f) = n.as_f64() {
+        if f.fract() == 0.0 {
+            (f as i64).to_string()
+        } else {
+            f.to_string()
+        }
+    } else {
+        n.to_string()
     }
 }
 
@@ -298,7 +463,6 @@ fn parse_jira_datetime(dt: &Option<String>) -> Option<DateTime<Utc>> {
 
 /// Get standard Jira custom fields for a project
 pub fn get_standard_custom_fields() -> Vec<ProjectCustomField> {
-    use tracker_core::StateValueInfo;
 
     vec![
         ProjectCustomField {
@@ -874,5 +1038,327 @@ mod tests {
         assert_eq!(state_values.len(), 3);
         assert!(state_values[2].is_resolved); // Closed should be resolved
         assert_eq!(state_values[2].name, "Closed");
+    }
+
+    // ==================== jira_issue_to_core tests ====================
+
+    /// Helper to build a minimal JiraIssue for conversion tests
+    fn mock_jira_issue_for_conversion(
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> JiraIssue {
+        JiraIssue {
+            id: "10001".to_string(),
+            key: "TEST-1".to_string(),
+            self_url: None,
+            fields: JiraIssueFields {
+                summary: "Test issue".to_string(),
+                description: None,
+                status: JiraStatus {
+                    id: Some("1".to_string()),
+                    name: "Open".to_string(),
+                    status_category: Some(JiraStatusCategory {
+                        key: "new".to_string(),
+                        name: Some("To Do".to_string()),
+                    }),
+                },
+                priority: Some(JiraPriority {
+                    id: Some("3".to_string()),
+                    name: "Medium".to_string(),
+                }),
+                issuetype: JiraIssueType {
+                    id: Some("10001".to_string()),
+                    name: "Task".to_string(),
+                    subtask: false,
+                },
+                project: JiraProjectRef {
+                    id: "10000".to_string(),
+                    key: "TEST".to_string(),
+                    name: Some("Test".to_string()),
+                    self_url: None,
+                },
+                assignee: None,
+                reporter: None,
+                labels: vec![],
+                created: Some("2024-01-15T10:00:00.000+0000".to_string()),
+                updated: Some("2024-01-15T12:00:00.000+0000".to_string()),
+                subtasks: vec![],
+                parent: None,
+                issuelinks: vec![],
+                comment: None,
+                extra,
+            },
+        }
+    }
+
+    #[test]
+    fn jira_issue_to_core_maps_standard_fields() {
+        let issue = mock_jira_issue_for_conversion(Default::default());
+        let core = jira_issue_to_core(issue, &[]);
+
+        assert_eq!(core.id, "10001");
+        assert_eq!(core.id_readable, "TEST-1");
+        assert_eq!(core.summary, "Test issue");
+
+        // Standard 4 custom fields should be present
+        let status = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::State { name, .. } if name == "Status"))
+            .unwrap();
+        assert!(matches!(status, CustomField::State { value: Some(v), is_resolved: false, .. } if v == "Open"));
+
+        let priority = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::SingleEnum { name, .. } if name == "Priority"))
+            .unwrap();
+        assert!(matches!(priority, CustomField::SingleEnum { value: Some(v), .. } if v == "Medium"));
+    }
+
+    #[test]
+    fn jira_issue_to_core_maps_number_field_with_metadata() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("customfield_10016".to_string(), serde_json::json!(5.0));
+
+        let fields = vec![JiraField {
+            id: "customfield_10016".to_string(),
+            name: "Story Points".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "number".to_string(),
+                custom: None,
+                items: None,
+            }),
+        }];
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &fields);
+
+        let sp = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::Text { name, .. } if name == "Story Points"))
+            .unwrap();
+        assert!(matches!(sp, CustomField::Text { value: Some(v), .. } if v == "5"));
+    }
+
+    #[test]
+    fn jira_issue_to_core_maps_option_field_with_metadata() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "customfield_11000".to_string(),
+            serde_json::json!({"self": "https://...", "value": "Option A", "id": "10100"}),
+        );
+
+        let fields = vec![JiraField {
+            id: "customfield_11000".to_string(),
+            name: "Severity".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "option".to_string(),
+                custom: None,
+                items: None,
+            }),
+        }];
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &fields);
+
+        let severity = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::SingleEnum { name, .. } if name == "Severity"))
+            .unwrap();
+        assert!(
+            matches!(severity, CustomField::SingleEnum { value: Some(v), .. } if v == "Option A")
+        );
+    }
+
+    #[test]
+    fn jira_issue_to_core_maps_user_field_with_metadata() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "customfield_12000".to_string(),
+            serde_json::json!({
+                "accountId": "abc123",
+                "displayName": "Jane Doe"
+            }),
+        );
+
+        let fields = vec![JiraField {
+            id: "customfield_12000".to_string(),
+            name: "Reviewer".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "user".to_string(),
+                custom: None,
+                items: None,
+            }),
+        }];
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &fields);
+
+        let reviewer = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::SingleUser { name, .. } if name == "Reviewer"))
+            .unwrap();
+        assert!(matches!(
+            reviewer,
+            CustomField::SingleUser {
+                login: Some(l),
+                display_name: Some(dn),
+                ..
+            } if l == "abc123" && dn == "Jane Doe"
+        ));
+    }
+
+    #[test]
+    fn jira_issue_to_core_maps_array_field_sprint() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "customfield_10020".to_string(),
+            serde_json::json!([{"id": 1, "name": "Sprint 1"}, {"id": 2, "name": "Sprint 2"}]),
+        );
+
+        let fields = vec![JiraField {
+            id: "customfield_10020".to_string(),
+            name: "Sprint".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "array".to_string(),
+                custom: None,
+                items: Some("string".to_string()),
+            }),
+        }];
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &fields);
+
+        let sprint = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "Sprint"))
+            .unwrap();
+        assert!(
+            matches!(sprint, CustomField::MultiEnum { values, .. } if values == &["Sprint 1", "Sprint 2"])
+        );
+    }
+
+    #[test]
+    fn jira_issue_to_core_skips_null_custom_fields() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("customfield_10016".to_string(), serde_json::Value::Null);
+        extra.insert("customfield_10017".to_string(), serde_json::json!(3.0));
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &[]);
+
+        // Should not have a field for the null value
+        assert!(!core
+            .custom_fields
+            .iter()
+            .any(|f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10016")));
+        // Should have the non-null field
+        assert!(core
+            .custom_fields
+            .iter()
+            .any(|f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10017")));
+    }
+
+    #[test]
+    fn jira_issue_to_core_skips_empty_array_fields() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "customfield_10020".to_string(),
+            serde_json::json!([]),
+        );
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &[]);
+
+        assert!(!core
+            .custom_fields
+            .iter()
+            .any(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "customfield_10020")));
+    }
+
+    #[test]
+    fn jira_issue_to_core_heuristic_fallback_without_metadata() {
+        let mut extra = std::collections::HashMap::new();
+        // Number without schema
+        extra.insert("customfield_10016".to_string(), serde_json::json!(8.0));
+        // Object with "value" key → SingleEnum
+        extra.insert(
+            "customfield_11000".to_string(),
+            serde_json::json!({"value": "High"}),
+        );
+        // Object with "displayName" → SingleUser
+        extra.insert(
+            "customfield_12000".to_string(),
+            serde_json::json!({"accountId": "usr1", "displayName": "Bob"}),
+        );
+        // String
+        extra.insert(
+            "customfield_13000".to_string(),
+            serde_json::json!("free text"),
+        );
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        // No metadata — empty slice
+        let core = jira_issue_to_core(issue, &[]);
+
+        // Number → Text with "8"
+        assert!(core.custom_fields.iter().any(
+            |f| matches!(f, CustomField::Text { name, value: Some(v) } if name == "customfield_10016" && v == "8")
+        ));
+        // Object with "value" → SingleEnum
+        assert!(core.custom_fields.iter().any(
+            |f| matches!(f, CustomField::SingleEnum { name, value: Some(v) } if name == "customfield_11000" && v == "High")
+        ));
+        // Object with "displayName" → SingleUser
+        assert!(core.custom_fields.iter().any(
+            |f| matches!(f, CustomField::SingleUser { name, login: Some(l), display_name: Some(dn) } if name == "customfield_12000" && l == "usr1" && dn == "Bob")
+        ));
+        // String → Text
+        assert!(core.custom_fields.iter().any(
+            |f| matches!(f, CustomField::Text { name, value: Some(v) } if name == "customfield_13000" && v == "free text")
+        ));
+    }
+
+    #[test]
+    fn jira_issue_to_core_ignores_non_custom_extra_fields() {
+        let mut extra = std::collections::HashMap::new();
+        // System fields that end up in extra should be ignored
+        extra.insert(
+            "environment".to_string(),
+            serde_json::json!("Production"),
+        );
+        extra.insert(
+            "customfield_10016".to_string(),
+            serde_json::json!(5.0),
+        );
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &[]);
+
+        // "environment" should NOT be in custom_fields
+        assert!(!core
+            .custom_fields
+            .iter()
+            .any(|f| matches!(f, CustomField::Text { name, .. } if name == "environment")));
+        // customfield_ should be present
+        assert!(core
+            .custom_fields
+            .iter()
+            .any(|f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10016")));
+    }
+
+    #[test]
+    fn format_number_strips_trailing_zero() {
+        assert_eq!(format_number(&serde_json::Number::from_f64(5.0).unwrap()), "5");
+        assert_eq!(format_number(&serde_json::Number::from_f64(3.5).unwrap()), "3.5");
+        assert_eq!(format_number(&serde_json::Number::from(42)), "42");
     }
 }

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -463,7 +463,6 @@ fn parse_jira_datetime(dt: &Option<String>) -> Option<DateTime<Utc>> {
 
 /// Get standard Jira custom fields for a project
 pub fn get_standard_custom_fields() -> Vec<ProjectCustomField> {
-
     vec![
         ProjectCustomField {
             id: "priority".to_string(),
@@ -1105,14 +1104,18 @@ mod tests {
             .iter()
             .find(|f| matches!(f, CustomField::State { name, .. } if name == "Status"))
             .unwrap();
-        assert!(matches!(status, CustomField::State { value: Some(v), is_resolved: false, .. } if v == "Open"));
+        assert!(
+            matches!(status, CustomField::State { value: Some(v), is_resolved: false, .. } if v == "Open")
+        );
 
         let priority = core
             .custom_fields
             .iter()
             .find(|f| matches!(f, CustomField::SingleEnum { name, .. } if name == "Priority"))
             .unwrap();
-        assert!(matches!(priority, CustomField::SingleEnum { value: Some(v), .. } if v == "Medium"));
+        assert!(
+            matches!(priority, CustomField::SingleEnum { value: Some(v), .. } if v == "Medium")
+        );
     }
 
     #[test]
@@ -1256,32 +1259,30 @@ mod tests {
         let core = jira_issue_to_core(issue, &[]);
 
         // Should not have a field for the null value
-        assert!(!core
-            .custom_fields
-            .iter()
-            .any(|f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10016")));
+        assert!(
+            !core.custom_fields.iter().any(
+                |f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10016")
+            )
+        );
         // Should have the non-null field
-        assert!(core
-            .custom_fields
-            .iter()
-            .any(|f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10017")));
+        assert!(
+            core.custom_fields.iter().any(
+                |f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10017")
+            )
+        );
     }
 
     #[test]
     fn jira_issue_to_core_skips_empty_array_fields() {
         let mut extra = std::collections::HashMap::new();
-        extra.insert(
-            "customfield_10020".to_string(),
-            serde_json::json!([]),
-        );
+        extra.insert("customfield_10020".to_string(), serde_json::json!([]));
 
         let issue = mock_jira_issue_for_conversion(extra);
         let core = jira_issue_to_core(issue, &[]);
 
-        assert!(!core
-            .custom_fields
-            .iter()
-            .any(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "customfield_10020")));
+        assert!(!core.custom_fields.iter().any(
+            |f| matches!(f, CustomField::MultiEnum { name, .. } if name == "customfield_10020")
+        ));
     }
 
     #[test]
@@ -1331,34 +1332,37 @@ mod tests {
     fn jira_issue_to_core_ignores_non_custom_extra_fields() {
         let mut extra = std::collections::HashMap::new();
         // System fields that end up in extra should be ignored
-        extra.insert(
-            "environment".to_string(),
-            serde_json::json!("Production"),
-        );
-        extra.insert(
-            "customfield_10016".to_string(),
-            serde_json::json!(5.0),
-        );
+        extra.insert("environment".to_string(), serde_json::json!("Production"));
+        extra.insert("customfield_10016".to_string(), serde_json::json!(5.0));
 
         let issue = mock_jira_issue_for_conversion(extra);
         let core = jira_issue_to_core(issue, &[]);
 
         // "environment" should NOT be in custom_fields
-        assert!(!core
-            .custom_fields
-            .iter()
-            .any(|f| matches!(f, CustomField::Text { name, .. } if name == "environment")));
+        assert!(
+            !core
+                .custom_fields
+                .iter()
+                .any(|f| matches!(f, CustomField::Text { name, .. } if name == "environment"))
+        );
         // customfield_ should be present
-        assert!(core
-            .custom_fields
-            .iter()
-            .any(|f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10016")));
+        assert!(
+            core.custom_fields.iter().any(
+                |f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10016")
+            )
+        );
     }
 
     #[test]
     fn format_number_strips_trailing_zero() {
-        assert_eq!(format_number(&serde_json::Number::from_f64(5.0).unwrap()), "5");
-        assert_eq!(format_number(&serde_json::Number::from_f64(3.5).unwrap()), "3.5");
+        assert_eq!(
+            format_number(&serde_json::Number::from_f64(5.0).unwrap()),
+            "5"
+        );
+        assert_eq!(
+            format_number(&serde_json::Number::from_f64(3.5).unwrap()),
+            "3.5"
+        );
         assert_eq!(format_number(&serde_json::Number::from(42)), "42");
     }
 }

--- a/crates/jira-backend/src/models/issue.rs
+++ b/crates/jira-backend/src/models/issue.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::comment::JiraComment;
@@ -56,6 +58,10 @@ pub struct JiraIssueFields {
     pub issuelinks: Vec<JiraIssueLink>,
     /// Comments (only included when expanded)
     pub comment: Option<JiraCommentsContainer>,
+    /// Extra/custom fields not captured by the named fields above.
+    /// Keys are field IDs like "customfield_10016".
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Comments container in issue response

--- a/crates/jira-backend/src/models/issue.rs
+++ b/crates/jira-backend/src/models/issue.rs
@@ -172,21 +172,18 @@ pub struct JiraIssueLinkType {
     pub outward: Option<String>,
 }
 
-/// Search result response
+/// Search result response from `/search/jql` endpoint.
+///
+/// The new Jira Cloud search endpoint returns `isLast` instead of `total`.
+/// It does not provide a total count of matching issues.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JiraSearchResult {
-    /// Starting index
-    #[serde(default)]
-    pub start_at: usize,
-    /// Maximum results per page
-    #[serde(default)]
-    pub max_results: usize,
-    /// Total number of results
-    #[serde(default)]
-    pub total: usize,
     /// Issues in this page
     pub issues: Vec<JiraIssue>,
+    /// Whether this is the last page of results
+    #[serde(default)]
+    pub is_last: bool,
 }
 
 /// Request to create an issue

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -33,23 +33,19 @@ impl IssueTracker for JiraClient {
         };
 
         let r = self.search_issues(&jql, limit, skip)?;
-        let total = r.total as u64;
         let fields = self.get_fields_cached();
         let items = r
             .issues
             .into_iter()
             .map(|i| jira_issue_to_core(i, &fields))
             .collect();
-        Ok(SearchResult::with_total(items, total))
+        Ok(SearchResult::from_items(items))
     }
 
-    fn get_issue_count(&self, query: &str) -> Result<Option<u64>> {
-        let jql = if query.contains('=') || query.contains(" AND ") || query.contains(" OR ") {
-            query.to_string()
-        } else {
-            convert_simple_query_to_jql(query)
-        };
-        Ok(Some(self.count_issues(&jql)? as u64))
+    fn get_issue_count(&self, _query: &str) -> Result<Option<u64>> {
+        // The new /search/jql endpoint does not return a total count,
+        // and there is no separate count endpoint on Jira Cloud.
+        Ok(None)
     }
 
     fn create_issue(&self, issue: &CreateIssue) -> Result<Issue> {

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -9,7 +9,7 @@ use tracker_core::{
 use crate::client::JiraClient;
 use crate::convert::{
     create_issue_to_jira, get_standard_custom_fields, jira_field_to_project_custom_field,
-    merge_fields, update_issue_to_jira,
+    jira_issue_to_core, merge_fields, update_issue_to_jira,
 };
 use crate::models::{
     CreateJiraIssueLink, IssueKeyRef, IssueLinkTypeName, ParentId, UpdateJiraIssue,
@@ -18,7 +18,9 @@ use crate::models::{
 
 impl IssueTracker for JiraClient {
     fn get_issue(&self, id: &str) -> Result<Issue> {
-        Ok(self.get_issue(id)?.into())
+        let issue = self.get_issue(id)?;
+        let fields = self.get_fields_cached();
+        Ok(jira_issue_to_core(issue, &fields))
     }
 
     fn search_issues(&self, query: &str, limit: usize, skip: usize) -> Result<SearchResult<Issue>> {
@@ -32,7 +34,12 @@ impl IssueTracker for JiraClient {
 
         let r = self.search_issues(&jql, limit, skip)?;
         let total = r.total as u64;
-        let items = r.issues.into_iter().map(Into::into).collect();
+        let fields = self.get_fields_cached();
+        let items = r
+            .issues
+            .into_iter()
+            .map(|i| jira_issue_to_core(i, &fields))
+            .collect();
         Ok(SearchResult::with_total(items, total))
     }
 
@@ -48,11 +55,14 @@ impl IssueTracker for JiraClient {
     fn create_issue(&self, issue: &CreateIssue) -> Result<Issue> {
         let fields = self.get_fields_cached();
         let jira_issue = create_issue_to_jira(issue, &fields);
-        Ok(self.create_issue(&jira_issue)?.into())
+        let created = self.create_issue(&jira_issue)?;
+        Ok(jira_issue_to_core(created, &fields))
     }
 
     fn update_issue(&self, id: &str, update: &UpdateIssue) -> Result<Issue> {
         use tracker_core::CustomFieldUpdate;
+
+        let fields = self.get_fields_cached();
 
         // 1. Separate the state change, if present.
         let (status_update, other_fields): (Vec<_>, Vec<_>) = update
@@ -79,7 +89,6 @@ impl IssueTracker for JiraClient {
             || stripped.parent.is_some();
 
         if has_field_updates {
-            let fields = self.get_fields_cached();
             let jira_update = update_issue_to_jira(&stripped, &fields);
             self.update_issue(id, &jira_update)?;
         }
@@ -91,7 +100,7 @@ impl IssueTracker for JiraClient {
         }
 
         // 4. Re-fetch the fresh issue (matches current behavior).
-        Ok(self.get_issue(id)?.into())
+        Ok(jira_issue_to_core(self.get_issue(id)?, &fields))
     }
 
     fn delete_issue(&self, id: &str) -> Result<()> {

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.7.2"
+version = "1.8.0"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 


### PR DESCRIPTION
## Summary

- Jira custom fields (Story Points, Sprint, etc.) are now returned on `issue get` and `issue search`, matching the YouTrack backend's first-class custom field support
- Removes the hardcoded `DEFAULT_ISSUE_FIELDS` list that restricted API responses to 14 standard fields
- Adds `#[serde(flatten)]` catch-all to `JiraIssueFields` to capture `customfield_*` values during deserialization
- Replaces `From<JiraIssue> for Issue` with `jira_issue_to_core()` that uses cached field metadata to resolve field IDs to human-readable names and map values to typed `CustomField` variants (schema-driven with heuristic fallback)

Closes #212

## Test plan

- [x] All 72 jira-backend unit tests pass (10 new tests added)
- [x] Full workspace build and test pass (2 pre-existing failures on main unrelated to this change)
- [x] Live test: `track -b jira i g <ID>` shows custom fields in text output
- [x] Live test: `track -b jira -o json i g <ID>` includes custom fields in JSON
- [x] Live test: `track -b jira i s "project = X"` returns custom fields on search results