### PR TITLE
fix(jira): redirect time tracking fields to composite payload

### DIFF
--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -414,8 +414,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/rest/api/3/issue/TEST-123"))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(mock_jira_issue("TEST-123", "Summary")),
+                ResponseTemplate::new(200).set_body_json(mock_jira_issue("TEST-123", "Summary")),
             )
             .mount(&mock_server)
             .await;
@@ -423,9 +422,12 @@ mod tests {
         let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
 
         let mut extra = std::collections::HashMap::new();
-        extra.insert("timetracking".to_string(), serde_json::json!({
-            "originalEstimate": "4h"
-        }));
+        extra.insert(
+            "timetracking".to_string(),
+            serde_json::json!({
+                "originalEstimate": "4h"
+            }),
+        );
 
         let update = UpdateJiraIssue {
             fields: UpdateJiraIssueFields {

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -393,6 +393,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_issue_with_time_tracking() {
+        let mock_server = MockServer::start().await;
+
+        // First mock: update returns 204 No Content and asserts body format
+        Mock::given(method("PUT"))
+            .and(path("/rest/api/3/issue/TEST-123"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "fields": {
+                    "timetracking": {
+                        "originalEstimate": "4h"
+                    }
+                }
+            })))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        // Second mock: get issue to fetch updated details
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-123"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(mock_jira_issue("TEST-123", "Summary")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("timetracking".to_string(), serde_json::json!({
+            "originalEstimate": "4h"
+        }));
+
+        let update = UpdateJiraIssue {
+            fields: UpdateJiraIssueFields {
+                summary: None,
+                description: None,
+                priority: None,
+                labels: None,
+                parent: None,
+                extra,
+            },
+        };
+
+        let _issue = client.update_issue("TEST-123", &update).unwrap();
+    }
+
+    #[tokio::test]
     async fn test_delete_issue() {
         let mock_server = MockServer::start().await;
 

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -749,11 +749,37 @@ pub fn resolve_extra_fields(
         }
 
         if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
-            let schema = schema_map.get(field_id.as_str()).copied();
-            extra.insert(
-                field_id.clone(),
-                custom_field_to_json(field_id, value, schema),
-            );
+            match field_id.as_str() {
+                "timeoriginalestimate" => {
+                    let entry = extra
+                        .entry("timetracking".into())
+                        .or_insert_with(|| serde_json::json!({}));
+                    if let Some(map) = entry.as_object_mut() {
+                        map.insert(
+                            "originalEstimate".into(),
+                            serde_json::Value::String(value.into()),
+                        );
+                    }
+                }
+                "timeestimate" => {
+                    let entry = extra
+                        .entry("timetracking".into())
+                        .or_insert_with(|| serde_json::json!({}));
+                    if let Some(map) = entry.as_object_mut() {
+                        map.insert(
+                            "remainingEstimate".into(),
+                            serde_json::Value::String(value.into()),
+                        );
+                    }
+                }
+                _ => {
+                    let schema = schema_map.get(field_id.as_str()).copied();
+                    extra.insert(
+                        field_id.clone(),
+                        custom_field_to_json(field_id, value, schema),
+                    );
+                }
+            }
         }
     }
 
