### PR TITLE
🛡️ Sentinel: [Medium] Fix insecure permissions on existing config files

### DIFF
--- a/crates/track/src/config.rs
+++ b/crates/track/src/config.rs
@@ -318,6 +318,12 @@ impl Config {
         file.write_all(toml_string.as_bytes())
             .map_err(|e| anyhow!("Failed to write config file: {}", e))?;
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Severity: Medium
Vulnerability: Pre-existing config files with overly permissive permissions (e.g. 0o644) retain those permissions when modified in-place using `save()` because `OpenOptions::mode()` only applies to newly created files.
Impact: API tokens and URLs stored in `.track.toml` could be read by other users on a shared Unix system if the user had manually created the file previously or if a prior version created it without strict permissions.
Fix: Explicitly call `fs::set_permissions(path, fs::Permissions::from_mode(0o600))` using `PermissionsExt` at the end of the `save()` method for config files.
Verification: Ran `cargo clippy` and `cargo test`, ensuring the existing file permission tests pass correctly with the change applied.

---
*PR created automatically by Jules for task [13523913330939179614](https://jules.google.com/task/13523913330939179614) started by @johnsdav*