### PR TITLE
⚡ Bolt: Replace `.to_lowercase() ==` with `eq_ignore_ascii_case`

### DIFF
--- a/crates/github-backend/src/convert.rs
+++ b/crates/github-backend/src/convert.rs
@@ -120,7 +120,9 @@ pub fn create_issue_from_core(issue: &CreateIssue) -> CreateGitHubIssue {
         .custom_fields
         .iter()
         .filter_map(|cf| match cf {
-            CustomFieldUpdate::SingleUser { name, login } if name.to_lowercase() == "assignee" => {
+            CustomFieldUpdate::SingleUser { name, login }
+                if name.eq_ignore_ascii_case("assignee") =>
+            {
                 Some(login.clone())
             }
             _ => None,
@@ -149,9 +151,9 @@ pub fn update_issue_from_core(update: &UpdateIssue) -> UpdateGitHubIssue {
     // Extract state from custom fields (CLI sends "State" or "Stage", backends may use "Status")
     let state = update.custom_fields.iter().find_map(|cf| match cf {
         CustomFieldUpdate::State { name, value }
-            if name.to_lowercase() == "status"
-                || name.to_lowercase() == "state"
-                || name.to_lowercase() == "stage" =>
+            if name.eq_ignore_ascii_case("status")
+                || name.eq_ignore_ascii_case("state")
+                || name.eq_ignore_ascii_case("stage") =>
         {
             let mapped_value = match value.to_lowercase().as_str() {
                 "done" | "resolved" | "closed" | "completed" => "closed",
@@ -167,7 +169,9 @@ pub fn update_issue_from_core(update: &UpdateIssue) -> UpdateGitHubIssue {
         .custom_fields
         .iter()
         .filter_map(|cf| match cf {
-            CustomFieldUpdate::SingleUser { name, login } if name.to_lowercase() == "assignee" => {
+            CustomFieldUpdate::SingleUser { name, login }
+                if name.eq_ignore_ascii_case("assignee") =>
+            {
                 Some(login.clone())
             }
             _ => None,

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -139,9 +139,9 @@ impl IssueTracker for GitLabClient {
         // Check for state changes in custom_fields
         let state_event = update.custom_fields.iter().find_map(|cf| match cf {
             tracker_core::CustomFieldUpdate::State { name, value }
-                if name.to_lowercase() == "status"
-                    || name.to_lowercase() == "state"
-                    || name.to_lowercase() == "stage" =>
+                if name.eq_ignore_ascii_case("status")
+                    || name.eq_ignore_ascii_case("state")
+                    || name.eq_ignore_ascii_case("stage") =>
             {
                 match value.to_lowercase().as_str() {
                     "closed" | "resolved" | "done" | "completed" => Some("close".to_string()),

--- a/crates/jira-backend/src/client.rs
+++ b/crates/jira-backend/src/client.rs
@@ -577,17 +577,20 @@ impl JiraClient {
     /// Resolve a user-provided status name (case-insensitive) to a transition id
     /// available on the issue's current workflow step.
     pub fn resolve_transition_id(&self, issue_key: &str, target_status: &str) -> Result<String> {
-        let target = target_status.trim().to_lowercase();
+        let target = target_status.trim();
         let transitions = self.list_transitions(issue_key)?;
 
         // Prefer exact match on the target status name, fall back to transition name.
         if let Some(t) = transitions
             .iter()
-            .find(|t| t.to.name.to_lowercase() == target)
+            .find(|t| t.to.name.eq_ignore_ascii_case(target))
         {
             return Ok(t.id.clone());
         }
-        if let Some(t) = transitions.iter().find(|t| t.name.to_lowercase() == target) {
+        if let Some(t) = transitions
+            .iter()
+            .find(|t| t.name.eq_ignore_ascii_case(target))
+        {
             return Ok(t.id.clone());
         }
 

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -408,13 +408,13 @@ pub fn create_issue_to_jira(
 
     for cf in &issue.custom_fields {
         if let CustomFieldUpdate::SingleEnum { name, value } = cf {
-            if priority.is_none() && name.to_lowercase() == "priority" {
+            if priority.is_none() && name.eq_ignore_ascii_case("priority") {
                 priority = Some(PriorityId {
                     id: None,
                     name: Some(value.clone()),
                 });
             } else if issue_type_opt.is_none()
-                && (name.to_lowercase() == "type" || name.to_lowercase() == "issuetype")
+                && (name.eq_ignore_ascii_case("type") || name.eq_ignore_ascii_case("issuetype"))
             {
                 issue_type_opt = Some(value.clone());
             }
@@ -465,7 +465,7 @@ pub fn update_issue_to_jira(
         .map(|d| markdown_to_adf_document(d));
 
     let priority = update.custom_fields.iter().find_map(|cf| match cf {
-        CustomFieldUpdate::SingleEnum { name, value } if name.to_lowercase() == "priority" => {
+        CustomFieldUpdate::SingleEnum { name, value } if name.eq_ignore_ascii_case("priority") => {
             Some(PriorityId {
                 id: None,
                 name: Some(value.clone()),

--- a/crates/track/src/commands/context.rs
+++ b/crates/track/src/commands/context.rs
@@ -68,7 +68,7 @@ impl From<&Issue> for IssueSummary {
         // Extract priority from custom fields
         let priority = issue.custom_fields.iter().find_map(|cf| {
             if let tracker_core::CustomField::SingleEnum { name, value } = cf {
-                if name.to_lowercase() == "priority" {
+                if name.eq_ignore_ascii_case("priority") {
                     value.clone()
                 } else {
                     None

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -421,7 +421,7 @@ impl Displayable for CustomField {
 }
 
 fn colorize_priority(field_name: &str, value: &str) -> String {
-    if field_name.to_lowercase() == "priority" {
+    if field_name.eq_ignore_ascii_case("priority") {
         match value.to_lowercase().as_str() {
             "critical" | "show-stopper" => value.red().bold().to_string(),
             "major" | "high" => value.red().to_string(),


### PR DESCRIPTION
💡 What: Replaced instances of `.to_lowercase() == "string"` with `.eq_ignore_ascii_case("string")` across multiple backend modules (`github-backend`, `gitlab-backend`, `jira-backend`, `track`).
🎯 Why: Using `.to_lowercase()` creates a new heap-allocated `String` for every comparison. For ASCII string literals (like "status", "priority", "assignee"), this is an unnecessary performance penalty on the hot path.
📊 Impact: Eliminates multiple redundant `String` allocations per issue serialization/deserialization across various backends, speeding up standard issue parsing and field updates.

---
*PR created automatically by Jules for task [8168727546524228099](https://jules.google.com/task/8168727546524228099) started by @johnsdav*