### PR TITLE
chore: fix .gitignore and remove leaked agent scratch file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ F
 .windsurf/
 CLAUDE.md
 GEMINI.md
-AGENTS.md.jules/
+AGENTS.md
+.jules/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-Bolt Journal
-
-- When normalizing maps and hashsets to be checked later on, one cannot avoid making memory allocations if string casing differ between input and expected output (i.e. replacing HashSet items to not allocate `.to_string()` without changing downstream iteration from `.contains()` to `iter().any(|r| r.eq_ignore_ascii_case())` changes algorithmic complexity). Therefore replacing `to_lowercase()` to `eq_ignore_ascii_case()` inside an iterator or if statement is a better idea instead.


### PR DESCRIPTION
## Summary

Two repo-hygiene cleanups:

1. **Fix malformed `.gitignore`.** The last entry was concatenated as `AGENTS.md.jules/` (single line, no trailing newline) — introduced as a side-effect of #230 (likely an automated merge collapse). Result: neither `AGENTS.md` nor `.jules/` was actually being ignored. Split back into two separate entries.

2. **Remove `.jules/bolt.md`.** Committed by #227 before `.jules/` made it into the ignore list. With #1 fixed, future agent scratch files in `.jules/` will be properly ignored.

## Test plan
- [ ] CI passes
- [ ] `git check-ignore .jules/foo.md` → matches
- [ ] `git check-ignore AGENTS.md` → matches