### PR TITLE
Fix Confluence article body rendering

### DIFF
--- a/crates/jira-backend/src/confluence_impl.rs
+++ b/crates/jira-backend/src/confluence_impl.rs
@@ -392,42 +392,216 @@ fn storage_to_text(storage: &str) -> String {
     output.trim().to_string()
 }
 
-/// Convert Markdown to Confluence storage format (basic)
+/// Convert Markdown to Confluence storage format.
 fn markdown_to_storage(markdown: &str) -> String {
+    use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+
+    if looks_like_confluence_storage(markdown) {
+        return markdown.to_string();
+    }
+
+    let parser = Parser::new_ext(
+        markdown,
+        Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TABLES | Options::ENABLE_TASKLISTS,
+    );
+
     let mut result = String::new();
+    let mut code_block: Option<(String, String)> = None;
+    let mut image: Option<(String, String)> = None;
+    let mut in_table_head = false;
 
-    for line in markdown.lines() {
-        let trimmed = line.trim();
-
-        if trimmed.is_empty() {
+    for event in parser {
+        if let Some((_, body)) = code_block.as_mut() {
+            match event {
+                Event::End(TagEnd::CodeBlock) => {
+                    let (language, body) = code_block.take().expect("code block is open");
+                    result.push_str(&storage_code_macro(&language, &body));
+                }
+                Event::Text(text)
+                | Event::Code(text)
+                | Event::Html(text)
+                | Event::InlineHtml(text)
+                | Event::InlineMath(text)
+                | Event::DisplayMath(text) => body.push_str(&text),
+                Event::SoftBreak | Event::HardBreak => body.push('\n'),
+                _ => {}
+            }
             continue;
         }
 
-        // Headers
-        if let Some(text) = trimmed.strip_prefix("### ") {
-            result.push_str(&format!("<h3>{}</h3>", html_escape(text)));
-        } else if let Some(text) = trimmed.strip_prefix("## ") {
-            result.push_str(&format!("<h2>{}</h2>", html_escape(text)));
-        } else if let Some(text) = trimmed.strip_prefix("# ") {
-            result.push_str(&format!("<h1>{}</h1>", html_escape(text)));
+        if let Some((_, alt_text)) = image.as_mut() {
+            match event {
+                Event::End(TagEnd::Image) => {
+                    let (url, alt_text) = image.take().expect("image is open");
+                    result.push_str(&format!(
+                        "<ac:image ac:alt=\"{}\"><ri:url ri:value=\"{}\" /></ac:image>",
+                        html_escape(&alt_text),
+                        html_escape(&url)
+                    ));
+                }
+                Event::Text(text) | Event::Code(text) => alt_text.push_str(&text),
+                Event::SoftBreak | Event::HardBreak => alt_text.push(' '),
+                _ => {}
+            }
+            continue;
         }
-        // Code blocks (simplified)
-        else if trimmed.starts_with("```") {
-            // Skip code fence markers
-        }
-        // List items
-        else if let Some(text) = trimmed.strip_prefix("- ") {
-            result.push_str(&format!("<li>{}</li>", html_escape(text)));
-        } else if let Some(text) = trimmed.strip_prefix("* ") {
-            result.push_str(&format!("<li>{}</li>", html_escape(text)));
-        }
-        // Regular paragraphs
-        else {
-            result.push_str(&format!("<p>{}</p>", html_escape(trimmed)));
+
+        match event {
+            Event::Start(tag) => match tag {
+                Tag::Paragraph => result.push_str("<p>"),
+                Tag::Heading { level, .. } => {
+                    result.push_str(&format!("<{}>", heading_tag(level)));
+                }
+                Tag::BlockQuote(_) => result.push_str("<blockquote>"),
+                Tag::CodeBlock(kind) => {
+                    let language = match kind {
+                        CodeBlockKind::Fenced(lang) => lang.to_string(),
+                        CodeBlockKind::Indented => String::new(),
+                    };
+                    code_block = Some((language, String::new()));
+                }
+                Tag::List(Some(start)) => {
+                    if start == 1 {
+                        result.push_str("<ol>");
+                    } else {
+                        result.push_str(&format!("<ol start=\"{start}\">"));
+                    }
+                }
+                Tag::List(None) => result.push_str("<ul>"),
+                Tag::Item => result.push_str("<li>"),
+                Tag::Emphasis => result.push_str("<em>"),
+                Tag::Strong => result.push_str("<strong>"),
+                Tag::Strikethrough => result.push_str("<del>"),
+                Tag::Link { dest_url, .. } => {
+                    result.push_str(&format!("<a href=\"{}\">", html_escape(&dest_url)));
+                }
+                Tag::Image { dest_url, .. } => {
+                    image = Some((dest_url.to_string(), String::new()));
+                }
+                Tag::Table(_) => result.push_str("<table><tbody>"),
+                Tag::TableHead => in_table_head = true,
+                Tag::TableRow => result.push_str("<tr>"),
+                Tag::TableCell => {
+                    result.push_str(if in_table_head { "<th>" } else { "<td>" });
+                }
+                Tag::DefinitionList => result.push_str("<dl>"),
+                Tag::DefinitionListTitle => result.push_str("<dt>"),
+                Tag::DefinitionListDefinition => result.push_str("<dd>"),
+                Tag::HtmlBlock | Tag::FootnoteDefinition(_) | Tag::MetadataBlock(_) => {}
+            },
+            Event::End(tag) => match tag {
+                TagEnd::Paragraph => result.push_str("</p>"),
+                TagEnd::Heading(level) => {
+                    result.push_str(&format!("</{}>", heading_tag(level)));
+                }
+                TagEnd::BlockQuote(_) => result.push_str("</blockquote>"),
+                TagEnd::CodeBlock => {}
+                TagEnd::List(true) => result.push_str("</ol>"),
+                TagEnd::List(false) => result.push_str("</ul>"),
+                TagEnd::Item => result.push_str("</li>"),
+                TagEnd::Emphasis => result.push_str("</em>"),
+                TagEnd::Strong => result.push_str("</strong>"),
+                TagEnd::Strikethrough => result.push_str("</del>"),
+                TagEnd::Link => result.push_str("</a>"),
+                TagEnd::Image => {}
+                TagEnd::Table => result.push_str("</tbody></table>"),
+                TagEnd::TableHead => in_table_head = false,
+                TagEnd::TableRow => result.push_str("</tr>"),
+                TagEnd::TableCell => {
+                    result.push_str(if in_table_head { "</th>" } else { "</td>" });
+                }
+                TagEnd::DefinitionList => result.push_str("</dl>"),
+                TagEnd::DefinitionListTitle => result.push_str("</dt>"),
+                TagEnd::DefinitionListDefinition => result.push_str("</dd>"),
+                TagEnd::HtmlBlock | TagEnd::FootnoteDefinition | TagEnd::MetadataBlock(_) => {}
+            },
+            Event::Text(text) => result.push_str(&html_escape(&text)),
+            Event::Code(text) => {
+                result.push_str(&format!("<code>{}</code>", html_escape(&text)));
+            }
+            Event::InlineMath(text) => {
+                result.push_str(&format!("<code>{}</code>", html_escape(&text)));
+            }
+            Event::DisplayMath(text) => {
+                result.push_str("<p><code>");
+                result.push_str(&html_escape(&text));
+                result.push_str("</code></p>");
+            }
+            Event::Html(html) | Event::InlineHtml(html) => result.push_str(&html),
+            Event::FootnoteReference(reference) => {
+                result.push_str(&format!("<sup>{}</sup>", html_escape(&reference)));
+            }
+            Event::SoftBreak => result.push('\n'),
+            Event::HardBreak => result.push_str("<br/>"),
+            Event::Rule => result.push_str("<hr/>"),
+            Event::TaskListMarker(checked) => {
+                result.push_str(if checked { "[x] " } else { "[ ] " });
+            }
         }
     }
 
     result
+}
+
+fn looks_like_confluence_storage(input: &str) -> bool {
+    let trimmed = input.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
+
+    [
+        "<ac:",
+        "<ri:",
+        "<table",
+        "<tbody",
+        "<thead",
+        "<tr",
+        "<td",
+        "<th",
+        "<p",
+        "<h1",
+        "<h2",
+        "<h3",
+        "<h4",
+        "<h5",
+        "<h6",
+        "<ul",
+        "<ol",
+        "<blockquote",
+        "<pre",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
+}
+
+fn heading_tag(level: pulldown_cmark::HeadingLevel) -> &'static str {
+    match level {
+        pulldown_cmark::HeadingLevel::H1 => "h1",
+        pulldown_cmark::HeadingLevel::H2 => "h2",
+        pulldown_cmark::HeadingLevel::H3 => "h3",
+        pulldown_cmark::HeadingLevel::H4 => "h4",
+        pulldown_cmark::HeadingLevel::H5 => "h5",
+        pulldown_cmark::HeadingLevel::H6 => "h6",
+    }
+}
+
+fn storage_code_macro(language: &str, body: &str) -> String {
+    let mut result = String::from("<ac:structured-macro ac:name=\"code\">");
+    let language = language.trim();
+
+    if !language.is_empty() {
+        result.push_str(&format!(
+            "<ac:parameter ac:name=\"language\">{}</ac:parameter>",
+            html_escape(language)
+        ));
+    }
+
+    result.push_str("<ac:plain-text-body><![CDATA[");
+    result.push_str(&escape_cdata(body));
+    result.push_str("]]></ac:plain-text-body></ac:structured-macro>");
+    result
+}
+
+fn escape_cdata(input: &str) -> String {
+    input.replace("]]>", "]]]]><![CDATA[>")
 }
 
 fn html_escape(input: &str) -> String {
@@ -451,6 +625,64 @@ mod tests {
             "title": title,
             "spaceId": "SPACE"
         })
+    }
+
+    #[test]
+    fn markdown_to_storage_renders_rich_markdown() {
+        let markdown = r#"# Title
+
+| A | B |
+|---|---|
+| 1<br>2 | **bold** |
+
+```bash
+echo hi
+```
+
+> **Note:** something
+"#;
+
+        let storage = markdown_to_storage(markdown);
+
+        assert!(storage.contains("<h1>Title</h1>"));
+        assert!(storage.contains("<table><tbody>"));
+        assert!(storage.contains("<th>A</th>"));
+        assert!(storage.contains("<td>1<br>2</td>"));
+        assert!(storage.contains("<td><strong>bold</strong></td>"));
+        assert!(storage.contains("<ac:structured-macro ac:name=\"code\">"));
+        assert!(storage.contains("<ac:parameter ac:name=\"language\">bash</ac:parameter>"));
+        assert!(storage.contains("<ac:plain-text-body><![CDATA[echo hi\n]]>"));
+        assert!(
+            storage.contains("<blockquote><p><strong>Note:</strong> something</p></blockquote>")
+        );
+        assert!(
+            !storage.contains("| A | B |"),
+            "table Markdown should be converted, got: {storage}"
+        );
+        assert!(
+            !storage.contains("```"),
+            "fenced code markers should not be emitted, got: {storage}"
+        );
+    }
+
+    #[test]
+    fn markdown_to_storage_preserves_native_storage_xml() {
+        let native_storage = r#"<table><tbody><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></tbody></table>
+<ac:structured-macro ac:name="info"><ac:rich-text-body><p>Hi</p></ac:rich-text-body></ac:structured-macro>"#;
+
+        let storage = markdown_to_storage(native_storage);
+
+        assert_eq!(storage, native_storage);
+        assert!(!storage.contains("&lt;table&gt;"));
+        assert!(!storage.contains("&lt;ac:structured-macro"));
+    }
+
+    #[test]
+    fn markdown_to_storage_converts_markdown_that_mentions_storage_tags() {
+        let storage = markdown_to_storage("# Title\n\n`<ac:structured-macro>`");
+
+        assert!(storage.contains("<h1>Title</h1>"));
+        assert!(storage.contains("<code>&lt;ac:structured-macro&gt;</code>"));
     }
 
     #[tokio::test]

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.8.1"
+version = "1.8.2"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 


### PR DESCRIPTION
## Summary

- Replaces the Confluence article Markdown-to-storage converter with a pulldown-cmark based renderer.
- Converts Markdown tables, blockquotes, fenced code blocks, inline formatting, links, lists, images, and inline HTML into Confluence storage markup.
- Preserves native Confluence storage XML when article bodies already start with storage-like tags, avoiding escaped tables and macros.
- Adds focused regression tests for rich Markdown, native storage passthrough, and Markdown that merely mentions storage tags.

## Root Cause

The Jira/Confluence backend used a line-oriented converter that only handled headings, simple list items, and paragraphs. Tables, blockquotes, fenced code, and inline formatting were either left as raw Markdown inside paragraphs or skipped. Native storage XML was also treated as Markdown text and escaped before being sent to Confluence.

## Validation

- cargo test --package jira-backend
- cargo test --package track
- Live OrekGames Confluence create validation using target/debug/track against space 65957 and parent 66062:
  - table, header cell, inline br, bold cell, code macro, code language, and blockquote were present in body.storage.value
  - raw Markdown table/fences did not leak
  - escaped table markup was absent
- Live OrekGames Confluence update validation using target/debug/track with native storage XML:
  - table and info macro were present unescaped
  - escaped table and escaped macro markup were absent
- Cleaned up temporary validation page 29097986 via track article delete and verified it is absent from current listing/search