### PR TITLE
Add Attachments Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2061,7 +2077,9 @@ dependencies = [
  "base64",
  "cookie_store",
  "flate2",
+ "getrandom 0.2.17",
  "log",
+ "mime_guess",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ gitlab-backend = { path = "crates/gitlab-backend" }
 tracker-mock = { path = "crates/tracker-mock" }
 
 # HTTP & serialization
-ureq = { version = "3.1", features = ["json"] }
+ureq = { version = "3.1", features = ["json", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/github-backend/src/trait_impl.rs
+++ b/crates/github-backend/src/trait_impl.rs
@@ -1,10 +1,10 @@
 //! Implementation of tracker-core traits for GitHubClient
 
 use tracker_core::{
-    Article, ArticleAttachment, ArticleRef, Comment, CommentAuthor, CreateArticle, CreateIssue,
-    CreateProject, CreateTag, Issue, IssueLink, IssueTag, IssueTracker, KnowledgeBase, Project,
-    ProjectCustomField, ProjectRef, Result, SearchResult, Tag, TrackerError, UpdateArticle,
-    UpdateIssue,
+    Article, ArticleAttachment, ArticleRef, AttachmentUpload, Comment, CommentAuthor,
+    CreateArticle, CreateIssue, CreateProject, CreateTag, Issue, IssueLink, IssueTag, IssueTracker,
+    KnowledgeBase, Project, ProjectCustomField, ProjectRef, Result, SearchResult, Tag,
+    TrackerError, UpdateArticle, UpdateIssue,
 };
 
 use crate::client::GitHubClient;
@@ -520,10 +520,40 @@ impl KnowledgeBase for GitHubClient {
         Ok(wiki_page_to_article(page, self.owner(), self.repo()))
     }
 
-    fn list_article_attachments(&self, _article_id: &str) -> Result<Vec<ArticleAttachment>> {
-        // GitHub wikis don't have native attachment support
-        // Could potentially scan for images in the markdown, but for now return empty
-        Ok(Vec::new())
+    fn list_article_attachments(&self, article_id: &str) -> Result<Vec<ArticleAttachment>> {
+        let wiki = self.wiki();
+        let attachments = wiki.list_attachments(article_id)?;
+        Ok(attachments
+            .into_iter()
+            .map(|attachment| ArticleAttachment {
+                id: attachment.path,
+                name: attachment.name,
+                size: attachment.size,
+                mime_type: attachment.mime_type,
+                url: attachment.url,
+                created: None,
+            })
+            .collect())
+    }
+
+    fn add_article_attachment(
+        &self,
+        article_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ArticleAttachment>> {
+        let wiki = self.wiki();
+        let attachments = wiki.add_attachments(article_id, upload)?;
+        Ok(attachments
+            .into_iter()
+            .map(|attachment| ArticleAttachment {
+                id: attachment.path,
+                name: attachment.name,
+                size: attachment.size,
+                mime_type: attachment.mime_type,
+                url: attachment.url,
+                created: None,
+            })
+            .collect())
     }
 
     fn get_article_comments(&self, _article_id: &str) -> Result<Vec<Comment>> {

--- a/crates/github-backend/src/trait_impl.rs
+++ b/crates/github-backend/src/trait_impl.rs
@@ -1,10 +1,10 @@
 //! Implementation of tracker-core traits for GitHubClient
 
 use tracker_core::{
-    Article, ArticleAttachment, ArticleRef, Comment, CommentAuthor, CreateArticle, CreateIssue,
-    CreateProject, CreateTag, Issue, IssueLink, IssueTag, IssueTracker, KnowledgeBase, Project,
-    ProjectCustomField, ProjectRef, Result, SearchResult, Tag, TrackerError, UpdateArticle,
-    UpdateIssue,
+    Article, ArticleAttachment, ArticleRef, AttachmentUpload, Comment, CommentAuthor,
+    CreateArticle, CreateIssue, CreateProject, CreateTag, Issue, IssueAttachment, IssueLink,
+    IssueTag, IssueTracker, KnowledgeBase, Project, ProjectCustomField, ProjectRef, Result,
+    SearchResult, Tag, TrackerError, UpdateArticle, UpdateIssue,
 };
 
 use crate::client::GitHubClient;
@@ -138,6 +138,24 @@ impl IssueTracker for GitHubClient {
         ))
     }
 
+    fn list_issue_attachments(&self, _issue_id: &str) -> Result<Vec<IssueAttachment>> {
+        Err(TrackerError::InvalidInput(
+            "GitHub Issues does not expose a public REST API for listing issue file attachments."
+                .to_string(),
+        ))
+    }
+
+    fn add_issue_attachment(
+        &self,
+        _issue_id: &str,
+        _upload: &AttachmentUpload,
+    ) -> Result<Vec<IssueAttachment>> {
+        Err(TrackerError::InvalidInput(
+            "GitHub Issues does not expose a public REST API for uploading issue file attachments."
+                .to_string(),
+        ))
+    }
+
     fn list_projects(&self) -> Result<Vec<Project>> {
         Ok(self.list_repos()?.into_iter().map(Into::into).collect())
     }
@@ -263,6 +281,18 @@ impl IssueTracker for GitHubClient {
     fn add_comment(&self, issue_id: &str, text: &str) -> Result<Comment> {
         let number = parse_issue_number(issue_id)?;
         Ok(self.add_comment(number, text)?.into())
+    }
+
+    fn add_issue_comment_attachment(
+        &self,
+        _issue_id: &str,
+        _text: &str,
+        _upload: &AttachmentUpload,
+    ) -> Result<Comment> {
+        Err(TrackerError::InvalidInput(
+            "GitHub Issues does not expose a public REST API for uploading issue comment file attachments."
+                .to_string(),
+        ))
     }
 
     fn get_comments(&self, issue_id: &str) -> Result<Vec<Comment>> {

--- a/crates/github-backend/src/wiki.rs
+++ b/crates/github-backend/src/wiki.rs
@@ -5,7 +5,12 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use tracker_core::AttachmentUpload;
 use walkdir::WalkDir;
+
+const ATTACHMENT_ROOT: &str = ".track-attachments";
+const ATTACHMENT_BLOCK_START: &str = "<!-- track:attachments:start -->";
+const ATTACHMENT_BLOCK_END: &str = "<!-- track:attachments:end -->";
 
 /// YAML front matter for wiki pages
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -35,6 +40,17 @@ pub struct WikiPage {
     pub updated: DateTime<Utc>,
     /// Author (from last commit)
     pub author: Option<String>,
+}
+
+/// Attachment managed in a wiki repository.
+#[derive(Debug, Clone)]
+pub struct WikiAttachment {
+    pub name: String,
+    pub path: String,
+    pub size: i64,
+    pub mime_type: Option<String>,
+    pub url: Option<String>,
+    pub markdown: String,
 }
 
 /// Validate a slug to prevent path traversal attacks
@@ -281,6 +297,12 @@ impl WikiManager {
             }
         }
 
+        if path_str.contains(&format!("/{}/", ATTACHMENT_ROOT))
+            || path_str.ends_with(&format!("/{}", ATTACHMENT_ROOT))
+        {
+            return true;
+        }
+
         false
     }
 
@@ -507,6 +529,106 @@ impl WikiManager {
         Ok(())
     }
 
+    /// List attachments from the managed markdown block on a page.
+    pub fn list_attachments(&self, slug: &str) -> Result<Vec<WikiAttachment>> {
+        let page = self.get_page(slug)?;
+        Ok(parse_attachment_block(&page.content)
+            .into_iter()
+            .map(|(name, path)| {
+                let disk_path = self.cache_dir.join(&path);
+                let size = disk_path
+                    .metadata()
+                    .map(|metadata| metadata.len() as i64)
+                    .unwrap_or(0);
+                WikiAttachment {
+                    mime_type: guess_mime_type(&path),
+                    markdown: format!("[{}]({})", name, path),
+                    name,
+                    path: path.clone(),
+                    size,
+                    url: Some(path),
+                }
+            })
+            .collect())
+    }
+
+    /// Copy files into the wiki repository and update the page's managed attachment block.
+    pub fn add_attachments(
+        &self,
+        slug: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<WikiAttachment>> {
+        if upload.comment.is_some() {
+            return Err(GitHubError::Wiki(
+                "GitHub wiki attachment fallback does not support --comment".to_string(),
+            ));
+        }
+
+        validate_slug(slug)?;
+        self.ensure_initialized()?;
+
+        let page_path = self.cache_dir.join(format!("{}.md", slug));
+        if !page_path.exists() {
+            return Err(GitHubError::Wiki(format!("Page '{}' not found", slug)));
+        }
+
+        let page = self.read_page(&page_path)?;
+        let mut existing = parse_attachment_block(&page.content);
+        let mut uploaded = Vec::new();
+        let mut changed_paths = Vec::new();
+
+        for file in &upload.files {
+            let name = attachment_file_name(file)?;
+            let relative_path = attachment_relative_path(slug, &name);
+            let destination = self.cache_dir.join(&relative_path);
+
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent).map_err(|e| {
+                    GitHubError::Wiki(format!("Failed to create attachment directory: {}", e))
+                })?;
+            }
+
+            fs::copy(&file.path, &destination)
+                .map_err(|e| GitHubError::Wiki(format!("Failed to copy attachment: {}", e)))?;
+
+            let path = relative_path.to_string_lossy().replace('\\', "/");
+            existing.retain(|(_, existing_path)| existing_path != &path);
+            existing.push((name.clone(), path.clone()));
+
+            let size = destination
+                .metadata()
+                .map(|metadata| metadata.len() as i64)
+                .unwrap_or(0);
+            let mime_type = file.mime_type.clone().or_else(|| guess_mime_type(&path));
+            let markdown = format!("[{}]({})", name, path);
+
+            uploaded.push(WikiAttachment {
+                name,
+                path: path.clone(),
+                size,
+                mime_type,
+                url: Some(path),
+                markdown,
+            });
+            changed_paths.push(destination);
+        }
+
+        let updated_content = replace_attachment_block(&page.content, &existing);
+        let markdown =
+            self.generate_markdown_with_frontmatter(&page.title, &updated_content, &page.tags);
+        fs::write(&page_path, markdown)
+            .map_err(|e| GitHubError::Wiki(format!("Failed to update page: {}", e)))?;
+        changed_paths.push(page_path);
+
+        let changed_refs: Vec<&Path> = changed_paths.iter().map(PathBuf::as_path).collect();
+        self.commit_and_push(
+            &format!("Attach files to {}", slug),
+            changed_refs.as_slice(),
+        )?;
+
+        Ok(uploaded)
+    }
+
     /// Move a page to a new location
     pub fn move_page(&self, slug: &str, new_parent: Option<&str>) -> Result<WikiPage> {
         validate_slug(slug)?;
@@ -692,5 +814,124 @@ impl WikiManager {
             .collect();
 
         Ok(children)
+    }
+}
+
+fn attachment_file_name(file: &tracker_core::AttachmentUploadFile) -> Result<String> {
+    let name = file
+        .name
+        .as_deref()
+        .map(str::to_string)
+        .or_else(|| {
+            file.path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .ok_or_else(|| GitHubError::Wiki("Attachment file name is required".to_string()))?;
+
+    if name.contains('/')
+        || name.contains('\\')
+        || name.contains("..")
+        || name.contains('\0')
+        || name.trim().is_empty()
+    {
+        return Err(GitHubError::Wiki(format!(
+            "Invalid attachment file name '{}'",
+            name
+        )));
+    }
+
+    Ok(name)
+}
+
+fn attachment_relative_path(slug: &str, name: &str) -> PathBuf {
+    Path::new(ATTACHMENT_ROOT).join(slug).join(name)
+}
+
+fn parse_attachment_block(content: &str) -> Vec<(String, String)> {
+    let mut attachments = Vec::new();
+    let mut in_block = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == ATTACHMENT_BLOCK_START {
+            in_block = true;
+            continue;
+        }
+        if trimmed == ATTACHMENT_BLOCK_END {
+            break;
+        }
+        if !in_block || !trimmed.starts_with("- [") {
+            continue;
+        }
+
+        if let Some((name, path)) = parse_markdown_link_line(trimmed) {
+            attachments.push((name, path));
+        }
+    }
+
+    attachments
+}
+
+fn parse_markdown_link_line(line: &str) -> Option<(String, String)> {
+    let rest = line.strip_prefix("- [")?;
+    let (name, rest) = rest.split_once("](")?;
+    let path = rest.strip_suffix(')')?;
+    Some((name.to_string(), path.to_string()))
+}
+
+fn replace_attachment_block(content: &str, attachments: &[(String, String)]) -> String {
+    let mut output = Vec::new();
+    let mut in_block = false;
+    let mut replaced = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == ATTACHMENT_BLOCK_START {
+            if !replaced {
+                push_attachment_block(&mut output, attachments);
+                replaced = true;
+            }
+            in_block = true;
+            continue;
+        }
+        if trimmed == ATTACHMENT_BLOCK_END {
+            in_block = false;
+            continue;
+        }
+        if !in_block {
+            output.push(line.to_string());
+        }
+    }
+
+    if !replaced {
+        if !output.is_empty() && output.last().is_some_and(|line| !line.is_empty()) {
+            output.push(String::new());
+        }
+        push_attachment_block(&mut output, attachments);
+    }
+
+    output.join("\n")
+}
+
+fn push_attachment_block(output: &mut Vec<String>, attachments: &[(String, String)]) {
+    output.push(ATTACHMENT_BLOCK_START.to_string());
+    output.push("## Attachments".to_string());
+    for (name, path) in attachments {
+        output.push(format!("- [{}]({})", name, path));
+    }
+    output.push(ATTACHMENT_BLOCK_END.to_string());
+}
+
+fn guess_mime_type(path: &str) -> Option<String> {
+    match Path::new(path).extension().and_then(|ext| ext.to_str()) {
+        Some("gif") => Some("image/gif".to_string()),
+        Some("jpg" | "jpeg") => Some("image/jpeg".to_string()),
+        Some("md") => Some("text/markdown".to_string()),
+        Some("pdf") => Some("application/pdf".to_string()),
+        Some("png") => Some("image/png".to_string()),
+        Some("txt") => Some("text/plain".to_string()),
+        Some("webp") => Some("image/webp".to_string()),
+        _ => None,
     }
 }

--- a/crates/github-backend/src/wiki_tests.rs
+++ b/crates/github-backend/src/wiki_tests.rs
@@ -7,6 +7,7 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
+    use tracker_core::{AttachmentUpload, AttachmentUploadFile};
 
     fn commit_all(repo: &Repository, message: &str) -> git2::Oid {
         let mut index = repo.index().expect("index");
@@ -335,5 +336,43 @@ mod tests {
 
         let children = wiki.get_child_pages("Home").expect("children");
         assert!(children.is_empty());
+    }
+
+    #[test]
+    fn managed_attachments_are_added_and_listed() {
+        let temp = TempDir::new().expect("tempdir");
+        let (wiki, cache_dir) = setup_wiki(&temp);
+        let source = temp.path().join("diagram.png");
+        fs::write(&source, b"png body").expect("write attachment");
+
+        let upload = AttachmentUpload {
+            files: vec![AttachmentUploadFile {
+                path: source,
+                name: Some("diagram.png".to_string()),
+                mime_type: Some("image/png".to_string()),
+            }],
+            comment: None,
+            silent: false,
+            minor_edit: true,
+        };
+
+        let uploaded = wiki.add_attachments("Home", &upload).expect("upload");
+        assert_eq!(uploaded.len(), 1);
+        assert_eq!(uploaded[0].name, "diagram.png");
+        assert_eq!(uploaded[0].mime_type.as_deref(), Some("image/png"));
+
+        let copied = cache_dir.join(".track-attachments/Home/diagram.png");
+        assert!(copied.exists(), "attachment should be copied into wiki");
+
+        let page = wiki.get_page("Home").expect("get page");
+        assert!(page.content.contains("track:attachments:start"));
+        assert!(
+            page.content
+                .contains("[diagram.png](.track-attachments/Home/diagram.png)")
+        );
+
+        let listed = wiki.list_attachments("Home").expect("list attachments");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "diagram.png");
     }
 }

--- a/crates/gitlab-backend/src/client.rs
+++ b/crates/gitlab-backend/src/client.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::time::Duration;
+use tracker_core::AttachmentUploadFile;
 use ureq::Agent;
+use ureq::unversioned::multipart::{Form, Part};
 
 use crate::error::{GitLabError, Result};
 use crate::models::*;
@@ -643,5 +645,127 @@ impl GitLabClient {
         let mut response = self.check_response(response)?;
         let members: Vec<GitLabUser> = response.body_mut().read_json()?;
         Ok(members)
+    }
+
+    // ==================== Wiki Operations ====================
+
+    /// List project wiki pages.
+    pub fn list_wiki_pages(&self, with_content: bool) -> Result<Vec<GitLabWikiPage>> {
+        let url = self.project_url(&format!(
+            "/wikis?with_content={}&per_page=100",
+            if with_content { 1 } else { 0 }
+        ))?;
+
+        let response = self
+            .agent
+            .get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("Accept", "application/json")
+            .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let pages: Vec<GitLabWikiPage> = response.body_mut().read_json()?;
+        Ok(pages)
+    }
+
+    /// Get a project wiki page by slug.
+    pub fn get_wiki_page(&self, slug: &str) -> Result<GitLabWikiPage> {
+        let url = self.project_url(&format!("/wikis/{}", urlencoding::encode(slug)))?;
+
+        let response = self
+            .agent
+            .get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("Accept", "application/json")
+            .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let page: GitLabWikiPage = response.body_mut().read_json()?;
+        Ok(page)
+    }
+
+    /// Create a project wiki page.
+    pub fn create_wiki_page(&self, page: &CreateGitLabWikiPage) -> Result<GitLabWikiPage> {
+        let url = self.project_url("/wikis")?;
+
+        let response = self
+            .agent
+            .post(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .send_json(page)
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let page: GitLabWikiPage = response.body_mut().read_json()?;
+        Ok(page)
+    }
+
+    /// Update a project wiki page.
+    pub fn update_wiki_page(
+        &self,
+        slug: &str,
+        update: &UpdateGitLabWikiPage,
+    ) -> Result<GitLabWikiPage> {
+        let url = self.project_url(&format!("/wikis/{}", urlencoding::encode(slug)))?;
+
+        let response = self
+            .agent
+            .put(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .send_json(update)
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let page: GitLabWikiPage = response.body_mut().read_json()?;
+        Ok(page)
+    }
+
+    /// Delete a project wiki page.
+    pub fn delete_wiki_page(&self, slug: &str) -> Result<()> {
+        let url = self.project_url(&format!("/wikis/{}", urlencoding::encode(slug)))?;
+
+        let response = self
+            .agent
+            .delete(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        self.check_response(response)?;
+        Ok(())
+    }
+
+    /// Upload one file to project wiki attachments.
+    pub fn upload_wiki_attachment(
+        &self,
+        file: &AttachmentUploadFile,
+    ) -> Result<GitLabWikiAttachment> {
+        let url = self.project_url("/wikis/attachments")?;
+        let mut part = Part::file(&file.path)?;
+        if let Some(name) = &file.name {
+            part = part.file_name(name);
+        }
+        if let Some(mime_type) = &file.mime_type {
+            part = part.mime_str(mime_type)?;
+        }
+        let form = Form::new().part("file", part);
+
+        let response = self
+            .agent
+            .post(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("Accept", "application/json")
+            .send(form)
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let attachment: GitLabWikiAttachment = response.body_mut().read_json()?;
+        Ok(attachment)
     }
 }

--- a/crates/gitlab-backend/src/client.rs
+++ b/crates/gitlab-backend/src/client.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::time::Duration;
+use tracker_core::AttachmentUploadFile;
 use ureq::Agent;
+use ureq::unversioned::multipart::{Form, Part};
 
 use crate::error::{GitLabError, Result};
 use crate::models::*;
@@ -298,6 +300,31 @@ impl GitLabClient {
 
         self.check_response(response)?;
         Ok(())
+    }
+
+    /// Upload a file to the project markdown uploads endpoint.
+    pub fn upload_project_file(&self, file: &AttachmentUploadFile) -> Result<GitLabUpload> {
+        let url = self.project_url("/uploads")?;
+        let mut part = Part::file(&file.path)?;
+        if let Some(name) = &file.name {
+            part = part.file_name(name);
+        }
+        if let Some(mime_type) = &file.mime_type {
+            part = part.mime_str(mime_type)?;
+        }
+        let form = Form::new().part("file", part);
+
+        let response = self
+            .agent
+            .post(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("Accept", "application/json")
+            .send(form)
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let upload: GitLabUpload = response.body_mut().read_json()?;
+        Ok(upload)
     }
 
     // ==================== Project Operations ====================

--- a/crates/gitlab-backend/src/client_tests.rs
+++ b/crates/gitlab-backend/src/client_tests.rs
@@ -3,9 +3,21 @@
 #[cfg(test)]
 mod tests {
     use crate::client::GitLabClient;
-    use tracker_core::IssueTracker;
-    use wiremock::matchers::{header, method, path, query_param};
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tracker_core::{AttachmentUpload, AttachmentUploadFile, IssueTracker};
+    use wiremock::matchers::{body_string_contains, header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn temp_upload_file(name: &str, contents: &[u8]) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("track-gitlab-upload-{nanos}-{name}"));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
 
     /// Helper to create a mock GitLab issue response
     fn mock_gitlab_issue(iid: u64, title: &str) -> serde_json::Value {
@@ -182,6 +194,71 @@ mod tests {
         let issue = client.create_issue(&create).unwrap();
         assert_eq!(issue.iid, 99);
         assert_eq!(issue.title, "New issue");
+    }
+
+    #[tokio::test]
+    async fn test_trait_issue_attachment_upload_creates_issue_note() {
+        let mock_server = MockServer::start().await;
+        let upload_path = temp_upload_file("evidence.txt", b"evidence");
+
+        Mock::given(method("POST"))
+            .and(path("/projects/123/uploads"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(body_string_contains("name=\"file\""))
+            .and(body_string_contains("filename=\"custom.txt\""))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "alt": "custom.txt",
+                "url": "/uploads/custom.txt",
+                "full_path": "/group/project/uploads/custom.txt",
+                "markdown": "[custom.txt](/uploads/custom.txt)"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/projects/123/issues/42/notes"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(body_string_contains("supporting material"))
+            .and(body_string_contains("[custom.txt](/uploads/custom.txt)"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": 5001,
+                "body": "supporting material\n\n[custom.txt](/uploads/custom.txt)",
+                "author": {
+                    "id": 7,
+                    "username": "maintainer",
+                    "name": "Maintainer"
+                },
+                "created_at": "2024-01-01T00:00:00.000Z",
+                "updated_at": "2024-01-01T00:00:00.000Z",
+                "system": false
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let upload = AttachmentUpload {
+            files: vec![AttachmentUploadFile {
+                path: upload_path.clone(),
+                name: Some("custom.txt".to_string()),
+                mime_type: Some("text/plain".to_string()),
+            }],
+            comment: Some("supporting material".to_string()),
+            silent: false,
+            minor_edit: false,
+        };
+
+        let attachments =
+            <GitLabClient as IssueTracker>::add_issue_attachment(&client, "42", &upload)
+                .expect("GitLab fallback attachment upload should succeed");
+
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].name, "custom.txt");
+        assert_eq!(attachments[0].comment_id.as_deref(), Some("5001"));
+        assert_eq!(
+            attachments[0].markdown.as_deref(),
+            Some("[custom.txt](/uploads/custom.txt)")
+        );
+        let _ = std::fs::remove_file(upload_path);
     }
 
     #[tokio::test]

--- a/crates/gitlab-backend/src/models/mod.rs
+++ b/crates/gitlab-backend/src/models/mod.rs
@@ -2,8 +2,10 @@ pub mod comment;
 pub mod issue;
 pub mod label;
 pub mod project;
+pub mod upload;
 
 pub use comment::*;
 pub use issue::*;
 pub use label::*;
 pub use project::*;
+pub use upload::*;

--- a/crates/gitlab-backend/src/models/mod.rs
+++ b/crates/gitlab-backend/src/models/mod.rs
@@ -2,8 +2,10 @@ pub mod comment;
 pub mod issue;
 pub mod label;
 pub mod project;
+pub mod wiki;
 
 pub use comment::*;
 pub use issue::*;
 pub use label::*;
 pub use project::*;
+pub use wiki::*;

--- a/crates/gitlab-backend/src/models/upload.rs
+++ b/crates/gitlab-backend/src/models/upload.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+/// GitLab project upload response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabUpload {
+    pub alt: String,
+    pub url: String,
+    #[serde(default)]
+    pub full_path: Option<String>,
+    pub markdown: String,
+}

--- a/crates/gitlab-backend/src/models/wiki.rs
+++ b/crates/gitlab-backend/src/models/wiki.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+
+/// GitLab project wiki page.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabWikiPage {
+    pub slug: String,
+    pub title: String,
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub format: Option<String>,
+    #[serde(default)]
+    pub encoding: Option<String>,
+}
+
+/// Request to create a GitLab wiki page.
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateGitLabWikiPage {
+    pub title: String,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+}
+
+/// Request to update a GitLab wiki page.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateGitLabWikiPage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+}
+
+/// GitLab wiki attachment upload response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabWikiAttachment {
+    pub file_name: String,
+    pub file_path: String,
+    #[serde(default)]
+    pub branch: Option<String>,
+    pub link: GitLabWikiAttachmentLink,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabWikiAttachmentLink {
+    pub url: String,
+    pub markdown: String,
+}

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -1,9 +1,10 @@
 //! Implementation of tracker-core traits for GitLabClient
 
 use tracker_core::{
-    Article, ArticleAttachment, Comment, CreateArticle, CreateIssue, CreateProject, CreateTag,
-    Issue, IssueLink, IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project,
-    ProjectCustomField, Result, SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
+    Article, ArticleAttachment, AttachmentUpload, Comment, CreateArticle, CreateIssue,
+    CreateProject, CreateTag, Issue, IssueAttachment, IssueLink, IssueLinkType, IssueTag,
+    IssueTracker, KnowledgeBase, Project, ProjectCustomField, Result, SearchResult, TrackerError,
+    UpdateArticle, UpdateIssue, User,
 };
 
 use crate::client::GitLabClient;
@@ -193,6 +194,65 @@ impl IssueTracker for GitLabClient {
     fn delete_issue(&self, id: &str) -> Result<()> {
         let iid = parse_issue_iid(id)?;
         Ok(self.delete_issue(iid)?)
+    }
+
+    fn add_issue_attachment(
+        &self,
+        issue_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<IssueAttachment>> {
+        let iid = parse_issue_iid(issue_id)?;
+        let mut uploaded = Vec::new();
+        let mut note_lines = Vec::new();
+
+        if let Some(comment) = upload.comment.as_deref() {
+            note_lines.push(comment.to_string());
+            note_lines.push(String::new());
+        }
+
+        for file in &upload.files {
+            let project_upload = self.upload_project_file(file)?;
+            note_lines.push(project_upload.markdown.clone());
+            uploaded.push((file, project_upload));
+        }
+
+        let note = self.add_note(iid, &note_lines.join("\n"))?;
+
+        Ok(uploaded
+            .into_iter()
+            .map(|(file, upload)| {
+                let name = file.name.clone().unwrap_or_else(|| upload.alt.clone());
+                let size = file
+                    .path
+                    .metadata()
+                    .map(|metadata| metadata.len() as i64)
+                    .unwrap_or(0);
+                IssueAttachment {
+                    id: upload
+                        .full_path
+                        .clone()
+                        .unwrap_or_else(|| upload.url.clone()),
+                    name,
+                    size,
+                    mime_type: file.mime_type.clone(),
+                    url: Some(upload.url),
+                    created: note
+                        .created_at
+                        .as_deref()
+                        .and_then(|created| chrono::DateTime::parse_from_rfc3339(created).ok())
+                        .map(|created| created.with_timezone(&chrono::Utc)),
+                    author: note
+                        .author
+                        .clone()
+                        .map(|author| tracker_core::CommentAuthor {
+                            login: author.username,
+                            name: Some(author.name),
+                        }),
+                    comment_id: Some(note.id.to_string()),
+                    markdown: Some(upload.markdown),
+                }
+            })
+            .collect())
     }
 
     fn list_projects(&self) -> Result<Vec<Project>> {

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -1,9 +1,10 @@
 //! Implementation of tracker-core traits for GitLabClient
 
 use tracker_core::{
-    Article, ArticleAttachment, Comment, CreateArticle, CreateIssue, CreateProject, CreateTag,
-    Issue, IssueLink, IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project,
-    ProjectCustomField, Result, SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
+    Article, ArticleAttachment, ArticleRef, AttachmentUpload, Comment, CreateArticle, CreateIssue,
+    CreateProject, CreateTag, Issue, IssueLink, IssueLinkType, IssueTag, IssueTracker,
+    KnowledgeBase, Project, ProjectCustomField, ProjectRef, Result, SearchResult, TrackerError,
+    UpdateArticle, UpdateIssue, User,
 };
 
 use crate::client::GitLabClient;
@@ -12,9 +13,13 @@ use crate::convert::{
     gitlab_issue_to_core, gitlab_link_to_core,
 };
 use crate::models::{
-    CreateGitLabIssue, CreateGitLabIssueLink, CreateGitLabLabel, UpdateGitLabIssue,
-    UpdateGitLabLabel,
+    CreateGitLabIssue, CreateGitLabIssueLink, CreateGitLabLabel, CreateGitLabWikiPage,
+    GitLabWikiAttachment, GitLabWikiPage, UpdateGitLabIssue, UpdateGitLabLabel,
+    UpdateGitLabWikiPage,
 };
+
+const ATTACHMENT_BLOCK_START: &str = "<!-- track:attachments:start -->";
+const ATTACHMENT_BLOCK_END: &str = "<!-- track:attachments:end -->";
 
 /// Parse an issue IID from a string, stripping an optional leading `#`.
 fn parse_issue_iid(id: &str) -> std::result::Result<u64, TrackerError> {
@@ -372,61 +377,170 @@ impl IssueTracker for GitLabClient {
     }
 }
 
-// ==================== KnowledgeBase stub ====================
-// GitLab does not support a knowledge base through this client.
-// main.rs calls `run_with_client(&client, &client, ...)` so GitLabClient
-// must implement KnowledgeBase.
+// ==================== KnowledgeBase via project wikis ====================
 
 impl KnowledgeBase for GitLabClient {
-    fn get_article(&self, _id: &str) -> Result<Article> {
-        Err(TrackerError::InvalidInput(
-            "GitLab backend does not support articles/knowledge base".to_string(),
+    fn get_article(&self, id: &str) -> Result<Article> {
+        Ok(gitlab_wiki_page_to_article(
+            self.get_wiki_page(id)?,
+            &self.project_id_str(),
         ))
     }
 
     fn list_articles(
         &self,
-        _project_id: Option<&str>,
-        _limit: usize,
-        _skip: usize,
+        project_id: Option<&str>,
+        limit: usize,
+        skip: usize,
     ) -> Result<Vec<Article>> {
-        Ok(Vec::new())
+        if let Some(project) = project_id
+            && project != self.project_id_str()
+        {
+            return Ok(Vec::new());
+        }
+
+        Ok(self
+            .list_wiki_pages(true)?
+            .into_iter()
+            .skip(skip)
+            .take(limit)
+            .map(|page| gitlab_wiki_page_to_article(page, &self.project_id_str()))
+            .collect())
     }
 
-    fn search_articles(&self, _query: &str, _limit: usize, _skip: usize) -> Result<Vec<Article>> {
-        Ok(Vec::new())
+    fn search_articles(&self, query: &str, limit: usize, skip: usize) -> Result<Vec<Article>> {
+        let query = query.to_lowercase();
+        Ok(self
+            .list_wiki_pages(true)?
+            .into_iter()
+            .filter(|page| {
+                page.title.to_lowercase().contains(&query)
+                    || page
+                        .content
+                        .as_deref()
+                        .unwrap_or_default()
+                        .to_lowercase()
+                        .contains(&query)
+            })
+            .skip(skip)
+            .take(limit)
+            .map(|page| gitlab_wiki_page_to_article(page, &self.project_id_str()))
+            .collect())
     }
 
-    fn create_article(&self, _article: &CreateArticle) -> Result<Article> {
-        Err(TrackerError::InvalidInput(
-            "GitLab backend does not support articles/knowledge base".to_string(),
+    fn create_article(&self, article: &CreateArticle) -> Result<Article> {
+        if article.project_id != self.project_id_str() {
+            return Err(TrackerError::InvalidInput(format!(
+                "Project '{}' does not match configured GitLab project '{}'",
+                article.project_id,
+                self.project_id_str()
+            )));
+        }
+
+        let title = if let Some(parent) = &article.parent_article_id {
+            format!("{}/{}", parent.trim_end_matches('/'), article.summary)
+        } else {
+            article.summary.clone()
+        };
+        let page = CreateGitLabWikiPage {
+            title,
+            content: article.content.clone().unwrap_or_default(),
+            format: Some("markdown".to_string()),
+        };
+
+        Ok(gitlab_wiki_page_to_article(
+            self.create_wiki_page(&page)?,
+            &self.project_id_str(),
         ))
     }
 
-    fn update_article(&self, _id: &str, _update: &UpdateArticle) -> Result<Article> {
-        Err(TrackerError::InvalidInput(
-            "GitLab backend does not support articles/knowledge base".to_string(),
+    fn update_article(&self, id: &str, update: &UpdateArticle) -> Result<Article> {
+        let page = UpdateGitLabWikiPage {
+            title: update.summary.clone(),
+            content: update.content.clone(),
+            format: Some("markdown".to_string()),
+        };
+
+        Ok(gitlab_wiki_page_to_article(
+            self.update_wiki_page(id, &page)?,
+            &self.project_id_str(),
         ))
     }
 
-    fn delete_article(&self, _id: &str) -> Result<()> {
-        Err(TrackerError::InvalidInput(
-            "GitLab backend does not support articles/knowledge base".to_string(),
-        ))
+    fn delete_article(&self, id: &str) -> Result<()> {
+        Ok(self.delete_wiki_page(id)?)
     }
 
-    fn get_child_articles(&self, _parent_id: &str) -> Result<Vec<Article>> {
-        Ok(Vec::new())
+    fn get_child_articles(&self, parent_id: &str) -> Result<Vec<Article>> {
+        let prefix = format!("{}/", parent_id.trim_end_matches('/'));
+        Ok(self
+            .list_wiki_pages(true)?
+            .into_iter()
+            .filter(|page| page.slug.starts_with(&prefix))
+            .map(|page| gitlab_wiki_page_to_article(page, &self.project_id_str()))
+            .collect())
     }
 
     fn move_article(&self, _article_id: &str, _new_parent_id: Option<&str>) -> Result<Article> {
         Err(TrackerError::InvalidInput(
-            "GitLab backend does not support articles/knowledge base".to_string(),
+            "Moving GitLab wiki pages is not supported by this backend".to_string(),
         ))
     }
 
-    fn list_article_attachments(&self, _article_id: &str) -> Result<Vec<ArticleAttachment>> {
-        Ok(Vec::new())
+    fn list_article_attachments(&self, article_id: &str) -> Result<Vec<ArticleAttachment>> {
+        let page = self.get_wiki_page(article_id)?;
+        Ok(
+            parse_managed_attachment_block(page.content.as_deref().unwrap_or_default())
+                .into_iter()
+                .map(|(name, markdown, url)| ArticleAttachment {
+                    id: markdown,
+                    name,
+                    size: 0,
+                    mime_type: None,
+                    url: Some(url),
+                    created: None,
+                })
+                .collect(),
+        )
+    }
+
+    fn add_article_attachment(
+        &self,
+        article_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ArticleAttachment>> {
+        if upload.comment.is_some() {
+            return Err(TrackerError::InvalidInput(
+                "GitLab wiki attachment upload does not support --comment".to_string(),
+            ));
+        }
+
+        let page = self.get_wiki_page(article_id)?;
+        let mut entries =
+            parse_managed_attachment_block(page.content.as_deref().unwrap_or_default());
+        let mut uploaded = Vec::new();
+
+        for file in &upload.files {
+            let attachment = self.upload_wiki_attachment(file)?;
+            entries.retain(|(_, _, url)| url != &attachment.link.url);
+            entries.push((
+                attachment.file_name.clone(),
+                attachment.link.markdown.clone(),
+                attachment.link.url.clone(),
+            ));
+            uploaded.push(gitlab_wiki_attachment_to_article_attachment(attachment));
+        }
+
+        let content =
+            replace_managed_attachment_block(page.content.as_deref().unwrap_or_default(), &entries);
+        let update = UpdateGitLabWikiPage {
+            title: None,
+            content: Some(content),
+            format: Some("markdown".to_string()),
+        };
+        self.update_wiki_page(article_id, &update)?;
+
+        Ok(uploaded)
     }
 
     fn get_article_comments(&self, _article_id: &str) -> Result<Vec<Comment>> {
@@ -435,7 +549,130 @@ impl KnowledgeBase for GitLabClient {
 
     fn add_article_comment(&self, _article_id: &str, _text: &str) -> Result<Comment> {
         Err(TrackerError::InvalidInput(
-            "GitLab backend does not support articles/knowledge base".to_string(),
+            "GitLab wiki pages do not support comments".to_string(),
         ))
     }
+}
+
+fn gitlab_wiki_page_to_article(page: GitLabWikiPage, project_id: &str) -> Article {
+    let parent_article = page.slug.rsplit_once('/').map(|(parent, _)| ArticleRef {
+        id: parent.to_string(),
+        id_readable: Some(parent.to_string()),
+        summary: Some(parent.replace('-', " ")),
+    });
+
+    Article {
+        id: page.slug.clone(),
+        id_readable: page.slug,
+        summary: page.title,
+        content: page.content,
+        project: ProjectRef {
+            id: project_id.to_string(),
+            name: Some(project_id.to_string()),
+            short_name: Some(project_id.to_string()),
+        },
+        parent_article,
+        has_children: false,
+        tags: Vec::new(),
+        created: chrono::Utc::now(),
+        updated: chrono::Utc::now(),
+        reporter: None,
+    }
+}
+
+fn gitlab_wiki_attachment_to_article_attachment(
+    attachment: GitLabWikiAttachment,
+) -> ArticleAttachment {
+    ArticleAttachment {
+        id: attachment.file_path,
+        name: attachment.file_name,
+        size: 0,
+        mime_type: None,
+        url: Some(attachment.link.url),
+        created: None,
+    }
+}
+
+fn parse_managed_attachment_block(content: &str) -> Vec<(String, String, String)> {
+    let mut attachments = Vec::new();
+    let mut in_block = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == ATTACHMENT_BLOCK_START {
+            in_block = true;
+            continue;
+        }
+        if trimmed == ATTACHMENT_BLOCK_END {
+            break;
+        }
+        if !in_block {
+            continue;
+        }
+
+        let markdown = trimmed.strip_prefix("- ").unwrap_or(trimmed);
+        if let Some((name, url)) = parse_markdown_link(markdown) {
+            attachments.push((name, markdown.to_string(), url));
+        }
+    }
+
+    attachments
+}
+
+fn parse_markdown_link(markdown: &str) -> Option<(String, String)> {
+    let rest = markdown
+        .strip_prefix("![")
+        .or_else(|| markdown.strip_prefix('['))?;
+    let (name, rest) = rest.split_once("](")?;
+    let url = rest.strip_suffix(')')?;
+    Some((name.to_string(), url.to_string()))
+}
+
+fn replace_managed_attachment_block(
+    content: &str,
+    attachments: &[(String, String, String)],
+) -> String {
+    let mut output = Vec::new();
+    let mut in_block = false;
+    let mut replaced = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == ATTACHMENT_BLOCK_START {
+            if !replaced {
+                push_managed_attachment_block(&mut output, attachments);
+                replaced = true;
+            }
+            in_block = true;
+            continue;
+        }
+        if trimmed == ATTACHMENT_BLOCK_END {
+            in_block = false;
+            continue;
+        }
+        if !in_block {
+            output.push(line.to_string());
+        }
+    }
+
+    if !replaced {
+        if !output.is_empty() && output.last().is_some_and(|line| !line.is_empty()) {
+            output.push(String::new());
+        }
+        push_managed_attachment_block(&mut output, attachments);
+    }
+
+    output.join("\n")
+}
+
+fn push_managed_attachment_block(
+    output: &mut Vec<String>,
+    attachments: &[(String, String, String)],
+) {
+    output.push(ATTACHMENT_BLOCK_START.to_string());
+    output.push("## Attachments".to_string());
+    for (_, markdown, _) in attachments {
+        output.push(format!("- {}", markdown));
+    }
+    output.push(ATTACHMENT_BLOCK_END.to_string());
 }

--- a/crates/jira-backend/src/client.rs
+++ b/crates/jira-backend/src/client.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Duration;
+use tracker_core::AttachmentUpload;
 use ureq::Agent;
+use ureq::unversioned::multipart::{Form, Part};
 
 use crate::error::{JiraError, Result};
 use crate::models::*;
@@ -262,6 +264,47 @@ impl JiraClient {
 
         self.check_response(response)?;
         Ok(())
+    }
+
+    /// Upload attachments to an issue.
+    pub fn add_issue_attachments(
+        &self,
+        key: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<JiraAttachment>> {
+        if upload.comment.is_some() {
+            return Err(JiraError::Api {
+                status: 0,
+                message: "Jira issue attachment upload does not support --comment".to_string(),
+            });
+        }
+
+        let url = self.api_url(&format!("/issue/{}/attachments", key));
+
+        let mut form = Form::new();
+        for file in &upload.files {
+            let mut part = Part::file(&file.path)?;
+            if let Some(name) = &file.name {
+                part = part.file_name(name);
+            }
+            if let Some(mime_type) = &file.mime_type {
+                part = part.mime_str(mime_type)?;
+            }
+            form = form.part("file", part);
+        }
+
+        let response = self
+            .agent
+            .post(&url)
+            .header("Authorization", &self.auth_header)
+            .header("Accept", "application/json")
+            .header("X-Atlassian-Token", "no-check")
+            .send(form)
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let attachments: Vec<JiraAttachment> = response.body_mut().read_json()?;
+        Ok(attachments)
     }
 
     // ==================== Project Operations ====================

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -4,8 +4,21 @@
 mod tests {
     use crate::client::JiraClient;
     use crate::models::*;
-    use wiremock::matchers::{header, method, path, query_param};
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tracker_core::{AttachmentUpload, AttachmentUploadFile};
+    use wiremock::matchers::{body_string_contains, header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn temp_upload_file(name: &str, contents: &[u8]) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("track-jira-upload-{nanos}-{name}"));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
 
     fn base64_encode_for_test(input: &str) -> String {
         const ALPHABET: &[u8; 64] =
@@ -192,6 +205,59 @@ mod tests {
         assert_eq!(issue.fields.summary, "Test issue");
         assert_eq!(issue.fields.status.name, "Open");
         assert_eq!(issue.fields.labels, vec!["bug", "urgent"]);
+    }
+
+    #[tokio::test]
+    async fn test_add_issue_attachment_uses_file_field_and_xsrf_header() {
+        let mock_server = MockServer::start().await;
+        let upload_path = temp_upload_file("evidence.txt", b"evidence");
+
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/issue/TEST-123/attachments"))
+            .and(header(
+                "Authorization",
+                "Basic dGVzdEB0ZXN0LmNvbTp0ZXN0LXRva2Vu",
+            ))
+            .and(header("X-Atlassian-Token", "no-check"))
+            .and(body_string_contains("name=\"file\""))
+            .and(body_string_contains("filename=\"custom.txt\""))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "10001",
+                    "filename": "custom.txt",
+                    "size": 8,
+                    "mimeType": "text/plain",
+                    "content": "https://test.atlassian.net/attachment/content/10001",
+                    "author": {
+                        "accountId": "abc123",
+                        "displayName": "Test User",
+                        "emailAddress": "test@example.com",
+                        "active": true
+                    }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+        let upload = AttachmentUpload {
+            files: vec![AttachmentUploadFile {
+                path: upload_path.clone(),
+                name: Some("custom.txt".to_string()),
+                mime_type: Some("text/plain".to_string()),
+            }],
+            comment: None,
+            silent: false,
+            minor_edit: false,
+        };
+
+        let attachments = client
+            .add_issue_attachments("TEST-123", &upload)
+            .expect("issue attachment upload should succeed");
+
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].filename, "custom.txt");
+        let _ = std::fs::remove_file(upload_path);
     }
 
     #[tokio::test]

--- a/crates/jira-backend/src/confluence.rs
+++ b/crates/jira-backend/src/confluence.rs
@@ -1,7 +1,9 @@
 //! Confluence REST API v2 client
 
 use std::time::Duration;
+use tracker_core::AttachmentUpload;
 use ureq::Agent;
+use ureq::unversioned::multipart::{Form, Part};
 
 use crate::error::{JiraError, Result};
 use crate::models::confluence::*;
@@ -394,6 +396,48 @@ impl ConfluenceClient {
         let mut response = self.check_response(response)?;
         let attachments: ConfluenceAttachmentList = response.body_mut().read_json()?;
         Ok(attachments)
+    }
+
+    /// Upload attachments to any Confluence content entity (page or comment).
+    pub fn add_content_attachments(
+        &self,
+        content_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ConfluenceAttachmentUpload>> {
+        let url = self.api_v1_url(&format!("/content/{}/child/attachment", content_id));
+
+        let mut form = Form::new();
+        for file in &upload.files {
+            let mut part = Part::file(&file.path)?;
+            if let Some(name) = &file.name {
+                part = part.file_name(name);
+            }
+            if let Some(mime_type) = &file.mime_type {
+                part = part.mime_str(mime_type)?;
+            }
+            form = form.part("file", part);
+        }
+
+        if let Some(comment) = upload.comment.as_deref() {
+            form = form.text("comment", comment);
+        }
+
+        if upload.minor_edit {
+            form = form.text("minorEdit", "true");
+        }
+
+        let response = self
+            .agent
+            .post(&url)
+            .header("Authorization", &self.auth_header)
+            .header("Accept", "application/json")
+            .header("X-Atlassian-Token", "nocheck")
+            .send(form)
+            .map_err(JiraError::from)?;
+
+        let mut response = self.check_response(response)?;
+        let uploaded: ConfluenceAttachmentUploadResponse = response.body_mut().read_json()?;
+        Ok(uploaded.results)
     }
 }
 

--- a/crates/jira-backend/src/confluence_impl.rs
+++ b/crates/jira-backend/src/confluence_impl.rs
@@ -2,8 +2,8 @@
 
 use chrono::{DateTime, Utc};
 use tracker_core::{
-    Article, ArticleAttachment, ArticleRef, Comment, CommentAuthor, CreateArticle, KnowledgeBase,
-    ProjectRef, Result, TrackerError, UpdateArticle,
+    Article, ArticleAttachment, ArticleRef, AttachmentUpload, Comment, CommentAuthor,
+    CreateArticle, KnowledgeBase, ProjectRef, Result, TrackerError, UpdateArticle,
 };
 
 use crate::confluence::ConfluenceClient;
@@ -181,6 +181,21 @@ impl KnowledgeBase for ConfluenceClient {
             .map_err(TrackerError::from)
     }
 
+    fn add_article_attachment(
+        &self,
+        article_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ArticleAttachment>> {
+        self.add_content_attachments(article_id, upload)
+            .map(|attachments| {
+                attachments
+                    .into_iter()
+                    .map(confluence_uploaded_attachment_to_article_attachment)
+                    .collect()
+            })
+            .map_err(TrackerError::from)
+    }
+
     fn get_article_comments(&self, article_id: &str) -> Result<Vec<Comment>> {
         self.get_page_comments(article_id, 100)
             .map(|r| {
@@ -196,6 +211,24 @@ impl KnowledgeBase for ConfluenceClient {
         self.add_page_comment(article_id, text)
             .map(confluence_comment_to_comment)
             .map_err(TrackerError::from)
+    }
+
+    fn add_article_comment_attachment(
+        &self,
+        article_id: &str,
+        text: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Comment> {
+        let comment = self
+            .add_page_comment(article_id, text)
+            .map_err(TrackerError::from)?;
+        self.add_content_attachments(&comment.id, upload)
+            .map_err(TrackerError::from)?;
+        Ok(confluence_comment_to_comment(comment))
+    }
+
+    fn supports_article_comment_attachments(&self) -> bool {
+        true
     }
 }
 
@@ -306,6 +339,39 @@ fn confluence_attachment_to_article_attachment(att: ConfluenceAttachment) -> Art
         name: att.title,
         size: att.file_size.unwrap_or(0),
         mime_type: att.media_type,
+        url: att.links.and_then(|l| l.download),
+        created,
+    }
+}
+
+fn confluence_uploaded_attachment_to_article_attachment(
+    att: ConfluenceAttachmentUpload,
+) -> ArticleAttachment {
+    let created = att
+        .version
+        .as_ref()
+        .and_then(|v| v.when.as_ref())
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.with_timezone(&Utc));
+
+    let (mime_type, size) = att
+        .metadata
+        .map(|metadata| {
+            (
+                metadata.media_type,
+                metadata
+                    .extensions
+                    .and_then(|extensions| extensions.file_size)
+                    .unwrap_or(0),
+            )
+        })
+        .unwrap_or((None, 0));
+
+    ArticleAttachment {
+        id: att.id,
+        name: att.title,
+        size,
+        mime_type,
         url: att.links.and_then(|l| l.download),
         created,
     }

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -1083,6 +1083,7 @@ mod tests {
                 subtasks: vec![],
                 parent: None,
                 issuelinks: vec![],
+                attachment: vec![],
                 comment: None,
                 extra,
             },

--- a/crates/jira-backend/src/models/confluence.rs
+++ b/crates/jira-backend/src/models/confluence.rs
@@ -236,6 +236,44 @@ pub struct ConfluenceAttachmentList {
     pub links: Option<ConfluencePaginationLinks>,
 }
 
+/// Attachment upload response from the Confluence v1 content API.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfluenceAttachmentUploadResponse {
+    pub results: Vec<ConfluenceAttachmentUpload>,
+}
+
+/// Uploaded attachment entry from the Confluence v1 content API.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfluenceAttachmentUpload {
+    pub id: String,
+    pub title: String,
+    pub metadata: Option<ConfluenceAttachmentUploadMetadata>,
+    pub version: Option<ConfluenceAttachmentUploadVersion>,
+    #[serde(rename = "_links")]
+    pub links: Option<ConfluenceAttachmentLinks>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfluenceAttachmentUploadMetadata {
+    pub media_type: Option<String>,
+    pub media_type_description: Option<String>,
+    pub extensions: Option<ConfluenceAttachmentUploadExtensions>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfluenceAttachmentUploadExtensions {
+    pub file_size: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConfluenceAttachmentUploadVersion {
+    pub when: Option<String>,
+}
+
 // ============================================================================
 // Search Models (v1 API for CQL search)
 // ============================================================================

--- a/crates/jira-backend/src/models/issue.rs
+++ b/crates/jira-backend/src/models/issue.rs
@@ -58,6 +58,9 @@ pub struct JiraIssueFields {
     pub issuelinks: Vec<JiraIssueLink>,
     /// Comments (only included when expanded)
     pub comment: Option<JiraCommentsContainer>,
+    /// Attachments on this issue.
+    #[serde(default)]
+    pub attachment: Vec<JiraAttachment>,
     /// Extra/custom fields not captured by the named fields above.
     /// Keys are field IDs like "customfield_10016".
     #[serde(flatten)]
@@ -71,6 +74,24 @@ pub struct JiraCommentsContainer {
     pub comments: Vec<JiraComment>,
     #[serde(default)]
     pub total: usize,
+}
+
+/// Jira issue attachment.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraAttachment {
+    pub id: String,
+    pub filename: String,
+    #[serde(default)]
+    pub size: i64,
+    #[serde(default)]
+    pub mime_type: Option<String>,
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub created: Option<String>,
+    #[serde(default)]
+    pub author: Option<JiraUser>,
 }
 
 /// Issue reference (used in subtasks, parent, links)

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -1,9 +1,9 @@
 //! Implementation of tracker-core traits for JiraClient
 
 use tracker_core::{
-    Comment, CreateIssue, CreateProject, CreateTag, Issue, IssueLink, IssueLinkType, IssueTag,
-    IssueTracker, Project, ProjectCustomField, Result, SearchResult, TrackerError, UpdateIssue,
-    User,
+    AttachmentUpload, Comment, CreateIssue, CreateProject, CreateTag, Issue, IssueAttachment,
+    IssueLink, IssueLinkType, IssueTag, IssueTracker, Project, ProjectCustomField, Result,
+    SearchResult, TrackerError, UpdateIssue, User,
 };
 
 use crate::client::JiraClient;
@@ -101,6 +101,28 @@ impl IssueTracker for JiraClient {
 
     fn delete_issue(&self, id: &str) -> Result<()> {
         Ok(self.delete_issue(id)?)
+    }
+
+    fn list_issue_attachments(&self, issue_id: &str) -> Result<Vec<IssueAttachment>> {
+        let issue = self.get_issue(issue_id)?;
+        Ok(issue
+            .fields
+            .attachment
+            .into_iter()
+            .map(jira_attachment_to_core)
+            .collect())
+    }
+
+    fn add_issue_attachment(
+        &self,
+        issue_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<IssueAttachment>> {
+        Ok(self
+            .add_issue_attachments(issue_id, upload)?
+            .into_iter()
+            .map(jira_attachment_to_core)
+            .collect())
     }
 
     fn list_projects(&self) -> Result<Vec<Project>> {
@@ -322,5 +344,35 @@ fn convert_simple_query_to_jql(query: &str) -> String {
         query.to_string()
     } else {
         parts.join(" AND ")
+    }
+}
+
+fn jira_attachment_to_core(attachment: crate::models::JiraAttachment) -> IssueAttachment {
+    let created = attachment
+        .created
+        .as_deref()
+        .and_then(|created| chrono::DateTime::parse_from_rfc3339(created).ok())
+        .map(|created| created.with_timezone(&chrono::Utc));
+
+    IssueAttachment {
+        id: attachment.id,
+        name: attachment.filename,
+        size: attachment.size,
+        mime_type: attachment.mime_type,
+        url: attachment.content,
+        created,
+        author: attachment.author.map(|author| {
+            let login = author
+                .account_id
+                .clone()
+                .or_else(|| author.display_name.clone())
+                .unwrap_or_else(|| "unknown".to_string());
+            tracker_core::CommentAuthor {
+                login,
+                name: author.display_name,
+            }
+        }),
+        comment_id: None,
+        markdown: None,
     }
 }

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.8.2"
+version = "1.9.0"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/cli.rs
+++ b/crates/track/src/cli.rs
@@ -477,6 +477,31 @@ pub enum IssueCommands {
         #[arg(value_delimiter = ',')]
         ids: Vec<String>,
     },
+    /// List attachments on an issue
+    Attachments {
+        /// Issue ID (e.g., PROJ-123)
+        id: String,
+    },
+    /// Upload attachment(s) to an issue
+    Attach {
+        /// Issue ID (e.g., PROJ-123)
+        id: String,
+        /// File path(s) to upload
+        #[arg(required = true, value_name = "PATH")]
+        paths: Vec<PathBuf>,
+        /// Override the uploaded filename; only valid with one file
+        #[arg(long)]
+        name: Option<String>,
+        /// Override the uploaded MIME type; only valid with one file
+        #[arg(long = "mime-type")]
+        mime_type: Option<String>,
+        /// Backend attachment comment, where supported
+        #[arg(long)]
+        comment: Option<String>,
+        /// Suppress notifications where the backend supports it
+        #[arg(long)]
+        silent: bool,
+    },
     /// Add a comment to an issue
     #[command(visible_alias = "cmt")]
     Comment {
@@ -488,6 +513,18 @@ pub enum IssueCommands {
         /// Read comment text from a file ("-" for stdin)
         #[arg(long, value_name = "PATH", conflicts_with = "text")]
         body_file: Option<PathBuf>,
+        /// File path(s) to attach to this comment
+        #[arg(long = "attach", value_name = "PATH")]
+        attach: Vec<PathBuf>,
+        /// Override the uploaded filename; only valid with one attached file
+        #[arg(long)]
+        name: Option<String>,
+        /// Override the uploaded MIME type; only valid with one attached file
+        #[arg(long = "mime-type")]
+        mime_type: Option<String>,
+        /// Suppress notifications where the backend supports it
+        #[arg(long)]
+        silent: bool,
     },
     /// List comments on an issue
     Comments {
@@ -1160,6 +1197,119 @@ mod tests {
             },
             _ => panic!("expected issue command"),
         }
+    }
+
+    #[test]
+    fn parses_issue_attachments_command() {
+        let cli = Cli::parse_from(["track", "issue", "attachments", "PROJ-123"]);
+
+        match cli.command {
+            Commands::Issue { action } => match action {
+                IssueCommands::Attachments { id } => {
+                    assert_eq!(id, "PROJ-123");
+                }
+                _ => panic!("expected issue attachments"),
+            },
+            _ => panic!("expected issue command"),
+        }
+    }
+
+    #[test]
+    fn parses_issue_attach_command() {
+        let cli = Cli::parse_from([
+            "track",
+            "issue",
+            "attach",
+            "PROJ-123",
+            "report.txt",
+            "--name",
+            "custom.txt",
+            "--mime-type",
+            "text/plain",
+            "--comment",
+            "supporting material",
+            "--silent",
+        ]);
+
+        match cli.command {
+            Commands::Issue { action } => match action {
+                IssueCommands::Attach {
+                    id,
+                    paths,
+                    name,
+                    mime_type,
+                    comment,
+                    silent,
+                } => {
+                    assert_eq!(id, "PROJ-123");
+                    assert_eq!(paths, vec![PathBuf::from("report.txt")]);
+                    assert_eq!(name.as_deref(), Some("custom.txt"));
+                    assert_eq!(mime_type.as_deref(), Some("text/plain"));
+                    assert_eq!(comment.as_deref(), Some("supporting material"));
+                    assert!(silent);
+                }
+                _ => panic!("expected issue attach"),
+            },
+            _ => panic!("expected issue command"),
+        }
+    }
+
+    #[test]
+    fn parses_issue_comment_with_attachment() {
+        let cli = Cli::parse_from([
+            "track",
+            "issue",
+            "comment",
+            "PROJ-123",
+            "-m",
+            "See attached",
+            "--attach",
+            "evidence.log",
+            "--name",
+            "evidence.txt",
+            "--mime-type",
+            "text/plain",
+            "--silent",
+        ]);
+
+        match cli.command {
+            Commands::Issue { action } => match action {
+                IssueCommands::Comment {
+                    id,
+                    text,
+                    attach,
+                    name,
+                    mime_type,
+                    silent,
+                    ..
+                } => {
+                    assert_eq!(id, "PROJ-123");
+                    assert_eq!(text.as_deref(), Some("See attached"));
+                    assert_eq!(attach, vec![PathBuf::from("evidence.log")]);
+                    assert_eq!(name.as_deref(), Some("evidence.txt"));
+                    assert_eq!(mime_type.as_deref(), Some("text/plain"));
+                    assert!(silent);
+                }
+                _ => panic!("expected issue comment"),
+            },
+            _ => panic!("expected issue command"),
+        }
+    }
+
+    #[test]
+    fn rejects_issue_comment_attachment_without_message_or_body_file() {
+        let result = Cli::try_parse_from([
+            "track",
+            "issue",
+            "comment",
+            "PROJ-123",
+            "--attach",
+            "evidence.log",
+        ]);
+        assert!(
+            result.is_err(),
+            "comment attachments still require comment text"
+        );
     }
 
     #[test]
@@ -2179,6 +2329,7 @@ mod tests {
                     id,
                     text,
                     body_file,
+                    ..
                 } => {
                     assert_eq!(id, "PROJ-1");
                     assert!(text.is_none());

--- a/crates/track/src/cli.rs
+++ b/crates/track/src/cli.rs
@@ -829,6 +829,29 @@ pub enum ArticleCommands {
         /// Article ID
         id: String,
     },
+    /// Upload attachment(s) to an article
+    Attach {
+        /// Article ID
+        id: String,
+        /// File path(s) to upload
+        #[arg(required = true, value_name = "PATH")]
+        paths: Vec<PathBuf>,
+        /// Override the uploaded filename; only valid with one file
+        #[arg(long)]
+        name: Option<String>,
+        /// Override the uploaded MIME type; only valid with one file
+        #[arg(long = "mime-type")]
+        mime_type: Option<String>,
+        /// Backend attachment comment, where supported
+        #[arg(long)]
+        comment: Option<String>,
+        /// Suppress notifications where the backend supports it
+        #[arg(long)]
+        silent: bool,
+        /// Mark the article/wiki attachment update as minor where supported
+        #[arg(long)]
+        minor_edit: bool,
+    },
     /// Add a comment to an article
     #[command(visible_alias = "cmt")]
     Comment {
@@ -840,6 +863,18 @@ pub enum ArticleCommands {
         /// Read comment text from a file ("-" for stdin)
         #[arg(long, value_name = "PATH", conflicts_with = "text")]
         body_file: Option<PathBuf>,
+        /// File path(s) to attach to this comment
+        #[arg(long = "attach", value_name = "PATH")]
+        attach: Vec<PathBuf>,
+        /// Override the uploaded filename; only valid with one attached file
+        #[arg(long)]
+        name: Option<String>,
+        /// Override the uploaded MIME type; only valid with one attached file
+        #[arg(long = "mime-type")]
+        mime_type: Option<String>,
+        /// Suppress notifications where the backend supports it
+        #[arg(long)]
+        silent: bool,
     },
     /// List comments on an article
     Comments {
@@ -979,6 +1014,102 @@ mod tests {
             },
             _ => panic!("expected issue command"),
         }
+    }
+
+    #[test]
+    fn parses_article_attach_with_options() {
+        let cli = Cli::parse_from([
+            "track",
+            "article",
+            "attach",
+            "KB-A-1",
+            "image.png",
+            "--name",
+            "diagram.png",
+            "--mime-type",
+            "image/png",
+            "--comment",
+            "reference image",
+            "--silent",
+            "--minor-edit",
+        ]);
+
+        match cli.command {
+            Commands::Article { action } => match action {
+                ArticleCommands::Attach {
+                    id,
+                    paths,
+                    name,
+                    mime_type,
+                    comment,
+                    silent,
+                    minor_edit,
+                } => {
+                    assert_eq!(id, "KB-A-1");
+                    assert_eq!(paths, vec![PathBuf::from("image.png")]);
+                    assert_eq!(name.as_deref(), Some("diagram.png"));
+                    assert_eq!(mime_type.as_deref(), Some("image/png"));
+                    assert_eq!(comment.as_deref(), Some("reference image"));
+                    assert!(silent);
+                    assert!(minor_edit);
+                }
+                _ => panic!("expected article attach"),
+            },
+            _ => panic!("expected article command"),
+        }
+    }
+
+    #[test]
+    fn parses_article_comment_with_attach() {
+        let cli = Cli::parse_from([
+            "track",
+            "article",
+            "comment",
+            "KB-A-1",
+            "-m",
+            "See attached",
+            "--attach",
+            "image.png",
+            "--name",
+            "diagram.png",
+            "--mime-type",
+            "image/png",
+        ]);
+
+        match cli.command {
+            Commands::Article { action } => match action {
+                ArticleCommands::Comment {
+                    id,
+                    text,
+                    attach,
+                    name,
+                    mime_type,
+                    ..
+                } => {
+                    assert_eq!(id, "KB-A-1");
+                    assert_eq!(text.as_deref(), Some("See attached"));
+                    assert_eq!(attach, vec![PathBuf::from("image.png")]);
+                    assert_eq!(name.as_deref(), Some("diagram.png"));
+                    assert_eq!(mime_type.as_deref(), Some("image/png"));
+                }
+                _ => panic!("expected article comment"),
+            },
+            _ => panic!("expected article command"),
+        }
+    }
+
+    #[test]
+    fn rejects_article_comment_attach_without_text() {
+        let result = Cli::try_parse_from([
+            "track",
+            "article",
+            "comment",
+            "KB-A-1",
+            "--attach",
+            "image.png",
+        ]);
+
+        assert!(result.is_err());
     }
 
     #[test]
@@ -2408,6 +2539,7 @@ mod tests {
                     id,
                     text,
                     body_file,
+                    ..
                 } => {
                     assert_eq!(id, "ART-1");
                     assert!(text.is_none());

--- a/crates/track/src/commands/article.rs
+++ b/crates/track/src/commands/article.rs
@@ -70,14 +70,46 @@ pub fn handle_article(
             handle_move(kb_client, id, parent.as_deref(), format)
         }
         ArticleCommands::Attachments { id } => handle_attachments(kb_client, id, format),
+        ArticleCommands::Attach {
+            id,
+            paths,
+            name,
+            mime_type,
+            comment,
+            silent,
+            minor_edit,
+        } => handle_attach(
+            kb_client,
+            id,
+            paths,
+            name.as_deref(),
+            mime_type.as_deref(),
+            comment.as_deref(),
+            *silent,
+            *minor_edit,
+            format,
+        ),
         ArticleCommands::Comment {
             id,
             text,
             body_file,
+            attach,
+            name,
+            mime_type,
+            silent,
         } => {
             let resolved_text = super::resolve_body(text.as_deref(), body_file.as_deref())?
                 .ok_or_else(|| anyhow!("Comment text is required"))?;
-            handle_comment(kb_client, id, &resolved_text, format)
+            handle_comment(
+                kb_client,
+                id,
+                &resolved_text,
+                attach,
+                name.as_deref(),
+                mime_type.as_deref(),
+                *silent,
+                format,
+            )
         }
         ArticleCommands::Comments { id, limit, all } => {
             handle_comments(kb_client, id, *limit, *all, format)
@@ -318,15 +350,60 @@ fn handle_attachments(client: &dyn KnowledgeBase, id: &str, format: OutputFormat
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn handle_attach(
+    client: &dyn KnowledgeBase,
+    id: &str,
+    paths: &[std::path::PathBuf],
+    name: Option<&str>,
+    mime_type: Option<&str>,
+    comment: Option<&str>,
+    silent: bool,
+    minor_edit: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    let upload = super::attachments::build_attachment_upload(
+        paths, name, mime_type, comment, silent, minor_edit,
+    )?;
+
+    let attachments = client
+        .add_article_attachment(id, &upload)
+        .with_context(|| format!("Failed to upload attachment(s) to article '{}'", id))?;
+
+    output_list(&attachments, format)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
 fn handle_comment(
     client: &dyn KnowledgeBase,
     id: &str,
     text: &str,
+    attach: &[std::path::PathBuf],
+    name: Option<&str>,
+    mime_type: Option<&str>,
+    silent: bool,
     format: OutputFormat,
 ) -> Result<()> {
-    let comment = client
-        .add_article_comment(id, text)
-        .with_context(|| format!("Failed to add comment to article '{}'", id))?;
+    let comment = if attach.is_empty() {
+        client
+            .add_article_comment(id, text)
+            .with_context(|| format!("Failed to add comment to article '{}'", id))?
+    } else {
+        if !client.supports_article_comment_attachments() {
+            return Err(anyhow!(
+                "Article comment attachment upload is not supported by this backend"
+            ));
+        }
+
+        let upload = super::attachments::build_attachment_upload(
+            attach, name, mime_type, None, silent, false,
+        )?;
+
+        client
+            .add_article_comment_attachment(id, text, &upload)
+            .with_context(|| format!("Failed to add comment attachment(s) to article '{}'", id))?
+    };
 
     output_result(&comment, format)?;
     Ok(())

--- a/crates/track/src/commands/attachments.rs
+++ b/crates/track/src/commands/attachments.rs
@@ -1,0 +1,160 @@
+#![allow(dead_code)]
+
+use anyhow::{Result, anyhow};
+use std::path::{Path, PathBuf};
+use tracker_core::{AttachmentUpload, AttachmentUploadFile};
+
+pub(crate) fn build_attachment_upload(
+    paths: &[PathBuf],
+    name: Option<&str>,
+    mime_type: Option<&str>,
+    comment: Option<&str>,
+    silent: bool,
+    minor_edit: bool,
+) -> Result<AttachmentUpload> {
+    if paths.is_empty() {
+        return Err(anyhow!("At least one attachment path is required"));
+    }
+
+    if paths.len() != 1 && name.is_some() {
+        return Err(anyhow!(
+            "--name can only be used when uploading exactly one file"
+        ));
+    }
+
+    if paths.len() != 1 && mime_type.is_some() {
+        return Err(anyhow!(
+            "--mime-type can only be used when uploading exactly one file"
+        ));
+    }
+
+    let mut files = Vec::with_capacity(paths.len());
+    for path in paths {
+        validate_attachment_path(path)?;
+        files.push(AttachmentUploadFile {
+            path: path.clone(),
+            name: (paths.len() == 1)
+                .then(|| name.map(str::to_string))
+                .flatten(),
+            mime_type: (paths.len() == 1)
+                .then(|| mime_type.map(str::to_string))
+                .flatten(),
+        });
+    }
+
+    Ok(AttachmentUpload {
+        files,
+        comment: comment.map(str::to_string),
+        silent,
+        minor_edit,
+    })
+}
+
+fn validate_attachment_path(path: &Path) -> Result<()> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|err| anyhow!("Failed to read attachment '{}': {}", path.display(), err))?;
+
+    if !metadata.is_file() {
+        return Err(anyhow!(
+            "Attachment path '{}' is not a file",
+            path.display()
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_temp_file(name: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("track-attachment-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join(name);
+        std::fs::write(&file, b"test").unwrap();
+        file
+    }
+
+    #[test]
+    fn builds_upload_for_single_file_with_overrides() {
+        // Arrange
+        let file = write_temp_file("single.bin");
+
+        // Act
+        let upload = build_attachment_upload(
+            std::slice::from_ref(&file),
+            Some("custom.bin"),
+            Some("application/octet-stream"),
+            Some("upload note"),
+            true,
+            false,
+        )
+        .unwrap();
+
+        // Assert
+        assert_eq!(upload.files.len(), 1);
+        assert_eq!(upload.files[0].path, file);
+        assert_eq!(upload.files[0].name.as_deref(), Some("custom.bin"));
+        assert_eq!(
+            upload.files[0].mime_type.as_deref(),
+            Some("application/octet-stream")
+        );
+        assert_eq!(upload.comment.as_deref(), Some("upload note"));
+        assert!(upload.silent);
+        assert!(!upload.minor_edit);
+    }
+
+    #[test]
+    fn rejects_name_with_multiple_files() {
+        // Arrange
+        let first = write_temp_file("first.txt");
+        let second = write_temp_file("second.txt");
+
+        // Act
+        let result = build_attachment_upload(
+            &[first, second],
+            Some("custom.txt"),
+            None,
+            None,
+            false,
+            false,
+        );
+
+        // Assert
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_mime_type_with_multiple_files() {
+        // Arrange
+        let first = write_temp_file("mime-first.txt");
+        let second = write_temp_file("mime-second.txt");
+
+        // Act
+        let result = build_attachment_upload(
+            &[first, second],
+            None,
+            Some("text/plain"),
+            None,
+            false,
+            false,
+        );
+
+        // Assert
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_missing_file() {
+        // Arrange
+        let missing = std::env::temp_dir().join("track-missing-attachment-file");
+
+        // Act
+        let result = build_attachment_upload(&[missing], None, None, None, false, false);
+
+        // Assert
+        assert!(result.is_err());
+    }
+}

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -131,14 +131,45 @@ pub fn handle_issue(
             handle_search(client, &args, format, default_project)
         }
         IssueCommands::Delete { ids } => handle_delete_batch(client, ids, format),
+        IssueCommands::Attachments { id } => handle_attachments(client, id, format),
+        IssueCommands::Attach {
+            id,
+            paths,
+            name,
+            mime_type,
+            comment,
+            silent,
+        } => handle_attach(
+            client,
+            id,
+            paths,
+            name.as_deref(),
+            mime_type.as_deref(),
+            comment.as_deref(),
+            *silent,
+            format,
+        ),
         IssueCommands::Comment {
             id,
             text,
             body_file,
+            attach,
+            name,
+            mime_type,
+            silent,
         } => {
             let resolved_text = super::resolve_body(text.as_deref(), body_file.as_deref())?
                 .ok_or_else(|| anyhow!("Comment text is required"))?;
-            handle_comment(client, id, &resolved_text, format)
+            handle_comment(
+                client,
+                id,
+                &resolved_text,
+                attach,
+                name.as_deref(),
+                mime_type.as_deref(),
+                *silent,
+                format,
+            )
         }
         IssueCommands::Comments { id, limit, all } => {
             handle_comments(client, id, *limit, *all, format)
@@ -951,15 +982,68 @@ fn handle_delete(client: &dyn IssueTracker, id: &str, format: OutputFormat) -> R
     Ok(())
 }
 
+fn handle_attachments(client: &dyn IssueTracker, id: &str, format: OutputFormat) -> Result<()> {
+    let attachments = client
+        .list_issue_attachments(id)
+        .with_context(|| format!("Failed to list attachments for issue '{}'", id))?;
+
+    output_list(&attachments, format)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_attach(
+    client: &dyn IssueTracker,
+    id: &str,
+    paths: &[std::path::PathBuf],
+    name: Option<&str>,
+    mime_type: Option<&str>,
+    comment: Option<&str>,
+    silent: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    let upload = super::attachments::build_attachment_upload(
+        paths, name, mime_type, comment, silent, false,
+    )?;
+
+    let attachments = client
+        .add_issue_attachment(id, &upload)
+        .with_context(|| format!("Failed to upload attachment(s) to issue '{}'", id))?;
+
+    output_list(&attachments, format)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
 fn handle_comment(
     client: &dyn IssueTracker,
     id: &str,
     text: &str,
+    attach: &[std::path::PathBuf],
+    name: Option<&str>,
+    mime_type: Option<&str>,
+    silent: bool,
     format: OutputFormat,
 ) -> Result<()> {
-    let comment = client
-        .add_comment(id, text)
-        .with_context(|| format!("Failed to add comment to issue '{}'", id))?;
+    let comment = if attach.is_empty() {
+        client
+            .add_comment(id, text)
+            .with_context(|| format!("Failed to add comment to issue '{}'", id))?
+    } else {
+        if !client.supports_issue_comment_attachments() {
+            return Err(anyhow!(
+                "Issue comment attachment upload is not supported by this backend"
+            ));
+        }
+
+        let upload = super::attachments::build_attachment_upload(
+            attach, name, mime_type, None, silent, false,
+        )?;
+
+        client
+            .add_issue_comment_attachment(id, text, &upload)
+            .with_context(|| format!("Failed to add comment attachment(s) to issue '{}'", id))?
+    };
 
     match format {
         OutputFormat::Json => {

--- a/crates/track/src/commands/mod.rs
+++ b/crates/track/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod article;
+pub(crate) mod attachments;
 pub mod bundle;
 pub mod cache;
 pub mod config;

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::io::IsTerminal;
 use tracker_core::{
     Article, ArticleAttachment, BundleDefinition, Comment, CustomField, CustomFieldDefinition,
-    Issue, IssueTag, Project, ProjectCustomField,
+    Issue, IssueAttachment, IssueTag, Project, ProjectCustomField,
 };
 
 pub fn output_json<T: Serialize + ?Sized>(value: &T) -> anyhow::Result<()> {
@@ -549,6 +549,39 @@ impl Displayable for ArticleAttachment {
             self.mime_type.as_deref().unwrap_or("unknown").dimmed(),
             size_str.dimmed()
         )
+    }
+}
+
+impl Displayable for IssueAttachment {
+    fn display(&self) -> String {
+        let size_str = if self.size > 1024 * 1024 {
+            format!("{:.1} MB", self.size as f64 / (1024.0 * 1024.0))
+        } else if self.size > 1024 {
+            format!("{:.1} KB", self.size as f64 / 1024.0)
+        } else {
+            format!("{} bytes", self.size)
+        };
+
+        let mut output = format!(
+            "{} ({}) - {}",
+            self.name.white().bold(),
+            self.mime_type.as_deref().unwrap_or("unknown").dimmed(),
+            size_str.dimmed()
+        );
+
+        if let Some(comment_id) = &self.comment_id {
+            output.push_str(&format!("\n  {}: {}", "Comment".dimmed(), comment_id));
+        }
+
+        if let Some(url) = &self.url {
+            output.push_str(&format!("\n  {}: {}", "URL".dimmed(), url));
+        }
+
+        if let Some(markdown) = &self.markdown {
+            output.push_str(&format!("\n  {}: {}", "Markdown".dimmed(), markdown));
+        }
+
+        output
     }
 }
 

--- a/crates/track/tests/github_integration_tests.rs
+++ b/crates/track/tests/github_integration_tests.rs
@@ -39,6 +39,15 @@ fn config_exists() -> bool {
 /// The project identifier for issue creation (owner/repo from .track.toml)
 const GITHUB_PROJECT: &str = "OrekGames/track-cli";
 
+fn temp_attachment_file(prefix: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "track-github-{prefix}-{}-attachment.txt",
+        std::process::id()
+    ));
+    std::fs::write(&path, b"attachment test content").expect("failed to write attachment file");
+    path
+}
+
 /// Helper to build a track command with GitHub backend and config
 fn track_github() -> assert_cmd::Command {
     let mut cmd = cargo_bin_cmd!("track");
@@ -1125,6 +1134,27 @@ fn test_github_delete_issue_not_supported() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("not support").or(predicate::str::contains("close")));
+}
+
+#[test]
+#[ignore]
+fn test_github_issue_attachment_upload_not_supported() {
+    if !config_exists() {
+        return;
+    }
+
+    let file = temp_attachment_file("issue");
+
+    track_github()
+        .args(["issue", "attach", "1"])
+        .arg(&file)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "does not expose a public REST API for uploading issue file attachments",
+        ));
+
+    let _ = std::fs::remove_file(&file);
 }
 
 // ============================================================================

--- a/crates/track/tests/gitlab_integration_tests.rs
+++ b/crates/track/tests/gitlab_integration_tests.rs
@@ -39,6 +39,15 @@ fn config_exists() -> bool {
 /// The project identifier for issue creation (project_id from .track.toml)
 const GITLAB_PROJECT: &str = "77945341";
 
+fn temp_attachment_file(prefix: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "track-gitlab-{prefix}-{}-attachment.txt",
+        std::process::id()
+    ));
+    std::fs::write(&path, b"attachment test content").expect("failed to write attachment file");
+    path
+}
+
 /// Helper to build a track command with GitLab backend and config
 fn track_gitlab() -> assert_cmd::Command {
     let mut cmd = cargo_bin_cmd!("track");
@@ -288,6 +297,75 @@ fn test_gitlab_issue_create_and_delete() {
         .args(["issue", "get", issue_iid])
         .assert()
         .failure();
+}
+
+#[test]
+#[ignore]
+fn test_gitlab_issue_attachment_upload_creates_note() {
+    if !config_exists() {
+        return;
+    }
+
+    let file = temp_attachment_file("issue");
+
+    let create_output = track_gitlab_json()
+        .args([
+            "issue",
+            "create",
+            "-p",
+            GITLAB_PROJECT,
+            "-s",
+            "Attachment Integration Test Issue - DELETE ME",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let create_str = String::from_utf8(create_output).unwrap();
+    let created: Value = serde_json::from_str(&create_str).unwrap();
+    let issue_id = created["id_readable"].as_str().unwrap();
+
+    let upload_output = track_gitlab_json()
+        .args(["issue", "attach", issue_id])
+        .arg(&file)
+        .args([
+            "--name",
+            "track-live-gitlab-attachment.txt",
+            "--comment",
+            "attachment fallback note",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let upload_str = String::from_utf8(upload_output).unwrap();
+    let uploaded: Value = serde_json::from_str(&upload_str).unwrap();
+    assert_eq!(uploaded[0]["name"], "track-live-gitlab-attachment.txt");
+    assert!(uploaded[0]["comment_id"].is_string());
+    assert!(uploaded[0]["markdown"].is_string());
+
+    let comments_output = track_gitlab_json()
+        .args(["issue", "comments", issue_id, "--all"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let comments_str = String::from_utf8(comments_output).unwrap();
+    let comments: Value = serde_json::from_str(&comments_str).unwrap();
+    assert!(comments.as_array().unwrap().iter().any(|comment| {
+        comment["text"]
+            .as_str()
+            .unwrap_or("")
+            .contains("track-live-gitlab-attachment.txt")
+    }));
+
+    let _ = std::fs::remove_file(&file);
+    let _ = track_gitlab().args(["issue", "delete", issue_id]).assert();
 }
 
 #[test]

--- a/crates/track/tests/jira_integration_tests.rs
+++ b/crates/track/tests/jira_integration_tests.rs
@@ -37,6 +37,15 @@ fn config_exists() -> bool {
     jira_config_path().exists()
 }
 
+fn temp_attachment_file(prefix: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "track-jira-{prefix}-{}-attachment.txt",
+        std::process::id()
+    ));
+    std::fs::write(&path, b"attachment test content").expect("failed to write attachment file");
+    path
+}
+
 // ============================================================================
 // Connection & Configuration Tests
 // ============================================================================
@@ -328,6 +337,83 @@ fn test_jira_issue_create_and_delete() {
         .timeout(Duration::from_secs(30))
         .assert()
         .failure();
+}
+
+#[test]
+#[ignore]
+fn test_jira_issue_attachment_upload_and_list() {
+    if !config_exists() {
+        return;
+    }
+
+    let file = temp_attachment_file("issue");
+
+    let create_output = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "-o", "json", "--config"])
+        .arg(jira_config_path())
+        .args([
+            "issue",
+            "create",
+            "-p",
+            "SMS",
+            "-s",
+            "Attachment Integration Test Issue - DELETE ME",
+        ])
+        .timeout(Duration::from_secs(30))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let create_str = String::from_utf8(create_output).unwrap();
+    let created: Value = serde_json::from_str(&create_str).unwrap();
+    let issue_key = created["id_readable"].as_str().unwrap();
+
+    let upload_output = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "-o", "json", "--config"])
+        .arg(jira_config_path())
+        .args(["issue", "attach", issue_key])
+        .arg(&file)
+        .args(["--name", "track-live-jira-attachment.txt"])
+        .timeout(Duration::from_secs(30))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let upload_str = String::from_utf8(upload_output).unwrap();
+    let uploaded: Value = serde_json::from_str(&upload_str).unwrap();
+    assert_eq!(uploaded[0]["name"], "track-live-jira-attachment.txt");
+
+    let list_output = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "-o", "json", "--config"])
+        .arg(jira_config_path())
+        .args(["issue", "attachments", issue_key])
+        .timeout(Duration::from_secs(30))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let list_str = String::from_utf8(list_output).unwrap();
+    let listed: Value = serde_json::from_str(&list_str).unwrap();
+    assert!(
+        listed
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|att| att["name"] == "track-live-jira-attachment.txt")
+    );
+
+    let _ = std::fs::remove_file(&file);
+    let _ = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "--config"])
+        .arg(jira_config_path())
+        .args(["issue", "delete", issue_key])
+        .timeout(Duration::from_secs(30))
+        .assert();
 }
 
 #[test]

--- a/crates/track/tests/youtrack_integration_tests.rs
+++ b/crates/track/tests/youtrack_integration_tests.rs
@@ -983,6 +983,15 @@ fn track_yt_json() -> assert_cmd::Command {
     cmd
 }
 
+fn temp_attachment_file(prefix: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "track-youtrack-{prefix}-{}-attachment.txt",
+        std::process::id()
+    ));
+    fs::write(&path, b"attachment test content").expect("failed to write attachment file");
+    path
+}
+
 // ============================================================================
 // Connection & Configuration
 // ============================================================================
@@ -1157,6 +1166,69 @@ fn test_youtrack_issue_create_and_delete() {
         .args(["issue", "get", issue_id])
         .assert()
         .failure();
+}
+
+#[test]
+#[ignore]
+fn test_youtrack_issue_attachment_upload_and_list() {
+    if !config_exists() {
+        return;
+    }
+
+    let file = temp_attachment_file("issue");
+
+    let create_output = track_yt_json()
+        .args([
+            "issue",
+            "create",
+            "-p",
+            YOUTRACK_PROJECT,
+            "-s",
+            "Attachment Integration Test Issue - DELETE ME",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let create_str = String::from_utf8(create_output).unwrap();
+    let created: Value = serde_json::from_str(&create_str).unwrap();
+    let issue_id = created["id_readable"].as_str().unwrap();
+
+    let upload_output = track_yt_json()
+        .args(["issue", "attach", issue_id])
+        .arg(&file)
+        .args(["--name", "track-live-youtrack-attachment.txt"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let upload_str = String::from_utf8(upload_output).unwrap();
+    let uploaded: Value = serde_json::from_str(&upload_str).unwrap();
+    assert_eq!(uploaded[0]["name"], "track-live-youtrack-attachment.txt");
+
+    let list_output = track_yt_json()
+        .args(["issue", "attachments", issue_id])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let list_str = String::from_utf8(list_output).unwrap();
+    let listed: Value = serde_json::from_str(&list_str).unwrap();
+    assert!(
+        listed
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|att| att["name"] == "track-live-youtrack-attachment.txt")
+    );
+
+    let _ = fs::remove_file(&file);
+    let _ = track_yt().args(["issue", "delete", issue_id]).assert();
 }
 
 #[test]

--- a/crates/tracker-core/src/models.rs
+++ b/crates/tracker-core/src/models.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 /// Common issue representation across all backends
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -196,6 +197,37 @@ pub struct Comment {
 pub struct CommentAuthor {
     pub login: String,
     pub name: Option<String>,
+}
+
+/// Upload request shared by issue and article attachment commands.
+#[derive(Debug, Clone)]
+pub struct AttachmentUpload {
+    pub files: Vec<AttachmentUploadFile>,
+    pub comment: Option<String>,
+    pub silent: bool,
+    pub minor_edit: bool,
+}
+
+/// One local file selected for attachment upload.
+#[derive(Debug, Clone)]
+pub struct AttachmentUploadFile {
+    pub path: PathBuf,
+    pub name: Option<String>,
+    pub mime_type: Option<String>,
+}
+
+/// Attachment on an issue or issue comment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueAttachment {
+    pub id: String,
+    pub name: String,
+    pub size: i64,
+    pub mime_type: Option<String>,
+    pub url: Option<String>,
+    pub created: Option<DateTime<Utc>>,
+    pub author: Option<CommentAuthor>,
+    pub comment_id: Option<String>,
+    pub markdown: Option<String>,
 }
 
 /// Data for creating a new issue

--- a/crates/tracker-core/src/traits.rs
+++ b/crates/tracker-core/src/traits.rs
@@ -31,6 +31,46 @@ pub trait IssueTracker: Send + Sync {
     /// Delete an issue
     fn delete_issue(&self, id: &str) -> Result<()>;
 
+    // ========== Attachment Operations ==========
+
+    /// List attachments on an issue.
+    fn list_issue_attachments(&self, issue_id: &str) -> Result<Vec<IssueAttachment>> {
+        let _ = issue_id;
+        Err(crate::error::TrackerError::InvalidInput(
+            "Issue attachments are not supported by this backend".to_string(),
+        ))
+    }
+
+    /// Upload one or more files to an issue.
+    fn add_issue_attachment(
+        &self,
+        issue_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<IssueAttachment>> {
+        let _ = (issue_id, upload);
+        Err(crate::error::TrackerError::InvalidInput(
+            "Issue attachment upload is not supported by this backend".to_string(),
+        ))
+    }
+
+    /// Add a comment with one or more native attachments to an issue.
+    fn add_issue_comment_attachment(
+        &self,
+        issue_id: &str,
+        text: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Comment> {
+        let _ = (issue_id, text, upload);
+        Err(crate::error::TrackerError::InvalidInput(
+            "Issue comment attachment upload is not supported by this backend".to_string(),
+        ))
+    }
+
+    /// Whether this backend supports native attachments on issue comments.
+    fn supports_issue_comment_attachments(&self) -> bool {
+        false
+    }
+
     // ========== Project Operations ==========
 
     /// List all projects
@@ -250,6 +290,18 @@ pub trait KnowledgeBase: Send + Sync {
     /// List attachments on an article
     fn list_article_attachments(&self, article_id: &str) -> Result<Vec<ArticleAttachment>>;
 
+    /// Upload one or more files to an article.
+    fn add_article_attachment(
+        &self,
+        article_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ArticleAttachment>> {
+        let _ = (article_id, upload);
+        Err(crate::error::TrackerError::InvalidInput(
+            "Article attachment upload is not supported by this backend".to_string(),
+        ))
+    }
+
     // ========== Comment Operations ==========
 
     /// Get comments on an article
@@ -257,4 +309,22 @@ pub trait KnowledgeBase: Send + Sync {
 
     /// Add a comment to an article
     fn add_article_comment(&self, article_id: &str, text: &str) -> Result<Comment>;
+
+    /// Add a comment with one or more native attachments to an article.
+    fn add_article_comment_attachment(
+        &self,
+        article_id: &str,
+        text: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Comment> {
+        let _ = (article_id, text, upload);
+        Err(crate::error::TrackerError::InvalidInput(
+            "Article comment attachment upload is not supported by this backend".to_string(),
+        ))
+    }
+
+    /// Whether this backend supports native attachments on article comments.
+    fn supports_article_comment_attachments(&self) -> bool {
+        false
+    }
 }

--- a/crates/youtrack-backend/src/client.rs
+++ b/crates/youtrack-backend/src/client.rs
@@ -2,7 +2,9 @@ use crate::error::{Result, YouTrackError};
 use crate::models::*;
 use std::collections::HashMap;
 use std::time::Duration;
+use tracker_core::AttachmentUpload;
 use ureq::Agent;
+use ureq::unversioned::multipart::{Form, Part};
 
 const DEFAULT_ISSUE_FIELDS: &str = "id,idReadable,summary,description,project(id,name,shortName),customFields(name,$type,value(name,login,isResolved,text)),tags(id,name),created,updated";
 const DEFAULT_PROJECT_FIELDS: &str = "id,name,shortName,description";
@@ -909,6 +911,101 @@ impl YouTrackClient {
             .header("Authorization", &self.auth_header())
             .header("Accept", "application/json")
             .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let attachments: Vec<ArticleAttachment> = response.body_mut().read_json()?;
+        Ok(attachments)
+    }
+
+    /// Upload attachments to an article.
+    pub fn add_article_attachments(
+        &self,
+        article_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ArticleAttachment>> {
+        if upload.comment.is_some() {
+            return Err(YouTrackError::Api {
+                status: 0,
+                message: "YouTrack article attachment upload does not support --comment"
+                    .to_string(),
+            });
+        }
+        if upload.minor_edit {
+            return Err(YouTrackError::Api {
+                status: 0,
+                message: "YouTrack article attachment upload does not support --minor-edit"
+                    .to_string(),
+            });
+        }
+
+        let mut url = format!(
+            "{}/api/articles/{}/attachments?fields=id,name,size,mimeType,url,created,author(login,name)",
+            self.base_url, article_id
+        );
+        if upload.silent {
+            url.push_str("&muteUpdateNotifications=true");
+        }
+
+        self.post_article_attachment_form(&url, upload)
+    }
+
+    /// Upload attachments to an article comment.
+    pub fn add_article_comment_attachments(
+        &self,
+        article_id: &str,
+        comment_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ArticleAttachment>> {
+        if upload.comment.is_some() {
+            return Err(YouTrackError::Api {
+                status: 0,
+                message: "YouTrack article comment attachment upload does not support --comment"
+                    .to_string(),
+            });
+        }
+        if upload.minor_edit {
+            return Err(YouTrackError::Api {
+                status: 0,
+                message: "YouTrack article comment attachment upload does not support --minor-edit"
+                    .to_string(),
+            });
+        }
+
+        let mut url = format!(
+            "{}/api/articles/{}/comments/{}/attachments?fields=id,name,size,mimeType,url,created,author(login,name)",
+            self.base_url, article_id, comment_id
+        );
+        if upload.silent {
+            url.push_str("&muteUpdateNotifications=true");
+        }
+
+        self.post_article_attachment_form(&url, upload)
+    }
+
+    fn post_article_attachment_form(
+        &self,
+        url: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ArticleAttachment>> {
+        let mut form = Form::new();
+        for file in &upload.files {
+            let mut part = Part::file(&file.path)?;
+            if let Some(name) = &file.name {
+                part = part.file_name(name);
+            }
+            if let Some(mime_type) = &file.mime_type {
+                part = part.mime_str(mime_type)?;
+            }
+            form = form.part("upload", part);
+        }
+
+        let response = self
+            .agent
+            .post(url)
+            .header("Authorization", &self.auth_header())
+            .header("Accept", "application/json")
+            .send(form)
             .map_err(|e| self.handle_error(e))?;
 
         let mut response = self.check_response(response)?;

--- a/crates/youtrack-backend/src/client.rs
+++ b/crates/youtrack-backend/src/client.rs
@@ -2,7 +2,9 @@ use crate::error::{Result, YouTrackError};
 use crate::models::*;
 use std::collections::HashMap;
 use std::time::Duration;
+use tracker_core::AttachmentUpload;
 use ureq::Agent;
+use ureq::unversioned::multipart::{Form, Part};
 
 const DEFAULT_ISSUE_FIELDS: &str = "id,idReadable,summary,description,project(id,name,shortName),customFields(name,$type,value(name,login,isResolved,text)),tags(id,name),created,updated";
 const DEFAULT_PROJECT_FIELDS: &str = "id,name,shortName,description";
@@ -295,6 +297,106 @@ impl YouTrackClient {
 
         self.check_response(response)?;
         Ok(())
+    }
+
+    /// List attachments on an issue.
+    pub fn list_issue_attachments(&self, issue_id: &str) -> Result<Vec<IssueAttachment>> {
+        let url = format!(
+            "{}/api/issues/{}/attachments?fields=id,name,size,mimeType,url,created,author(login,name),comment(id)",
+            self.base_url, issue_id
+        );
+
+        let response = self
+            .agent
+            .get(&url)
+            .header("Authorization", &self.auth_header())
+            .header("Accept", "application/json")
+            .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let attachments: Vec<IssueAttachment> = response.body_mut().read_json()?;
+        Ok(attachments)
+    }
+
+    /// Upload attachments to an issue.
+    pub fn add_issue_attachments(
+        &self,
+        issue_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<IssueAttachment>> {
+        if upload.comment.is_some() {
+            return Err(YouTrackError::Api {
+                status: 0,
+                message: "YouTrack issue attachment upload does not support --comment".to_string(),
+            });
+        }
+
+        let mut url = format!(
+            "{}/api/issues/{}/attachments?fields=id,name,size,mimeType,url,created,author(login,name),comment(id)",
+            self.base_url, issue_id
+        );
+        if upload.silent {
+            url.push_str("&muteUpdateNotifications=true");
+        }
+
+        self.post_issue_attachment_form(&url, upload)
+    }
+
+    /// Upload attachments to an issue comment.
+    pub fn add_issue_comment_attachments(
+        &self,
+        issue_id: &str,
+        comment_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<IssueAttachment>> {
+        if upload.comment.is_some() {
+            return Err(YouTrackError::Api {
+                status: 0,
+                message: "YouTrack issue comment attachment upload does not support --comment"
+                    .to_string(),
+            });
+        }
+
+        let mut url = format!(
+            "{}/api/issues/{}/comments/{}/attachments?fields=id,name,size,mimeType,url,created,author(login,name),comment(id)",
+            self.base_url, issue_id, comment_id
+        );
+        if upload.silent {
+            url.push_str("&muteUpdateNotifications=true");
+        }
+
+        self.post_issue_attachment_form(&url, upload)
+    }
+
+    fn post_issue_attachment_form(
+        &self,
+        url: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<IssueAttachment>> {
+        let mut form = Form::new();
+        for file in &upload.files {
+            let mut part = Part::file(&file.path)?;
+            if let Some(name) = &file.name {
+                part = part.file_name(name);
+            }
+            if let Some(mime_type) = &file.mime_type {
+                part = part.mime_str(mime_type)?;
+            }
+            form = form.part("upload", part);
+        }
+
+        let response = self
+            .agent
+            .post(url)
+            .header("Authorization", &self.auth_header())
+            .header("Accept", "application/json")
+            .send(form)
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let attachments: Vec<IssueAttachment> = response.body_mut().read_json()?;
+        Ok(attachments)
     }
 
     pub fn list_projects(&self) -> Result<Vec<Project>> {

--- a/crates/youtrack-backend/src/client_tests.rs
+++ b/crates/youtrack-backend/src/client_tests.rs
@@ -2,7 +2,8 @@
 mod tests {
     use crate::client::YouTrackClient;
     use crate::models::*;
-    use wiremock::matchers::{body_json, header, method, path, query_param};
+    use tracker_core::{AttachmentUpload, AttachmentUploadFile};
+    use wiremock::matchers::{body_json, body_string_contains, header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -560,6 +561,55 @@ mod tests {
         assert_eq!(attachments[0].name, "document.pdf");
         assert_eq!(attachments[0].size, 102400);
         assert_eq!(attachments[1].name, "image.png");
+    }
+
+    #[tokio::test]
+    async fn test_add_article_attachment_uses_upload_multipart_field() {
+        let mock_server = MockServer::start().await;
+        let dir = std::env::temp_dir().join(format!(
+            "track-youtrack-article-attachment-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("article.txt");
+        std::fs::write(&file, "attachment body").unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/api/articles/KB-A-1/attachments"))
+            .and(header("Authorization", "Bearer test-token"))
+            .and(header("Accept", "application/json"))
+            .and(body_string_contains(
+                "Content-Disposition: form-data; name=\"upload\"; filename=\"article.txt\"",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "att-3",
+                    "name": "article.txt",
+                    "size": 15,
+                    "mimeType": "text/plain",
+                    "created": 1640000000000i64
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let upload = AttachmentUpload {
+            files: vec![AttachmentUploadFile {
+                path: file,
+                name: None,
+                mime_type: Some("text/plain".to_string()),
+            }],
+            comment: None,
+            silent: false,
+            minor_edit: false,
+        };
+
+        let attachments = client.add_article_attachments("KB-A-1", &upload).unwrap();
+
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].name, "article.txt");
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[tokio::test]

--- a/crates/youtrack-backend/src/client_tests.rs
+++ b/crates/youtrack-backend/src/client_tests.rs
@@ -2,8 +2,21 @@
 mod tests {
     use crate::client::YouTrackClient;
     use crate::models::*;
-    use wiremock::matchers::{body_json, header, method, path, query_param};
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tracker_core::{AttachmentUpload, AttachmentUploadFile};
+    use wiremock::matchers::{body_json, body_string_contains, header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn temp_upload_file(name: &str, contents: &[u8]) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("track-yt-upload-{nanos}-{name}"));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
 
     #[tokio::test]
     async fn test_get_issue() {
@@ -180,6 +193,49 @@ mod tests {
         let client = YouTrackClient::new(&mock_server.uri(), "test-token");
         let result = client.delete_issue("PROJ-123");
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_add_issue_attachment_uses_upload_multipart_field() {
+        let mock_server = MockServer::start().await;
+        let upload_path = temp_upload_file("evidence.txt", b"evidence");
+
+        Mock::given(method("POST"))
+            .and(path("/api/issues/PROJ-123/attachments"))
+            .and(header("Authorization", "Bearer test-token"))
+            .and(body_string_contains("name=\"upload\""))
+            .and(body_string_contains("filename=\"custom.txt\""))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "att-1",
+                    "name": "custom.txt",
+                    "size": 8,
+                    "mimeType": "text/plain",
+                    "url": "https://youtrack.example/attachments/custom.txt"
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let upload = AttachmentUpload {
+            files: vec![AttachmentUploadFile {
+                path: upload_path.clone(),
+                name: Some("custom.txt".to_string()),
+                mime_type: Some("text/plain".to_string()),
+            }],
+            comment: None,
+            silent: false,
+            minor_edit: false,
+        };
+
+        let attachments = client
+            .add_issue_attachments("PROJ-123", &upload)
+            .expect("issue attachment upload should succeed");
+
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].name, "custom.txt");
+        let _ = std::fs::remove_file(upload_path);
     }
 
     #[tokio::test]

--- a/crates/youtrack-backend/src/convert.rs
+++ b/crates/youtrack-backend/src/convert.rs
@@ -220,6 +220,26 @@ impl From<yt::IssueComment> for core::Comment {
     }
 }
 
+/// Convert YouTrack IssueAttachment to tracker-core IssueAttachment
+impl From<yt::IssueAttachment> for core::IssueAttachment {
+    fn from(attachment: yt::IssueAttachment) -> Self {
+        Self {
+            id: attachment.id,
+            name: attachment.name,
+            size: attachment.size,
+            mime_type: attachment.mime_type,
+            url: attachment.url,
+            created: attachment.created,
+            author: attachment.author.map(|a| core::CommentAuthor {
+                login: a.login,
+                name: a.name,
+            }),
+            comment_id: attachment.comment.map(|comment| comment.id),
+            markdown: None,
+        }
+    }
+}
+
 /// Convert tracker-core CreateIssue to YouTrack CreateIssue
 impl From<&core::CreateIssue> for yt::CreateIssue {
     fn from(create: &core::CreateIssue) -> Self {

--- a/crates/youtrack-backend/src/models/issue.rs
+++ b/crates/youtrack-backend/src/models/issue.rs
@@ -259,6 +259,31 @@ pub struct IssueComment {
     pub created: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Issue attachment
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueAttachment {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub size: i64,
+    #[serde(default)]
+    pub mime_type: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default, with = "chrono::serde::ts_milliseconds_option")]
+    pub created: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub author: Option<CommentAuthor>,
+    #[serde(default)]
+    pub comment: Option<IssueCommentRef>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct IssueCommentRef {
+    pub id: String,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct CommentAuthor {
     pub login: String,

--- a/crates/youtrack-backend/src/trait_impl.rs
+++ b/crates/youtrack-backend/src/trait_impl.rs
@@ -7,8 +7,8 @@ use crate::models::{
     CreateCustomFieldRequest, CreateIssueTagRequest, CustomFieldRef, FieldTypeRef, TagColorRequest,
 };
 use tracker_core::{
-    Article, ArticleAttachment, AttachFieldToProject, BundleDefinition, BundleType,
-    BundleValueDefinition, Comment, CreateArticle, CreateBundle, CreateBundleValue,
+    Article, ArticleAttachment, AttachFieldToProject, AttachmentUpload, BundleDefinition,
+    BundleType, BundleValueDefinition, Comment, CreateArticle, CreateBundle, CreateBundleValue,
     CreateCustomField, CreateIssue, CreateProject, CreateTag, CustomFieldDefinition, Issue,
     IssueLink, IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project, ProjectCustomField,
     Result, SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
@@ -375,6 +375,18 @@ impl KnowledgeBase for YouTrackClient {
             .collect())
     }
 
+    fn add_article_attachment(
+        &self,
+        article_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<ArticleAttachment>> {
+        Ok(self
+            .add_article_attachments(article_id, upload)?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
     fn get_article_comments(&self, article_id: &str) -> Result<Vec<Comment>> {
         Ok(self
             .get_article_comments(article_id)?
@@ -385,5 +397,20 @@ impl KnowledgeBase for YouTrackClient {
 
     fn add_article_comment(&self, article_id: &str, text: &str) -> Result<Comment> {
         Ok(self.add_article_comment(article_id, text)?.into())
+    }
+
+    fn add_article_comment_attachment(
+        &self,
+        article_id: &str,
+        text: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Comment> {
+        let comment = self.add_article_comment(article_id, text)?;
+        self.add_article_comment_attachments(article_id, &comment.id, upload)?;
+        Ok(comment.into())
+    }
+
+    fn supports_article_comment_attachments(&self) -> bool {
+        true
     }
 }

--- a/crates/youtrack-backend/src/trait_impl.rs
+++ b/crates/youtrack-backend/src/trait_impl.rs
@@ -7,11 +7,11 @@ use crate::models::{
     CreateCustomFieldRequest, CreateIssueTagRequest, CustomFieldRef, FieldTypeRef, TagColorRequest,
 };
 use tracker_core::{
-    Article, ArticleAttachment, AttachFieldToProject, BundleDefinition, BundleType,
-    BundleValueDefinition, Comment, CreateArticle, CreateBundle, CreateBundleValue,
+    Article, ArticleAttachment, AttachFieldToProject, AttachmentUpload, BundleDefinition,
+    BundleType, BundleValueDefinition, Comment, CreateArticle, CreateBundle, CreateBundleValue,
     CreateCustomField, CreateIssue, CreateProject, CreateTag, CustomFieldDefinition, Issue,
-    IssueLink, IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project, ProjectCustomField,
-    Result, SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
+    IssueAttachment, IssueLink, IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project,
+    ProjectCustomField, Result, SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
 };
 
 impl IssueTracker for YouTrackClient {
@@ -56,6 +56,26 @@ impl IssueTracker for YouTrackClient {
 
     fn delete_issue(&self, id: &str) -> Result<()> {
         Ok(self.delete_issue(id)?)
+    }
+
+    fn list_issue_attachments(&self, issue_id: &str) -> Result<Vec<IssueAttachment>> {
+        Ok(self
+            .list_issue_attachments(issue_id)?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
+    fn add_issue_attachment(
+        &self,
+        issue_id: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Vec<IssueAttachment>> {
+        Ok(self
+            .add_issue_attachments(issue_id, upload)?
+            .into_iter()
+            .map(Into::into)
+            .collect())
     }
 
     fn list_projects(&self) -> Result<Vec<Project>> {
@@ -174,6 +194,21 @@ impl IssueTracker for YouTrackClient {
 
     fn add_comment(&self, issue_id: &str, text: &str) -> Result<Comment> {
         Ok(self.add_comment(issue_id, text)?.into())
+    }
+
+    fn add_issue_comment_attachment(
+        &self,
+        issue_id: &str,
+        text: &str,
+        upload: &AttachmentUpload,
+    ) -> Result<Comment> {
+        let comment = self.add_comment(issue_id, text)?;
+        self.add_issue_comment_attachments(issue_id, &comment.id, upload)?;
+        Ok(comment.into())
+    }
+
+    fn supports_issue_comment_attachments(&self) -> bool {
+        true
     }
 
     fn get_comments(&self, issue_id: &str) -> Result<Vec<Comment>> {


### PR DESCRIPTION
## Summary

Adds attachment upload support across the `track` CLI:

- shared attachment upload/result models and trait defaults
- `issue attachments`, `issue attach`, and `issue comment --attach`
- `article attach` and `article comment --attach`
- YouTrack issue/article native uploads
- Jira issue uploads and Confluence page/comment uploads
- GitHub wiki-backed article attachment fallback and explicit unsupported issue attachment errors
- GitLab issue upload fallback through project uploads plus issue notes, and restored GitLab wiki article support

## Validation

- `cargo test --workspace`
- Built `./target/debug/track`
- Live validated YouTrack issue/article attachment upload, listing, and comment attachment flows
- Live validated Jira issue attachment upload/list and unsupported issue comment attachment preflight
- Live validated Confluence article attachment upload/list and article comment attachment upload
- Live validated GitHub issue attachment unsupported behavior and wiki-backed article attachment upload/list
