### PR TITLE
🧪 add unit tests for GitHub query conversion

### DIFF
--- a/crates/github-backend/src/convert_tests.rs
+++ b/crates/github-backend/src/convert_tests.rs
@@ -1,0 +1,31 @@
+#[cfg(test)]
+mod tests {
+    use crate::convert::convert_query_to_github;
+
+    #[test]
+    fn test_convert_query_to_github() {
+        let cases = vec![
+            ("", "is:issue"),
+            ("   ", "is:issue"),
+            ("bug", "bug is:issue"),
+            ("project:owner/repo", "is:issue"),
+            ("project:owner/repo bug", "bug is:issue"),
+            ("#open", "is:open is:issue"),
+            ("#unresolved", "is:open is:issue"),
+            ("#closed", "is:closed is:issue"),
+            ("#resolved", "is:closed is:issue"),
+            ("#bug", "label:bug is:issue"),
+            ("bug #open", "bug is:open is:issue"),
+            ("some term #feature #open", "some term label:feature is:open is:issue"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                convert_query_to_github(input),
+                expected,
+                "Failed for input: '{}'",
+                input
+            );
+        }
+    }
+}

--- a/crates/github-backend/src/convert_tests.rs
+++ b/crates/github-backend/src/convert_tests.rs
@@ -16,7 +16,10 @@ mod tests {
             ("#resolved", "is:closed is:issue"),
             ("#bug", "label:bug is:issue"),
             ("bug #open", "bug is:open is:issue"),
-            ("some term #feature #open", "some term label:feature is:open is:issue"),
+            (
+                "some term #feature #open",
+                "some term label:feature is:open is:issue",
+            ),
         ];
 
         for (input, expected) in cases {

--- a/crates/github-backend/src/lib.rs
+++ b/crates/github-backend/src/lib.rs
@@ -8,6 +8,8 @@ pub(crate) mod wiki;
 #[cfg(test)]
 mod client_tests;
 #[cfg(test)]
+mod convert_tests;
+#[cfg(test)]
 mod wiki_tests;
 
 pub use client::GitHubClient;


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the \`convert_query_to_github\` function in the GitHub backend.

📊 **Coverage:** Added table-driven tests in \`convert_tests.rs\` covering:
- Empty queries
- Queries with \`project:\` prefixes (which are correctly stripped)
- State hashtags (\`#open\`, \`#closed\`, \`#unresolved\`, \`#resolved\`)
- Label hashtags (e.g., \`#bug\` -> \`label:bug\`)
- Combined search terms and hashtags
- Ensuring \`is:issue\` is always present in the output to filter out PRs

✨ **Result:** Improved test coverage for core string transformation logic in the GitHub backend. Verified that the implementation correctly handles varied user input while maintaining GitHub-specific search constraints.

---
*PR created automatically by Jules for task [1385458319195900641](https://jules.google.com/task/1385458319195900641) started by @johnsdav*