### PR TITLE
fix(jira): resolve critical search and text parsing defects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jira-backend"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "pulldown-cmark",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/jira-backend/Cargo.toml
+++ b/crates/jira-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jira-backend"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Jira backend implementation for tracker-core"
 

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -727,6 +727,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_adf_text_extraction_multiline() {
+        // Test that block nodes like paragraphs and list items preserve newlines and bullets
+        let adf = serde_json::json!({
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "First paragraph"
+                        }
+                    ]
+                },
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Second paragraph"
+                        }
+                    ]
+                },
+                {
+                    "type": "bulletList",
+                    "content": [
+                        {
+                            "type": "listItem",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Item A"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "listItem",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Item B"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let text = adf_to_text(&adf);
+        assert_eq!(text, "First paragraph\n\nSecond paragraph\n\n- Item A\n- Item B");
+    }
+
+    #[tokio::test]
     async fn test_markdown_to_adf_conversion() {
         // Test that plain text produces a valid ADF doc
         let adf = markdown_to_adf("Hello World");

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -778,7 +778,10 @@ mod tests {
         });
 
         let text = adf_to_text(&adf);
-        assert_eq!(text, "First paragraph\n\nSecond paragraph\n\n- Item A\n- Item B");
+        assert_eq!(
+            text,
+            "First paragraph\n\nSecond paragraph\n\n- Item A\n- Item B"
+        );
     }
 
     #[tokio::test]

--- a/crates/jira-backend/src/markdown/adf.rs
+++ b/crates/jira-backend/src/markdown/adf.rs
@@ -465,13 +465,43 @@ pub(crate) fn adf_to_text(adf: &serde_json::Value) -> String {
     fn extract_text(value: &serde_json::Value) -> String {
         match value {
             serde_json::Value::Object(obj) => {
-                if let Some(text) = obj.get("text").and_then(|t| t.as_str()) {
-                    return text.to_string();
+                let node_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                
+                match node_type {
+                    "text" => {
+                        obj.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string()
+                    }
+                    "hardBreak" => {
+                        "\n".to_string()
+                    }
+                    "paragraph" | "heading" | "codeBlock" | "blockquote" => {
+                        let inner = obj.get("content").map(extract_text).unwrap_or_default();
+                        format!("{}\n\n", inner.trim())
+                    }
+                    "listItem" | "taskItem" => {
+                        let inner = obj.get("content").map(extract_text).unwrap_or_default();
+                        format!("- {}\n", inner.trim())
+                    }
+                    "bulletList" | "orderedList" | "taskList" => {
+                        let inner = obj.get("content").map(extract_text).unwrap_or_default();
+                        format!("{}\n", inner.trim())
+                    }
+                    "tableRow" => {
+                        let inner = obj.get("content").map(extract_text).unwrap_or_default();
+                        format!("{}\n", inner.trim())
+                    }
+                    "tableHeader" | "tableCell" => {
+                        let inner = obj.get("content").map(extract_text).unwrap_or_default();
+                        format!("| {} ", inner.trim())
+                    }
+                    _ => {
+                        if let Some(content) = obj.get("content") {
+                            extract_text(content)
+                        } else {
+                            String::new()
+                        }
+                    }
                 }
-                if let Some(content) = obj.get("content") {
-                    return extract_text(content);
-                }
-                String::new()
             }
             serde_json::Value::Array(arr) => {
                 arr.iter().map(extract_text).collect::<Vec<_>>().join("")
@@ -479,7 +509,7 @@ pub(crate) fn adf_to_text(adf: &serde_json::Value) -> String {
             _ => String::new(),
         }
     }
-    extract_text(adf)
+    extract_text(adf).trim().to_string()
 }
 
 #[cfg(test)]

--- a/crates/jira-backend/src/markdown/adf.rs
+++ b/crates/jira-backend/src/markdown/adf.rs
@@ -466,14 +466,14 @@ pub(crate) fn adf_to_text(adf: &serde_json::Value) -> String {
         match value {
             serde_json::Value::Object(obj) => {
                 let node_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                
+
                 match node_type {
-                    "text" => {
-                        obj.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string()
-                    }
-                    "hardBreak" => {
-                        "\n".to_string()
-                    }
+                    "text" => obj
+                        .get("text")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    "hardBreak" => "\n".to_string(),
                     "paragraph" | "heading" | "codeBlock" | "blockquote" => {
                         let inner = obj.get("content").map(extract_text).unwrap_or_default();
                         format!("{}\n\n", inner.trim())

--- a/crates/jira-backend/src/markdown/storage.rs
+++ b/crates/jira-backend/src/markdown/storage.rs
@@ -4,7 +4,6 @@
 
 /// Convert Confluence storage format (XHTML) to plain text
 pub(crate) fn storage_to_text(storage: &str) -> String {
-    // Simple HTML tag stripping - a full implementation would use an HTML parser
     let mut result = storage.to_string();
 
     // Replace common block elements with newlines
@@ -21,16 +20,54 @@ pub(crate) fn storage_to_text(storage: &str) -> String {
     result = result.replace("</h5>", "\n");
     result = result.replace("</h6>", "\n");
 
-    // Strip all remaining HTML tags
-    let mut in_tag = false;
+    // Strip HTML tags while fully preserving CDATA contents
+    let chars: Vec<char> = result.chars().collect();
     let mut output = String::new();
-    for c in result.chars() {
-        if c == '<' {
-            in_tag = true;
-        } else if c == '>' {
-            in_tag = false;
-        } else if !in_tag {
-            output.push(c);
+    let mut i = 0;
+    let mut in_tag = false;
+    let mut in_cdata = false;
+
+    while i < chars.len() {
+        if in_cdata {
+            // Check if we are at the end of CDATA: "]]>"
+            if i + 2 < chars.len()
+                && chars[i] == ']'
+                && chars[i + 1] == ']'
+                && chars[i + 2] == '>'
+            {
+                in_cdata = false;
+                i += 3;
+            } else {
+                output.push(chars[i]);
+                i += 1;
+            }
+        } else if in_tag {
+            if chars[i] == '>' {
+                in_tag = false;
+            }
+            i += 1;
+        } else {
+            // Check for CDATA start: "<![CDATA["
+            if chars[i] == '<'
+                && i + 8 < chars.len()
+                && chars[i + 1] == '!'
+                && chars[i + 2] == '['
+                && chars[i + 3] == 'C'
+                && chars[i + 4] == 'D'
+                && chars[i + 5] == 'A'
+                && chars[i + 6] == 'T'
+                && chars[i + 7] == 'A'
+                && chars[i + 8] == '['
+            {
+                in_cdata = true;
+                i += 9;
+            } else if chars[i] == '<' {
+                in_tag = true;
+                i += 1;
+            } else {
+                output.push(chars[i]);
+                i += 1;
+            }
         }
     }
 
@@ -366,5 +403,13 @@ echo hi
             !storage.contains("Prepare release:<ol><li>Prepare release:"),
             "child item text should remain independent, got: {storage}"
         );
+    }
+
+    #[test]
+    fn test_storage_to_text_correct() {
+        // Test: CDATA blocks are completely preserved, even if they contain comparative operators
+        let storage_xml = "<ac:structured-macro ac:name=\"code\"><ac:plain-text-body><![CDATA[if x < 5 && y > 3 { println!(\"hi\"); }]]></ac:plain-text-body></ac:structured-macro>";
+        let plain_text = storage_to_text(storage_xml);
+        assert_eq!(plain_text, "if x < 5 && y > 3 { println!(\"hi\"); }");
     }
 }

--- a/crates/jira-backend/src/markdown/storage.rs
+++ b/crates/jira-backend/src/markdown/storage.rs
@@ -30,10 +30,7 @@ pub(crate) fn storage_to_text(storage: &str) -> String {
     while i < chars.len() {
         if in_cdata {
             // Check if we are at the end of CDATA: "]]>"
-            if i + 2 < chars.len()
-                && chars[i] == ']'
-                && chars[i + 1] == ']'
-                && chars[i + 2] == '>'
+            if i + 2 < chars.len() && chars[i] == ']' && chars[i + 1] == ']' && chars[i + 2] == '>'
             {
                 in_cdata = false;
                 i += 3;

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -308,25 +308,14 @@ impl IssueTracker for JiraClient {
 /// Convert simple tracker-core query format to JQL
 fn convert_simple_query_to_jql(query: &str) -> String {
     let mut parts = Vec::new();
-    let mut remaining = query.trim();
+    let mut keywords = Vec::new();
 
-    // Handle project: syntax
-    if let Some(rest) = remaining.strip_prefix("project:") {
-        let rest = rest.trim_start();
-        if let Some(space_pos) = rest.find(' ') {
-            let project = rest[..space_pos].trim();
-            parts.push(format!("project = {}", project));
-            remaining = &rest[space_pos..];
-        } else {
-            parts.push(format!("project = {}", rest.trim()));
-            remaining = "";
-        }
-    }
-
-    // Handle #hashtag syntax (states)
-    let tokens: Vec<&str> = remaining.split_whitespace().collect();
-    for token in tokens {
-        if let Some(state) = token.strip_prefix('#') {
+    for token in query.split_whitespace() {
+        if let Some(project) = token.strip_prefix("project:") {
+            if !project.is_empty() {
+                parts.push(format!("project = {}", project));
+            }
+        } else if let Some(state) = token.strip_prefix('#') {
             if state.eq_ignore_ascii_case("unresolved") {
                 parts.push("resolution IS EMPTY".to_string());
             } else if state.eq_ignore_ascii_case("resolved") {
@@ -344,12 +333,18 @@ fn convert_simple_query_to_jql(query: &str) -> String {
             } else {
                 parts.push(format!("status = \"{}\"", state));
             }
+        } else {
+            keywords.push(token);
         }
     }
 
+    if !keywords.is_empty() {
+        let joined_keywords = keywords.join(" ");
+        parts.push(format!("text ~ \"{}\"", joined_keywords));
+    }
+
     if parts.is_empty() {
-        // If no conversion happened, use the query as-is (might be valid JQL)
-        query.to_string()
+        String::new()
     } else {
         parts.join(" AND ")
     }
@@ -382,5 +377,23 @@ fn jira_attachment_to_core(attachment: crate::models::JiraAttachment) -> IssueAt
         }),
         comment_id: None,
         markdown: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_simple_query_to_jql_correct() {
+        // Test 1: Mixed query preserves keywords under text operator
+        let query = "project:PROJ #unresolved bug";
+        let jql = convert_simple_query_to_jql(query);
+        assert_eq!(jql, "project = PROJ AND resolution IS EMPTY AND text ~ \"bug\"");
+
+        // Test 2: Pure keyword query converts cleanly to text operator JQL
+        let pure_keyword = "bug fixing";
+        let jql_pure_keyword = convert_simple_query_to_jql(pure_keyword);
+        assert_eq!(jql_pure_keyword, "text ~ \"bug fixing\"");
     }
 }

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -389,7 +389,10 @@ mod tests {
         // Test 1: Mixed query preserves keywords under text operator
         let query = "project:PROJ #unresolved bug";
         let jql = convert_simple_query_to_jql(query);
-        assert_eq!(jql, "project = PROJ AND resolution IS EMPTY AND text ~ \"bug\"");
+        assert_eq!(
+            jql,
+            "project = PROJ AND resolution IS EMPTY AND text ~ \"bug\""
+        );
 
         // Test 2: Pure keyword query converts cleanly to text operator JQL
         let pure_keyword = "bug fixing";

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 


### PR DESCRIPTION
This pull request resolves three critical bugs in the Jira and Confluence backend implementation:

1. **Simple JQL Query Conversion**: Fixed silent keyword loss and query crashes by tokenising keywords and mapping them via the native JQL 'text ~' operator.
2. **Confluence CDATA Tag-Stripping**: Implemented a robust state-machine tag stripper in 'storage_to_text' that correctly parses and preserves comparative operators inside code CDATA blocks.
3. **ADF Newline Collapsing**: Refactored 'adf_to_text' to be block-type aware, preserving newlines between block elements like paragraphs, list items, headings, and code blocks.