### PR TITLE
chore(deps): bump rustls-webpki 0.103.9 -> 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Bump `rustls-webpki` from 0.103.9 to 0.103.13 in `Cargo.lock` (Dependabot-flagged advisory).
- Originally bundled into #228 alongside permission changes; pulled out into its own PR so it can land independently of the permissions work.

Cargo.lock-only change — no source modifications.

## Test plan
- [ ] CI passes
- [ ] No source-level changes; existing tests cover the indirect-dependency surface