### PR TITLE
⚡ Bolt: [performance improvement] Avoid allocations in Jira field ID map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ F
 CLAUDE.md
 GEMINI.md
 AGENTS.md
+.jules/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,0 @@
-- **HashMap Pre-allocation and Borrowing:** Avoided cloning strings and reallocations in `build_field_id_map` by preallocating the map with `HashMap::with_capacity(fields.len() + 5)` and borrowing standard fields with `&str`. This prevents allocating new strings during metadata evaluation in the `resolve_extra_fields` hot path, while still passing correctness checks.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,1 @@
+- **HashMap Pre-allocation and Borrowing:** Avoided cloning strings and reallocations in `build_field_id_map` by preallocating the map with `HashMap::with_capacity(fields.len() + 5)` and borrowing standard fields with `&str`. This prevents allocating new strings during metadata evaluation in the `resolve_extra_fields` hot path, while still passing correctness checks.

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -733,9 +733,9 @@ pub fn resolve_extra_fields(
                     continue;
                 }
                 if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
-            let schema = schema_map.get(*field_id).copied();
+                    let schema = schema_map.get(*field_id).copied();
                     extra.insert(
-                field_id.to_string(),
+                        field_id.to_string(),
                         custom_field_to_json(field_id, &joined, schema),
                     );
                 }

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -630,17 +630,17 @@ pub fn flatten_project_statuses(
 }
 
 /// Build a name → field ID lookup from JiraField metadata.
-pub fn build_field_id_map(fields: &[JiraField]) -> HashMap<String, String> {
-    let mut map = HashMap::new();
+pub fn build_field_id_map(fields: &[JiraField]) -> HashMap<String, &str> {
+    let mut map = HashMap::with_capacity(fields.len() + 5);
     for field in fields {
-        map.insert(field.name.to_lowercase(), field.id.clone());
+        map.insert(field.name.to_lowercase(), field.id.as_str());
     }
     // Also insert known standard field name mappings
-    map.insert("priority".to_string(), "priority".to_string());
-    map.insert("assignee".to_string(), "assignee".to_string());
-    map.insert("status".to_string(), "status".to_string());
-    map.insert("type".to_string(), "issuetype".to_string());
-    map.insert("labels".to_string(), "labels".to_string());
+    map.insert("priority".to_string(), "priority");
+    map.insert("assignee".to_string(), "assignee");
+    map.insert("status".to_string(), "status");
+    map.insert("type".to_string(), "issuetype");
+    map.insert("labels".to_string(), "labels");
     map
 }
 
@@ -733,9 +733,9 @@ pub fn resolve_extra_fields(
                     continue;
                 }
                 if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
-                    let schema = schema_map.get(field_id.as_str()).copied();
+            let schema = schema_map.get(*field_id).copied();
                     extra.insert(
-                        field_id.clone(),
+                field_id.to_string(),
                         custom_field_to_json(field_id, &joined, schema),
                     );
                 }
@@ -749,9 +749,9 @@ pub fn resolve_extra_fields(
         }
 
         if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
-            let schema = schema_map.get(field_id.as_str()).copied();
+            let schema = schema_map.get(*field_id).copied();
             extra.insert(
-                field_id.clone(),
+                field_id.to_string(),
                 custom_field_to_json(field_id, value, schema),
             );
         }


### PR DESCRIPTION
💡 What: Optimized `build_field_id_map` in `jira-backend/src/convert.rs` to return `HashMap<String, &str>` and use `HashMap::with_capacity`.
🎯 Why: `build_field_id_map` was dynamically allocating a completely new map of `String` -> `String` including strings for literal values, and it is called in `resolve_extra_fields` every time a Jira issue needs conversion. This led to unnecessary `.clone()` overhead.
📊 Impact: Removes redundant `String` clones for every single `JiraField` id evaluated during conversion and eliminates a hash map reallocation penalty, reducing allocations on the hot path.

---
*PR created automatically by Jules for task [8944043538375410043](https://jules.google.com/task/8944043538375410043) started by @johnsdav*