@@ -888,6 +914,53 @@ mod tests {
         let jira = update_issue_to_jira(&update, &fields);
         let json = serde_json::to_value(&jira).unwrap();
         assert_eq!(json["fields"]["customfield_10016"], 8.0);
+    }
+
+    #[test]
+    fn resolve_extra_fields_redirects_timetracking() {
+        let custom_fields = vec![
+            CustomFieldUpdate::SingleEnum {
+                name: "Original Estimate".to_string(),
+                value: "4h".to_string(),
+            },
+            CustomFieldUpdate::SingleEnum {
+                name: "Remaining Estimate".to_string(),
+                value: "2h".to_string(),
+            },
+        ];
+
+        let jira_fields = vec![
+            JiraField {
+                id: "timeoriginalestimate".to_string(),
+                name: "Original Estimate".to_string(),
+                custom: false,
+                schema: Some(JiraFieldSchema {
+                    field_type: "number".to_string(),
+                    custom: None,
+                    items: None,
+                }),
+            },
+            JiraField {
+                id: "timeestimate".to_string(),
+                name: "Remaining Estimate".to_string(),
+                custom: false,
+                schema: Some(JiraFieldSchema {
+                    field_type: "number".to_string(),
+                    custom: None,
+                    items: None,
+                }),
+            },
+        ];
+
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields);
+
+        assert!(!extra.contains_key("timeoriginalestimate"));
+        assert!(!extra.contains_key("timeestimate"));
+        assert!(extra.contains_key("timetracking"));
+
+        let timetracking = extra.get("timetracking").unwrap();
+        assert_eq!(timetracking["originalEstimate"], serde_json::json!("4h"));
+        assert_eq!(timetracking["remainingEstimate"], serde_json::json!("2h"));
     }
 
     #[test]

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -862,6 +862,27 @@ mod tests {
     }
 
     #[test]
+    fn update_issue_to_jira_redirects_estimate_to_timetracking() {
+        let update = UpdateIssue {
+            custom_fields: vec![CustomFieldUpdate::SingleEnum {
+                name: "Original Estimate".to_string(),
+                value: "4h".to_string(),
+            }],
+            ..Default::default()
+        };
+        let fields = vec![JiraField {
+            id: "timeoriginalestimate".to_string(),
+            name: "Original Estimate".to_string(),
+            custom: false,
+            schema: None,
+        }];
+        let jira = update_issue_to_jira(&update, &fields);
+        let json = serde_json::to_value(&jira).unwrap();
+        assert_eq!(json["fields"]["timetracking"]["originalEstimate"], "4h");
+        assert!(json["fields"].get("timeoriginalestimate").is_none());
+    }
+
+    #[test]
     fn update_issue_to_jira_maps_parent() {
         let update = UpdateIssue {
             summary: None,

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -393,7 +393,7 @@ impl From<JiraIssueLink> for IssueLink {
 /// Convert CreateIssue to Jira format.
 /// When `jira_fields` is provided, custom field updates are resolved to Jira field IDs
 /// and included in the request. Without it, only standard fields (priority, type, labels) are sent.
-pub fn create_issue_to_jira(issue: &CreateIssue, jira_fields: &[JiraField]) -> CreateJiraIssue {
+pub fn create_issue_to_jira(issue: &CreateIssue, jira_fields: &[JiraField]) -> tracker_core::Result<CreateJiraIssue> {
     let description = issue
         .description
         .as_ref()
@@ -424,9 +424,9 @@ pub fn create_issue_to_jira(issue: &CreateIssue, jira_fields: &[JiraField]) -> C
         })
         .unwrap_or_else(|| "Task".to_string());
 
-    let extra = resolve_extra_fields(&issue.custom_fields, jira_fields);
+    let extra = resolve_extra_fields(&issue.custom_fields, jira_fields)?;
 
-    CreateJiraIssue {
+    Ok(CreateJiraIssue {
         fields: CreateJiraIssueFields {
             project: ProjectId {
                 id: None,
@@ -450,13 +450,13 @@ pub fn create_issue_to_jira(issue: &CreateIssue, jira_fields: &[JiraField]) -> C
             }),
             extra,
         },
-    }
+    })
 }
 
 /// Convert UpdateIssue to Jira format.
 /// When `jira_fields` is provided, custom field updates are resolved to Jira field IDs
 /// and included in the request. Without it, only standard fields (priority, labels) are sent.
-pub fn update_issue_to_jira(update: &UpdateIssue, jira_fields: &[JiraField]) -> UpdateJiraIssue {
+pub fn update_issue_to_jira(update: &UpdateIssue, jira_fields: &[JiraField]) -> tracker_core::Result<UpdateJiraIssue> {
     let description = update
         .description
         .as_ref()
@@ -472,9 +472,9 @@ pub fn update_issue_to_jira(update: &UpdateIssue, jira_fields: &[JiraField]) -> 
         _ => None,
     });
 
-    let extra = resolve_extra_fields(&update.custom_fields, jira_fields);
+    let extra = resolve_extra_fields(&update.custom_fields, jira_fields)?;
 
-    UpdateJiraIssue {
+    Ok(UpdateJiraIssue {
         fields: UpdateJiraIssueFields {
             summary: update.summary.clone(),
             description,
@@ -490,7 +490,7 @@ pub fn update_issue_to_jira(update: &UpdateIssue, jira_fields: &[JiraField]) -> 
             }),
             extra,
         },
-    }
+    })
 }
 
 /// Parse Jira datetime string to chrono DateTime
