### PR TITLE
🛡️ Sentinel: High Fix restrictive Unix file permissions on configuration and cache

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+When applying Unix-specific security configurations like file permissions (`std::os::unix::fs::PermissionsExt`), always use `#[cfg(unix)]` to maintain Windows compatibility, and consider swallowing non-critical permission errors (e.g., `let _ = fs::set_permissions(...)`) to prevent application failure on unsupported file systems.

--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -652,7 +652,10 @@ impl TrackerCache {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = fs::set_permissions(path.parent().unwrap_or(path), fs::Permissions::from_mode(0o700));
+            let _ = fs::set_permissions(
+                path.parent().unwrap_or(path),
+                fs::Permissions::from_mode(0o700),
+            );
         }
 
         {

--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -278,6 +278,12 @@ impl TrackerCache {
         let root = Self::cache_dir_path(cache_dir.clone())?;
         fs::create_dir_all(&root)?;
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&root, fs::Permissions::from_mode(0o700));
+        }
+
         // 1. Save index.json
         let index = CacheIndexV2 {
             version: CACHE_VERSION,
@@ -643,6 +649,12 @@ impl TrackerCache {
             fs::create_dir_all(parent)?;
         }
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(path.parent().unwrap_or(path), fs::Permissions::from_mode(0o700));
+        }
+
         {
             let mut file = File::create(&temp_path)
                 .with_context(|| format!("Failed to create temp file: {}", temp_path.display()))?;
@@ -651,6 +663,12 @@ impl TrackerCache {
             })?;
             file.sync_all()
                 .with_context(|| format!("Failed to sync temp file: {}", temp_path.display()))?;
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600));
         }
 
         fs::rename(&temp_path, path).with_context(|| {

--- a/crates/track/src/config.rs
+++ b/crates/track/src/config.rs
@@ -302,7 +302,15 @@ impl Config {
     pub fn save(&self, path: &Path) -> Result<()> {
         let toml_string = toml::to_string_pretty(self)
             .map_err(|e| anyhow!("Failed to serialize config: {}", e))?;
-        fs::write(path, toml_string).map_err(|e| anyhow!("Failed to write config file: {}", e))?;
+
+        fs::write(path, toml_string.as_bytes()).map_err(|e| anyhow!("Failed to write config file: {}", e))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+        }
+
         Ok(())
     }
 

--- a/crates/track/src/config.rs
+++ b/crates/track/src/config.rs
@@ -303,7 +303,8 @@ impl Config {
         let toml_string = toml::to_string_pretty(self)
             .map_err(|e| anyhow!("Failed to serialize config: {}", e))?;
 
-        fs::write(path, toml_string.as_bytes()).map_err(|e| anyhow!("Failed to write config file: {}", e))?;
+        fs::write(path, toml_string.as_bytes())
+            .map_err(|e| anyhow!("Failed to write config file: {}", e))?;
 
         #[cfg(unix)]
         {


### PR DESCRIPTION
Severity: High
Vulnerability: Config files and cache directories were created with default file permissions, potentially allowing other users on the system to read sensitive data such as API tokens, issue content, or server URLs.
Impact: Local privilege escalation / information disclosure. Any other user on a shared system (e.g., jump host, shared build server) could read the configuration (`.track.toml`) or cache files (`.tracker-cache`) containing secrets.
Fix: Used `std::os::unix::fs::PermissionsExt` (gated by `#[cfg(unix)]`) to explicitly restrict directory permissions to `0o700` and file permissions to `0o600` when saving config and cache files. Permission errors are ignored to prevent runtime failure on non-UNIX filesystems.
Verification: Passed `cargo test` and `cargo clippy`. Tested that standard workflows (config read/write, cache updates) compile correctly.

---
*PR created automatically by Jules for task [7123330300495972300](https://jules.google.com/task/7123330300495972300) started by @johnsdav*