### PR TITLE
🛡️ Sentinel: [High] Fix missing restrictive permissions for config and cache files

### DIFF
--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -646,6 +646,15 @@ impl TrackerCache {
         {
             let mut file = File::create(&temp_path)
                 .with_context(|| format!("Failed to create temp file: {}", temp_path.display()))?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = file.metadata()?.permissions();
+                perms.set_mode(0o600);
+                file.set_permissions(perms)?;
+            }
+
             file.write_all(content).with_context(|| {
                 format!("Failed to write to temp file: {}", temp_path.display())
             })?;

--- a/crates/track/src/config.rs
+++ b/crates/track/src/config.rs
@@ -303,6 +303,17 @@ impl Config {
         let toml_string = toml::to_string_pretty(self)
             .map_err(|e| anyhow!("Failed to serialize config: {}", e))?;
         fs::write(path, toml_string).map_err(|e| anyhow!("Failed to write config file: {}", e))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(metadata) = fs::metadata(path) {
+                let mut perms = metadata.permissions();
+                perms.set_mode(0o600);
+                let _ = fs::set_permissions(path, perms);
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Severity: High

Vulnerability: Missing restrictive permissions for configuration and cache files (`.track.toml` and files in `.tracker-cache`). These files contain sensitive data (API tokens, cached issue data) but were previously created with default file permissions, making them potentially readable by other users on the system.

Impact: Unauthorized users with access to the system could read API tokens or sensitive project data.

Fix: Added explicit permission setting (`0o600`) to `crates/track/src/config.rs` (`save`) and `crates/track/src/cache.rs` (`atomic_write`) on Unix systems using `std::os::unix::fs::PermissionsExt`.

Verification: Tests and clippy pass.

---
*PR created automatically by Jules for task [2943790201918673669](https://jules.google.com/task/2943790201918673669) started by @johnsdav*