@@ -746,7 +746,7 @@ fn insert_resolved_field(
     field_id: &str,
     value: &str,
     schema: Option<&JiraFieldSchema>,
-) {
+) -> tracker_core::Result<()> {
     match field_id {
         "timeoriginalestimate" => {
             let entry = extra
@@ -771,8 +771,9 @@ fn insert_resolved_field(
             }
         }
         "timespent" | "timetracking" => {
-            // Silently reject unsupported/read-only time tracking fields
-            // (Jira typically throws a 400 API error if we send these anyway)
+            return Err(tracker_core::TrackerError::InvalidInput(
+                "Time Spent and Time Tracking are read-only via --field. Use `track issue worklog add` for logged time, or `--field 'Original Estimate' / 'Remaining Estimate'` for estimates.".to_string(),
+            ));
         }
         _ => {
             extra.insert(
@@ -781,12 +782,13 @@ fn insert_resolved_field(
             );
         }
     }
+    Ok(())
 }
 
 pub fn resolve_extra_fields(
     custom_fields: &[CustomFieldUpdate],
     jira_fields: &[JiraField],
-) -> HashMap<String, serde_json::Value> {
+) -> tracker_core::Result<HashMap<String, serde_json::Value>> {
     let field_id_map = build_field_id_map(jira_fields);
     let schema_map: HashMap<&str, &JiraFieldSchema> = jira_fields
         .iter()
@@ -805,7 +807,7 @@ pub fn resolve_extra_fields(
                 }
                 if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
                     let schema = schema_map.get(field_id.as_str()).copied();
-                    insert_resolved_field(&mut extra, field_id, value, schema);
+                    insert_resolved_field(&mut extra, field_id, value, schema)?;
                 }
             }
             CustomFieldUpdate::MultiEnum { name, values } => {
@@ -815,13 +817,13 @@ pub fn resolve_extra_fields(
                 }
                 if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
                     let schema = schema_map.get(field_id.as_str()).copied();
-                    insert_resolved_field(&mut extra, field_id, &joined, schema);
+                    insert_resolved_field(&mut extra, field_id, &joined, schema)?;
                 }
             }
         }
     }
 
