### PR TITLE
⚡ Bolt: Replace `.to_lowercase()` string allocations with `.eq_ignore_ascii_case()`

### DIFF
--- a/crates/github-backend/src/convert.rs
+++ b/crates/github-backend/src/convert.rs
@@ -120,7 +120,9 @@ pub fn create_issue_from_core(issue: &CreateIssue) -> CreateGitHubIssue {
         .custom_fields
         .iter()
         .filter_map(|cf| match cf {
-            CustomFieldUpdate::SingleUser { name, login } if name.eq_ignore_ascii_case("assignee") => {
+            CustomFieldUpdate::SingleUser { name, login }
+                if name.eq_ignore_ascii_case("assignee") =>
+            {
                 Some(login.clone())
             }
             _ => None,
@@ -167,7 +169,9 @@ pub fn update_issue_from_core(update: &UpdateIssue) -> UpdateGitHubIssue {
         .custom_fields
         .iter()
         .filter_map(|cf| match cf {
-            CustomFieldUpdate::SingleUser { name, login } if name.eq_ignore_ascii_case("assignee") => {
+            CustomFieldUpdate::SingleUser { name, login }
+                if name.eq_ignore_ascii_case("assignee") =>
+            {
                 Some(login.clone())
             }
             _ => None,
@@ -212,7 +216,8 @@ pub fn convert_query_to_github(query: &str) -> String {
         if let Some(state) = token.strip_prefix('#') {
             if state.eq_ignore_ascii_case("unresolved") || state.eq_ignore_ascii_case("open") {
                 parts.push("is:open".to_string());
-            } else if state.eq_ignore_ascii_case("resolved") || state.eq_ignore_ascii_case("closed") {
+            } else if state.eq_ignore_ascii_case("resolved") || state.eq_ignore_ascii_case("closed")
+            {
                 parts.push("is:closed".to_string());
             } else {
                 parts.push(format!("label:{}", state));

--- a/crates/github-backend/src/convert.rs
+++ b/crates/github-backend/src/convert.rs
@@ -120,7 +120,7 @@ pub fn create_issue_from_core(issue: &CreateIssue) -> CreateGitHubIssue {
         .custom_fields
         .iter()
         .filter_map(|cf| match cf {
-            CustomFieldUpdate::SingleUser { name, login } if name.to_lowercase() == "assignee" => {
+            CustomFieldUpdate::SingleUser { name, login } if name.eq_ignore_ascii_case("assignee") => {
                 Some(login.clone())
             }
             _ => None,
@@ -149,9 +149,9 @@ pub fn update_issue_from_core(update: &UpdateIssue) -> UpdateGitHubIssue {
     // Extract state from custom fields (CLI sends "State" or "Stage", backends may use "Status")
     let state = update.custom_fields.iter().find_map(|cf| match cf {
         CustomFieldUpdate::State { name, value }
-            if name.to_lowercase() == "status"
-                || name.to_lowercase() == "state"
-                || name.to_lowercase() == "stage" =>
+            if name.eq_ignore_ascii_case("status")
+                || name.eq_ignore_ascii_case("state")
+                || name.eq_ignore_ascii_case("stage") =>
         {
             let mapped_value = match value.to_lowercase().as_str() {
                 "done" | "resolved" | "closed" | "completed" => "closed",
@@ -167,7 +167,7 @@ pub fn update_issue_from_core(update: &UpdateIssue) -> UpdateGitHubIssue {
         .custom_fields
         .iter()
         .filter_map(|cf| match cf {
-            CustomFieldUpdate::SingleUser { name, login } if name.to_lowercase() == "assignee" => {
+            CustomFieldUpdate::SingleUser { name, login } if name.eq_ignore_ascii_case("assignee") => {
                 Some(login.clone())
             }
             _ => None,
@@ -210,10 +210,12 @@ pub fn convert_query_to_github(query: &str) -> String {
     let tokens: Vec<&str> = remaining.split_whitespace().collect();
     for token in tokens {
         if let Some(state) = token.strip_prefix('#') {
-            match state.to_lowercase().as_str() {
-                "unresolved" | "open" => parts.push("is:open".to_string()),
-                "resolved" | "closed" => parts.push("is:closed".to_string()),
-                _ => parts.push(format!("label:{}", state)),
+            if state.eq_ignore_ascii_case("unresolved") || state.eq_ignore_ascii_case("open") {
+                parts.push("is:open".to_string());
+            } else if state.eq_ignore_ascii_case("resolved") || state.eq_ignore_ascii_case("closed") {
+                parts.push("is:closed".to_string());
+            } else {
+                parts.push(format!("label:{}", state));
             }
         } else {
             parts.push(token.to_string());

--- a/crates/gitlab-backend/src/convert.rs
+++ b/crates/gitlab-backend/src/convert.rs
@@ -317,9 +317,14 @@ fn parse_token_query(query: &str) -> (String, Option<String>, Option<String>) {
     let tokens: Vec<&str> = query.split_whitespace().collect();
     for token in &tokens {
         if let Some(hash_tag) = token.strip_prefix('#') {
-            if hash_tag.eq_ignore_ascii_case("unresolved") || hash_tag.eq_ignore_ascii_case("open") || hash_tag.eq_ignore_ascii_case("opened") {
+            if hash_tag.eq_ignore_ascii_case("unresolved")
+                || hash_tag.eq_ignore_ascii_case("open")
+                || hash_tag.eq_ignore_ascii_case("opened")
+            {
                 state = Some("opened".to_string());
-            } else if hash_tag.eq_ignore_ascii_case("resolved") || hash_tag.eq_ignore_ascii_case("closed") {
+            } else if hash_tag.eq_ignore_ascii_case("resolved")
+                || hash_tag.eq_ignore_ascii_case("closed")
+            {
                 state = Some("closed".to_string());
             } else {
                 search_parts.push(*token);

--- a/crates/gitlab-backend/src/convert.rs
+++ b/crates/gitlab-backend/src/convert.rs
@@ -317,10 +317,12 @@ fn parse_token_query(query: &str) -> (String, Option<String>, Option<String>) {
     let tokens: Vec<&str> = query.split_whitespace().collect();
     for token in &tokens {
         if let Some(hash_tag) = token.strip_prefix('#') {
-            match hash_tag.to_lowercase().as_str() {
-                "unresolved" | "open" | "opened" => state = Some("opened".to_string()),
-                "resolved" | "closed" => state = Some("closed".to_string()),
-                _ => search_parts.push(*token),
+            if hash_tag.eq_ignore_ascii_case("unresolved") || hash_tag.eq_ignore_ascii_case("open") || hash_tag.eq_ignore_ascii_case("opened") {
+                state = Some("opened".to_string());
+            } else if hash_tag.eq_ignore_ascii_case("resolved") || hash_tag.eq_ignore_ascii_case("closed") {
+                state = Some("closed".to_string());
+            } else {
+                search_parts.push(*token);
             }
         } else if let Some(rest) = token.strip_prefix("project:") {
             // Skip project: prefix for GitLab (project is already scoped via project_id)

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -139,9 +139,9 @@ impl IssueTracker for GitLabClient {
         // Check for state changes in custom_fields
         let state_event = update.custom_fields.iter().find_map(|cf| match cf {
             tracker_core::CustomFieldUpdate::State { name, value }
-                if name.to_lowercase() == "status"
-                    || name.to_lowercase() == "state"
-                    || name.to_lowercase() == "stage" =>
+                if name.eq_ignore_ascii_case("status")
+                    || name.eq_ignore_ascii_case("state")
+                    || name.eq_ignore_ascii_case("stage") =>
             {
                 match value.to_lowercase().as_str() {
                     "closed" | "resolved" | "done" | "completed" => Some("close".to_string()),

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -408,13 +408,13 @@ pub fn create_issue_to_jira(
 
     for cf in &issue.custom_fields {
         if let CustomFieldUpdate::SingleEnum { name, value } = cf {
-            if priority.is_none() && name.to_lowercase() == "priority" {
+            if priority.is_none() && name.eq_ignore_ascii_case("priority") {
                 priority = Some(PriorityId {
                     id: None,
                     name: Some(value.clone()),
                 });
             } else if issue_type_opt.is_none()
-                && (name.to_lowercase() == "type" || name.to_lowercase() == "issuetype")
+                && (name.eq_ignore_ascii_case("type") || name.eq_ignore_ascii_case("issuetype"))
             {
                 issue_type_opt = Some(value.clone());
             }
@@ -465,7 +465,7 @@ pub fn update_issue_to_jira(
         .map(|d| markdown_to_adf_document(d));
 
     let priority = update.custom_fields.iter().find_map(|cf| match cf {
-        CustomFieldUpdate::SingleEnum { name, value } if name.to_lowercase() == "priority" => {
+        CustomFieldUpdate::SingleEnum { name, value } if name.eq_ignore_ascii_case("priority") => {
             Some(PriorityId {
                 id: None,
                 name: Some(value.clone()),
@@ -619,10 +619,8 @@ pub fn merge_fields(
     instance: Vec<ProjectCustomField>,
 ) -> Vec<ProjectCustomField> {
     let mut result = standard;
-    let existing_names: Vec<String> = result.iter().map(|f| f.name.to_lowercase()).collect();
-
     for field in instance {
-        if !existing_names.contains(&field.name.to_lowercase()) {
+        if !result.iter().any(|f| f.name.eq_ignore_ascii_case(&field.name)) {
             result.push(field);
         }
     }
@@ -738,7 +736,7 @@ const RESERVED_FIELD_NAMES: &[&str] = &[
 ];
 
 fn is_reserved_field(name: &str) -> bool {
-    RESERVED_FIELD_NAMES.contains(&name.to_lowercase().as_str())
+    RESERVED_FIELD_NAMES.iter().any(|&r| r.eq_ignore_ascii_case(name))
 }
 
 /// Resolve custom field updates to Jira extra fields using field metadata.

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -620,7 +620,10 @@ pub fn merge_fields(
 ) -> Vec<ProjectCustomField> {
     let mut result = standard;
     for field in instance {
-        if !result.iter().any(|f| f.name.eq_ignore_ascii_case(&field.name)) {
+        if !result
+            .iter()
+            .any(|f| f.name.eq_ignore_ascii_case(&field.name))
+        {
             result.push(field);
         }
     }
@@ -736,7 +739,9 @@ const RESERVED_FIELD_NAMES: &[&str] = &[
 ];
 
 fn is_reserved_field(name: &str) -> bool {
-    RESERVED_FIELD_NAMES.iter().any(|&r| r.eq_ignore_ascii_case(name))
+    RESERVED_FIELD_NAMES
+        .iter()
+        .any(|&r| r.eq_ignore_ascii_case(name))
 }
 
 /// Resolve custom field updates to Jira extra fields using field metadata.

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -327,14 +327,20 @@ fn convert_simple_query_to_jql(query: &str) -> String {
     let tokens: Vec<&str> = remaining.split_whitespace().collect();
     for token in tokens {
         if let Some(state) = token.strip_prefix('#') {
-            match state.to_lowercase().as_str() {
-                "unresolved" => parts.push("resolution IS EMPTY".to_string()),
-                "resolved" => parts.push("resolution IS NOT EMPTY".to_string()),
-                "open" => parts.push("status = Open".to_string()),
-                "closed" => parts.push("status = Closed".to_string()),
-                "done" => parts.push("status = Done".to_string()),
-                "inprogress" | "in-progress" => parts.push("status = \"In Progress\"".to_string()),
-                _ => parts.push(format!("status = \"{}\"", state)),
+            if state.eq_ignore_ascii_case("unresolved") {
+                parts.push("resolution IS EMPTY".to_string());
+            } else if state.eq_ignore_ascii_case("resolved") {
+                parts.push("resolution IS NOT EMPTY".to_string());
+            } else if state.eq_ignore_ascii_case("open") {
+                parts.push("status = Open".to_string());
+            } else if state.eq_ignore_ascii_case("closed") {
+                parts.push("status = Closed".to_string());
+            } else if state.eq_ignore_ascii_case("done") {
+                parts.push("status = Done".to_string());
+            } else if state.eq_ignore_ascii_case("inprogress") || state.eq_ignore_ascii_case("in-progress") {
+                parts.push("status = \"In Progress\"".to_string());
+            } else {
+                parts.push(format!("status = \"{}\"", state));
             }
         }
     }

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -337,7 +337,9 @@ fn convert_simple_query_to_jql(query: &str) -> String {
                 parts.push("status = Closed".to_string());
             } else if state.eq_ignore_ascii_case("done") {
                 parts.push("status = Done".to_string());
-            } else if state.eq_ignore_ascii_case("inprogress") || state.eq_ignore_ascii_case("in-progress") {
+            } else if state.eq_ignore_ascii_case("inprogress")
+                || state.eq_ignore_ascii_case("in-progress")
+            {
                 parts.push("status = \"In Progress\"".to_string());
             } else {
                 parts.push(format!("status = \"{}\"", state));

--- a/crates/track/src/commands/context.rs
+++ b/crates/track/src/commands/context.rs
@@ -68,7 +68,7 @@ impl From<&Issue> for IssueSummary {
         // Extract priority from custom fields
         let priority = issue.custom_fields.iter().find_map(|cf| {
             if let tracker_core::CustomField::SingleEnum { name, value } = cf {
-                if name.to_lowercase() == "priority" {
+                if name.eq_ignore_ascii_case("priority") {
                     value.clone()
                 } else {
                     None

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -421,7 +421,7 @@ impl Displayable for CustomField {
 }
 
 fn colorize_priority(field_name: &str, value: &str) -> String {
-    if field_name.to_lowercase() == "priority" {
+    if field_name.eq_ignore_ascii_case("priority") {
         match value.to_lowercase().as_str() {
             "critical" | "show-stopper" => value.red().bold().to_string(),
             "major" | "high" => value.red().to_string(),


### PR DESCRIPTION
💡 What: Replaced occurrences of `.to_lowercase() == "..."` and `match value.to_lowercase().as_str()` with `.eq_ignore_ascii_case("...")` across GitHub, GitLab, Jira backends and Track CLI commands. Also optimized a nested `Vec<String>` allocation in Jira's `merge_fields` helper that used `.contains()` with `to_lowercase()`.

🎯 Why: Calling `.to_lowercase()` creates a new heap-allocated `String`. In tight loops (like querying strings or parsing custom fields), these allocations add unnecessary memory pressure and slowdowns. Rust natively provides `eq_ignore_ascii_case` which operates directly on slices without allocations.

📊 Impact: Removes multiple redundant `String` heap allocations per issue fetched or queried across the CLI. Makes parsing of CLI queries for open/closed status strings strictly zero-allocation for casing.

---
*PR created automatically by Jules for task [15734108858206956623](https://jules.google.com/task/15734108858206956623) started by @johnsdav*