-    extra
+    Ok(extra)
 }
 
 #[cfg(test)]

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -103,29 +103,33 @@ pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
 
         if key == "timetracking" {
             if let Some(obj) = value.as_object() {
-                if let Some(orig) = obj.get("originalEstimate") {
-                    if let Some(cf) = json_value_to_custom_field("Original Estimate".to_string(), orig, None) {
-                        custom_fields.push(cf);
-                    }
+                if let Some(orig) = obj.get("originalEstimate")
+                    && let Some(cf) =
+                        json_value_to_custom_field("Original Estimate".to_string(), orig, None)
+                {
+                    custom_fields.push(cf);
                 }
-                if let Some(rem) = obj.get("remainingEstimate") {
-                    if let Some(cf) = json_value_to_custom_field("Remaining Estimate".to_string(), rem, None) {
-                        custom_fields.push(cf);
-                    }
+                if let Some(rem) = obj.get("remainingEstimate")
+                    && let Some(cf) =
+                        json_value_to_custom_field("Remaining Estimate".to_string(), rem, None)
+                {
+                    custom_fields.push(cf);
                 }
             }
         } else if key == "timeoriginalestimate" {
-             if let Some(cf) = json_value_to_custom_field("Original Estimate".to_string(), value, None) {
-                 custom_fields.push(cf);
-             }
+            if let Some(cf) =
+                json_value_to_custom_field("Original Estimate".to_string(), value, None)
+            {
+                custom_fields.push(cf);
+            }
         } else if key == "timeestimate" {
-             if let Some(cf) = json_value_to_custom_field("Remaining Estimate".to_string(), value, None) {
-                 custom_fields.push(cf);
-             }
-        } else {
-             if let Some(cf) = json_value_to_custom_field(name, value, schema) {
-                 custom_fields.push(cf);
-             }
+            if let Some(cf) =
+                json_value_to_custom_field("Remaining Estimate".to_string(), value, None)
+            {
+                custom_fields.push(cf);
+            }
+        } else if let Some(cf) = json_value_to_custom_field(name, value, schema) {
+            custom_fields.push(cf);
         }
     }
 
@@ -767,8 +771,8 @@ fn insert_resolved_field(
             }
         }
         "timespent" | "timetracking" => {
-             // Silently reject unsupported/read-only time tracking fields
-             // (Jira typically throws a 400 API error if we send these anyway)
+            // Silently reject unsupported/read-only time tracking fields
+            // (Jira typically throws a 400 API error if we send these anyway)
         }
         _ => {
             extra.insert(

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -709,6 +709,44 @@ fn is_reserved_field(name: &str) -> bool {
 
 /// Resolve custom field updates to Jira extra fields using field metadata.
 /// Returns a map of field_id → JSON value for fields not handled by the standard struct.
+fn insert_resolved_field(
+    extra: &mut HashMap<String, serde_json::Value>,
+    field_id: &str,
+    value: &str,
+    schema: Option<&JiraFieldSchema>,
+) {
+    match field_id {
+        "timeoriginalestimate" => {
+            let entry = extra
+                .entry("timetracking".into())
+                .or_insert_with(|| serde_json::json!({}));
+            if let Some(map) = entry.as_object_mut() {
+                map.insert(
+                    "originalEstimate".into(),
+                    serde_json::Value::String(value.into()),
+                );
+            }
+        }
+        "timeestimate" => {
+            let entry = extra
+                .entry("timetracking".into())
+                .or_insert_with(|| serde_json::json!({}));
+            if let Some(map) = entry.as_object_mut() {
+                map.insert(
+                    "remainingEstimate".into(),
+                    serde_json::Value::String(value.into()),
+                );
+            }
+        }
+        _ => {
+            extra.insert(
+                field_id.to_string(),
+                custom_field_to_json(field_id, value, schema),
+            );
+        }
+    }
+}
+
 pub fn resolve_extra_fields(
     custom_fields: &[CustomFieldUpdate],
     jira_fields: &[JiraField],
@@ -722,62 +760,26 @@ pub fn resolve_extra_fields(
     let mut extra = HashMap::new();
 
     for cf in custom_fields {
-        let (name, value) = match cf {
-            CustomFieldUpdate::SingleEnum { name, value } => (name.as_str(), value.as_str()),
-            CustomFieldUpdate::State { name, value } => (name.as_str(), value.as_str()),
-            CustomFieldUpdate::SingleUser { name, login } => (name.as_str(), login.as_str()),
+        match cf {
+            CustomFieldUpdate::SingleEnum { name, value }
+            | CustomFieldUpdate::State { name, value }
+            | CustomFieldUpdate::SingleUser { name, login: value } => {
+                if is_reserved_field(name) {
+                    continue;
+                }
+                if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
+                    let schema = schema_map.get(field_id.as_str()).copied();
+                    insert_resolved_field(&mut extra, field_id, value, schema);
+                }
+            }
             CustomFieldUpdate::MultiEnum { name, values } => {
-                // Handle multi-enum specially
                 let joined = values.join(",");
                 if is_reserved_field(name) {
                     continue;
                 }
                 if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
                     let schema = schema_map.get(field_id.as_str()).copied();
-                    extra.insert(
-                        field_id.clone(),
-                        custom_field_to_json(field_id, &joined, schema),
-                    );
-                }
-                continue;
-            }
-        };
-
-        // Skip standard fields handled by the struct
-        if is_reserved_field(name) {
-            continue;
-        }
-
-        if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
-            match field_id.as_str() {
-                "timeoriginalestimate" => {
-                    let entry = extra
-                        .entry("timetracking".into())
-                        .or_insert_with(|| serde_json::json!({}));
-                    if let Some(map) = entry.as_object_mut() {
-                        map.insert(
-                            "originalEstimate".into(),
-                            serde_json::Value::String(value.into()),
-                        );
-                    }
-                }
-                "timeestimate" => {
-                    let entry = extra
-                        .entry("timetracking".into())
-                        .or_insert_with(|| serde_json::json!({}));
-                    if let Some(map) = entry.as_object_mut() {
-                        map.insert(
-                            "remainingEstimate".into(),
-                            serde_json::Value::String(value.into()),
-                        );
-                    }
-                }
-                _ => {
-                    let schema = schema_map.get(field_id.as_str()).copied();
-                    extra.insert(
-                        field_id.clone(),
-                        custom_field_to_json(field_id, value, schema),
-                    );
+                    insert_resolved_field(&mut extra, field_id, &joined, schema);
                 }
             }
         }
@@ -961,6 +963,38 @@ mod tests {
         let timetracking = extra.get("timetracking").unwrap();
         assert_eq!(timetracking["originalEstimate"], serde_json::json!("4h"));
         assert_eq!(timetracking["remainingEstimate"], serde_json::json!("2h"));
+    }
+
+    #[test]
+    fn resolve_extra_fields_redirects_partial_timetracking() {
+        let custom_fields = vec![
+            CustomFieldUpdate::SingleEnum {
+                name: "Original Estimate".to_string(),
+                value: "4h".to_string(),
+            },
+        ];
+
+        let jira_fields = vec![
+            JiraField {
+                id: "timeoriginalestimate".to_string(),
+                name: "Original Estimate".to_string(),
+                custom: false,
+                schema: Some(JiraFieldSchema {
+                    field_type: "number".to_string(),
+                    custom: None,
+                    items: None,
+                }),
+            },
+        ];
+
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields);
+
+        assert!(!extra.contains_key("timeoriginalestimate"));
+        assert!(extra.contains_key("timetracking"));
+
+        let timetracking = extra.get("timetracking").unwrap();
+        assert_eq!(timetracking["originalEstimate"], serde_json::json!("4h"));
+        assert_eq!(timetracking.get("remainingEstimate"), None);
     }
 
     #[test]

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -85,7 +85,11 @@ pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
         .collect();
 
     for (key, value) in &j.fields.extra {
-        if !key.starts_with("customfield_") {
+        if !key.starts_with("customfield_")
+            && key != "timeoriginalestimate"
+            && key != "timeestimate"
+            && key != "timetracking"
+        {
             continue;
         }
         if value.is_null() {
@@ -96,8 +100,32 @@ pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
             .map(|n| n.to_string())
             .unwrap_or_else(|| key.clone());
         let schema = id_to_schema.get(key.as_str()).copied();
-        if let Some(cf) = json_value_to_custom_field(name, value, schema) {
-            custom_fields.push(cf);
+
+        if key == "timetracking" {
+            if let Some(obj) = value.as_object() {
+                if let Some(orig) = obj.get("originalEstimate") {
+                    if let Some(cf) = json_value_to_custom_field("Original Estimate".to_string(), orig, None) {
+                        custom_fields.push(cf);
+                    }
+                }
+                if let Some(rem) = obj.get("remainingEstimate") {
+                    if let Some(cf) = json_value_to_custom_field("Remaining Estimate".to_string(), rem, None) {
+                        custom_fields.push(cf);
+                    }
+                }
+            }
+        } else if key == "timeoriginalestimate" {
+             if let Some(cf) = json_value_to_custom_field("Original Estimate".to_string(), value, None) {
+                 custom_fields.push(cf);
+             }
+        } else if key == "timeestimate" {
+             if let Some(cf) = json_value_to_custom_field("Remaining Estimate".to_string(), value, None) {
+                 custom_fields.push(cf);
+             }
+        } else {
+             if let Some(cf) = json_value_to_custom_field(name, value, schema) {
+                 custom_fields.push(cf);
+             }
         }
     }
 
@@ -737,6 +765,10 @@ fn insert_resolved_field(
                     serde_json::Value::String(value.into()),
                 );
             }
+        }
+        "timespent" | "timetracking" => {
+             // Silently reject unsupported/read-only time tracking fields
+             // (Jira typically throws a 400 API error if we send these anyway)
         }
         _ => {
             extra.insert(

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -967,25 +967,21 @@ mod tests {
 
     #[test]
     fn resolve_extra_fields_redirects_partial_timetracking() {
-        let custom_fields = vec![
-            CustomFieldUpdate::SingleEnum {
-                name: "Original Estimate".to_string(),
-                value: "4h".to_string(),
-            },
-        ];
+        let custom_fields = vec![CustomFieldUpdate::SingleEnum {
+            name: "Original Estimate".to_string(),
+            value: "4h".to_string(),
+        }];
 
-        let jira_fields = vec![
-            JiraField {
-                id: "timeoriginalestimate".to_string(),
-                name: "Original Estimate".to_string(),
-                custom: false,
-                schema: Some(JiraFieldSchema {
-                    field_type: "number".to_string(),
-                    custom: None,
-                    items: None,
-                }),
-            },
-        ];
+        let jira_fields = vec![JiraField {
+            id: "timeoriginalestimate".to_string(),
+            name: "Original Estimate".to_string(),
+            custom: false,
+            schema: Some(JiraFieldSchema {
+                field_type: "number".to_string(),
+                custom: None,
+                items: None,
+            }),
+        }];
 
         let extra = resolve_extra_fields(&custom_fields, &jira_fields);
 

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -842,7 +842,7 @@ mod tests {
             parent: Some("PROJ-100".to_string()),
         };
 
-        let jira = create_issue_to_jira(&issue, &[]);
+        let jira = create_issue_to_jira(&issue, &[]).unwrap();
         let parent = jira.fields.parent.expect("parent should be set");
         assert_eq!(parent.key.as_deref(), Some("PROJ-100"));
         assert!(parent.id.is_none());
@@ -859,7 +859,7 @@ mod tests {
             parent: None,
         };
 
-        let jira = create_issue_to_jira(&issue, &[]);
+        let jira = create_issue_to_jira(&issue, &[]).unwrap();
         assert!(jira.fields.parent.is_none());
     }
 
@@ -878,7 +878,7 @@ mod tests {
             custom: false,
             schema: None,
         }];
-        let jira = update_issue_to_jira(&update, &fields);
+        let jira = update_issue_to_jira(&update, &fields).unwrap();
         let json = serde_json::to_value(&jira).unwrap();
         assert_eq!(json["fields"]["timetracking"]["originalEstimate"], "4h");
         assert!(json["fields"].get("timeoriginalestimate").is_none());
@@ -894,7 +894,7 @@ mod tests {
             parent: Some("PROJ-200".to_string()),
         };
 
-        let jira = update_issue_to_jira(&update, &[]);
+        let jira = update_issue_to_jira(&update, &[]).unwrap();
         let parent = jira.fields.parent.expect("parent should be set");
         assert_eq!(parent.key.as_deref(), Some("PROJ-200"));
     }
@@ -909,7 +909,7 @@ mod tests {
             parent: Some("DS-100".to_string()),
         };
 
-        let jira = update_issue_to_jira(&update, &[]);
+        let jira = update_issue_to_jira(&update, &[]).unwrap();
         let json = serde_json::to_value(&jira).unwrap();
 
         // parent.key should be present, parent.id should be omitted
@@ -943,7 +943,7 @@ mod tests {
             }),
         }];
 
-        let jira = create_issue_to_jira(&issue, &fields);
+        let jira = create_issue_to_jira(&issue, &fields).unwrap();
         let json = serde_json::to_value(&jira).unwrap();
         assert_eq!(json["fields"]["customfield_10016"], 5.0);
     }
@@ -972,7 +972,7 @@ mod tests {
             }),
         }];
 
-        let jira = update_issue_to_jira(&update, &fields);
+        let jira = update_issue_to_jira(&update, &fields).unwrap();
         let json = serde_json::to_value(&jira).unwrap();
         assert_eq!(json["fields"]["customfield_10016"], 8.0);
     }
@@ -1013,7 +1013,7 @@ mod tests {
             },
         ];
 
-        let extra = resolve_extra_fields(&custom_fields, &jira_fields);
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields).unwrap();
 
         assert!(!extra.contains_key("timeoriginalestimate"));
         assert!(!extra.contains_key("timeestimate"));
@@ -1042,7 +1042,7 @@ mod tests {
             }),
         }];
 
-        let extra = resolve_extra_fields(&custom_fields, &jira_fields);
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields).unwrap();
 
         assert!(!extra.contains_key("timeoriginalestimate"));
         assert!(extra.contains_key("timetracking"));
@@ -1092,7 +1092,7 @@ mod tests {
             },
         ];
 
-        let extra = resolve_extra_fields(&custom_fields, &jira_fields);
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields).unwrap();
         // Priority and State should be skipped (handled by struct/transitions),
         // Story Points should be resolved
         assert!(!extra.contains_key("priority"));

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -393,7 +393,10 @@ impl From<JiraIssueLink> for IssueLink {
 /// Convert CreateIssue to Jira format.
 /// When `jira_fields` is provided, custom field updates are resolved to Jira field IDs
 /// and included in the request. Without it, only standard fields (priority, type, labels) are sent.
-pub fn create_issue_to_jira(issue: &CreateIssue, jira_fields: &[JiraField]) -> tracker_core::Result<CreateJiraIssue> {
+pub fn create_issue_to_jira(
+    issue: &CreateIssue,
+    jira_fields: &[JiraField],
+) -> tracker_core::Result<CreateJiraIssue> {
     let description = issue
         .description
         .as_ref()
@@ -456,7 +459,10 @@ pub fn create_issue_to_jira(issue: &CreateIssue, jira_fields: &[JiraField]) -> t
 /// Convert UpdateIssue to Jira format.
 /// When `jira_fields` is provided, custom field updates are resolved to Jira field IDs
 /// and included in the request. Without it, only standard fields (priority, labels) are sent.
-pub fn update_issue_to_jira(update: &UpdateIssue, jira_fields: &[JiraField]) -> tracker_core::Result<UpdateJiraIssue> {
+pub fn update_issue_to_jira(
+    update: &UpdateIssue,
+    jira_fields: &[JiraField],
+) -> tracker_core::Result<UpdateJiraIssue> {
     let description = update
         .description
         .as_ref()

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -50,7 +50,7 @@ impl IssueTracker for JiraClient {
 
     fn create_issue(&self, issue: &CreateIssue) -> Result<Issue> {
         let fields = self.get_fields_cached();
-        let jira_issue = create_issue_to_jira(issue, &fields);
+        let jira_issue = create_issue_to_jira(issue, &fields)?;
         let created = self.create_issue(&jira_issue)?;
         Ok(jira_issue_to_core(created, &fields))
     }
@@ -85,7 +85,7 @@ impl IssueTracker for JiraClient {
             || stripped.parent.is_some();
 
         if has_field_updates {
-            let jira_update = update_issue_to_jira(&stripped, &fields);
+            let jira_update = update_issue_to_jira(&stripped, &fields)?;
             self.update_issue(id, &jira_update)?;
         }
 


### PR DESCRIPTION
Fixes issue #221 where Jira's time tracking fields could not be set via the CLI because they were routed to read-only projections rather than the writable composite object payload.

---
*PR created automatically by Jules for task [1387077186976743452](https://jules.google.com/task/1387077186976743452) started by @johnsdav*