### PR TITLE
fix(jira): use cursor-based pagination for issue search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/jira-backend/src/client.rs
+++ b/crates/jira-backend/src/client.rs
@@ -173,23 +173,33 @@ impl JiraClient {
         Ok(issue)
     }
 
-    /// Search issues using JQL
+    /// Search issues using JQL.
+    ///
+    /// `/search/jql` is cursor-based: pass `next_page_token = None` for the
+    /// first page, then the token from the previous response's
+    /// `next_page_token` for each subsequent page. The endpoint does not
+    /// support offset pagination (`startAt` is silently ignored), and the
+    /// server may cap or shrink pages below `max_results`.
     pub fn search_issues(
         &self,
         jql: &str,
         max_results: usize,
-        start_at: usize,
+        next_page_token: Option<&str>,
     ) -> Result<JiraSearchResult> {
         // Jira Cloud uses GET /search/jql (the old POST /search was removed).
         // `fields=*all` is required — without it the endpoint returns only issue IDs.
         let jql_encoded = urlencoding::encode(jql);
-        let url = format!(
-            "{}?jql={}&startAt={}&maxResults={}&fields=*all",
+        let mut url = format!(
+            "{}?jql={}&maxResults={}&fields=*all",
             self.api_url("/search/jql"),
             jql_encoded,
-            start_at,
             max_results,
         );
+        if let Some(token) = next_page_token {
+            // The token is an opaque server string; percent-encode it.
+            url.push_str("&nextPageToken=");
+            url.push_str(&urlencoding::encode(token));
+        }
 
         let response = self
             .agent

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -7,7 +7,9 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tracker_core::{AttachmentUpload, AttachmentUploadFile};
-    use wiremock::matchers::{body_string_contains, header, method, path, query_param};
+    use wiremock::matchers::{
+        body_string_contains, header, method, path, query_param, query_param_is_missing,
+    };
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn temp_upload_file(name: &str, contents: &[u8]) -> PathBuf {
@@ -53,8 +55,14 @@ mod tests {
 
     /// Helper to create a mock Jira issue response
     fn mock_jira_issue(key: &str, summary: &str) -> serde_json::Value {
+        mock_jira_issue_with_id("10001", key, summary)
+    }
+
+    /// Like `mock_jira_issue`, but with a distinct internal id — needed by
+    /// tests that exercise dedup-by-id pagination.
+    fn mock_jira_issue_with_id(id: &str, key: &str, summary: &str) -> serde_json::Value {
         serde_json::json!({
-            "id": "10001",
+            "id": id,
             "key": key,
             "self": format!("https://test.atlassian.net/rest/api/3/issue/{}", key),
             "fields": {
@@ -264,13 +272,16 @@ mod tests {
     async fn test_search_issues() {
         let mock_server = MockServer::start().await;
 
-        // The new Jira API uses GET /search/jql with query parameters
+        // The new Jira API uses GET /search/jql with cursor-based pagination
         Mock::given(method("GET"))
             .and(path("/rest/api/3/search/jql"))
             .and(header(
                 "Authorization",
                 "Basic dGVzdEB0ZXN0LmNvbTp0ZXN0LXRva2Vu",
             ))
+            .and(query_param("maxResults", "20"))
+            .and(query_param_is_missing("startAt"))
+            .and(query_param_is_missing("nextPageToken"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "issues": [
                     mock_jira_issue("TEST-123", "First issue"),
@@ -282,9 +293,10 @@ mod tests {
             .await;
 
         let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
-        let result = client.search_issues("project = TEST", 20, 0).unwrap();
+        let result = client.search_issues("project = TEST", 20, None).unwrap();
 
         assert!(result.is_last);
+        assert!(result.next_page_token.is_none());
         assert_eq!(result.issues.len(), 2);
         assert_eq!(result.issues[0].key, "TEST-123");
         assert_eq!(result.issues[1].key, "TEST-124");
@@ -798,27 +810,544 @@ mod tests {
     async fn test_search_with_pagination() {
         let mock_server = MockServer::start().await;
 
-        // The new Jira API uses GET /search/jql with query parameters
+        // Client-level token round-trip: the first page hands back a token,
+        // and the next request must carry it (and never a startAt offset).
         Mock::given(method("GET"))
             .and(path("/rest/api/3/search/jql"))
+            .and(query_param_is_missing("nextPageToken"))
+            .and(query_param_is_missing("startAt"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "issues": [
                     mock_jira_issue("TEST-11", "Issue 11"),
-                    mock_jira_issue("TEST-12", "Issue 12"),
-                    mock_jira_issue("TEST-13", "Issue 13"),
-                    mock_jira_issue("TEST-14", "Issue 14"),
-                    mock_jira_issue("TEST-15", "Issue 15")
+                    mock_jira_issue("TEST-12", "Issue 12")
                 ],
+                "nextPageToken": "tok-1",
                 "isLast": false
             })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("nextPageToken", "tok-1"))
+            .and(query_param_is_missing("startAt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-13", "Issue 13")
+                ],
+                "isLast": true
+            })))
+            .expect(1)
             .mount(&mock_server)
             .await;
 
         let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
-        let result = client.search_issues("project = TEST", 5, 10).unwrap();
 
-        assert!(!result.is_last);
-        assert_eq!(result.issues.len(), 5);
+        let page1 = client.search_issues("project = TEST", 2, None).unwrap();
+        assert_eq!(page1.next_page_token.as_deref(), Some("tok-1"));
+        assert_eq!(page1.issues.len(), 2);
+
+        let page2 = client
+            .search_issues("project = TEST", 2, page1.next_page_token.as_deref())
+            .unwrap();
+        assert!(page2.next_page_token.is_none());
+        assert!(page2.is_last);
+        assert_eq!(page2.issues[0].key, "TEST-13");
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_walks_token_chain() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("maxResults", "4"))
+            .and(query_param_is_missing("nextPageToken"))
+            .and(query_param_is_missing("startAt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-1", "Issue 1"),
+                    mock_jira_issue("TEST-2", "Issue 2")
+                ],
+                "nextPageToken": "t2"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("maxResults", "2"))
+            .and(query_param("nextPageToken", "t2"))
+            .and(query_param_is_missing("startAt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-3", "Issue 3"),
+                    mock_jira_issue("TEST-4", "Issue 4")
+                ]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_issues(&client, "project = TEST", 4, 0).unwrap();
+
+        let keys: Vec<&str> = result
+            .items
+            .iter()
+            .map(|i| i.id_readable.as_str())
+            .collect();
+        assert_eq!(keys, vec!["TEST-1", "TEST-2", "TEST-3", "TEST-4"]);
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_skip_across_page_boundary() {
+        let mock_server = MockServer::start().await;
+
+        // skip=4, limit=2 over pages of 3+3: the entire first page is
+        // discarded, the remaining skip of 1 applies within page 2.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param_is_missing("nextPageToken"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-1", "Issue 1"),
+                    mock_jira_issue("TEST-2", "Issue 2"),
+                    mock_jira_issue("TEST-3", "Issue 3")
+                ],
+                "nextPageToken": "t2"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("nextPageToken", "t2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-4", "Issue 4"),
+                    mock_jira_issue("TEST-5", "Issue 5"),
+                    mock_jira_issue("TEST-6", "Issue 6")
+                ]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_issues(&client, "project = TEST", 2, 4).unwrap();
+
+        let keys: Vec<&str> = result
+            .items
+            .iter()
+            .map(|i| i.id_readable.as_str())
+            .collect();
+        assert_eq!(keys, vec!["TEST-5", "TEST-6"]);
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_terminates_on_missing_token() {
+        let mock_server = MockServer::start().await;
+
+        // No nextPageToken and no isLast in the response (serde defaults):
+        // token absence alone must terminate the walk after one request.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-1", "Issue 1"),
+                    mock_jira_issue("TEST-2", "Issue 2"),
+                    mock_jira_issue("TEST-3", "Issue 3")
+                ]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_issues(&client, "project = TEST", 50, 0).unwrap();
+        assert_eq!(result.items.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_limit_over_100_accumulates() {
+        let mock_server = MockServer::start().await;
+
+        let page1: Vec<serde_json::Value> = (1..=100)
+            .map(|i| mock_jira_issue_with_id(&i.to_string(), &format!("TEST-{i}"), "Issue"))
+            .collect();
+        let page2: Vec<serde_json::Value> = (101..=150)
+            .map(|i| mock_jira_issue_with_id(&i.to_string(), &format!("TEST-{i}"), "Issue"))
+            .collect();
+
+        // Requests are clamped to the server's 100 cap, then shrink to the
+        // remainder.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("maxResults", "100"))
+            .and(query_param_is_missing("nextPageToken"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": page1,
+                "nextPageToken": "t2"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("maxResults", "50"))
+            .and(query_param("nextPageToken", "t2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": page2
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_issues(&client, "project = TEST", 150, 0).unwrap();
+        assert_eq!(result.items.len(), 150);
+        assert_eq!(result.items[0].id_readable, "TEST-1");
+        assert_eq!(result.items[149].id_readable, "TEST-150");
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_errors_on_repeated_token() {
+        let mock_server = MockServer::start().await;
+
+        // A server that echoes the same token forever must not hang the
+        // walk or silently emit duplicate rows: the second response repeats
+        // the token just used, so the walk fails loudly after exactly two
+        // requests.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [mock_jira_issue("TEST-1", "Issue 1")],
+                "nextPageToken": "same"
+            })))
+            .expect(2)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::{IssueTracker, TrackerError};
+        let result = IssueTracker::search_issues(&client, "project = TEST", 10, 0);
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_continues_past_empty_page_with_fresh_token() {
+        let mock_server = MockServer::start().await;
+
+        // An empty page with a fresh token is NOT the end of results
+        // (token absence is the only authoritative last-page signal).
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param_is_missing("nextPageToken"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-1", "Issue 1"),
+                    mock_jira_issue("TEST-2", "Issue 2")
+                ],
+                "nextPageToken": "t2"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("nextPageToken", "t2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [],
+                "nextPageToken": "t3"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("nextPageToken", "t3"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-3", "Issue 3"),
+                    mock_jira_issue("TEST-4", "Issue 4")
+                ]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_issues(&client, "project = TEST", 4, 0).unwrap();
+
+        let keys: Vec<&str> = result
+            .items
+            .iter()
+            .map(|i| i.id_readable.as_str())
+            .collect();
+        assert_eq!(keys, vec!["TEST-1", "TEST-2", "TEST-3", "TEST-4"]);
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_skip_beyond_end_returns_empty() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue("TEST-1", "Issue 1"),
+                    mock_jira_issue("TEST-2", "Issue 2"),
+                    mock_jira_issue("TEST-3", "Issue 3")
+                ]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_issues(&client, "project = TEST", 5, 10).unwrap();
+        assert!(result.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_limit_zero_makes_no_requests() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": []
+            })))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_issues(&client, "project = TEST", 0, 0).unwrap();
+        assert!(result.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_issues_percent_encodes_token() {
+        let mock_server = MockServer::start().await;
+
+        // Tokens are opaque server strings; characters like '+', '/', '=',
+        // '&' must survive the URL round-trip. wiremock decodes the query
+        // string, so this matcher only matches if the client encoded it.
+        let raw_token = "tok+1/x=&y";
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("nextPageToken", raw_token))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [mock_jira_issue("TEST-1", "Issue 1")]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+        let result = client
+            .search_issues("project = TEST", 5, Some(raw_token))
+            .unwrap();
+        assert_eq!(result.issues.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_search_all_issues_walks_token_chain_with_short_page() {
+        let mock_server = MockServer::start().await;
+
+        // Three pages; the middle one is deliberately short (1 issue) —
+        // per the API contract a short page must NOT terminate the walk,
+        // only token absence does.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param_is_missing("nextPageToken"))
+            .and(query_param_is_missing("startAt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("1", "TEST-1", "Issue 1"),
+                    mock_jira_issue_with_id("2", "TEST-2", "Issue 2")
+                ],
+                "nextPageToken": "t2"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("nextPageToken", "t2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("3", "TEST-3", "Issue 3")
+                ],
+                "nextPageToken": "t3"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("nextPageToken", "t3"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("4", "TEST-4", "Issue 4"),
+                    mock_jira_issue_with_id("5", "TEST-5", "Issue 5")
+                ]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_all_issues(&client, "project = TEST", 1000).unwrap();
+
+        let keys: Vec<&str> = result.iter().map(|i| i.id_readable.as_str()).collect();
+        assert_eq!(keys, vec!["TEST-1", "TEST-2", "TEST-3", "TEST-4", "TEST-5"]);
+    }
+
+    #[tokio::test]
+    async fn test_search_all_issues_errors_on_repeated_token() {
+        let mock_server = MockServer::start().await;
+
+        // The second response echoes back the token that was just used:
+        // the cursor is not advancing. Must fail loudly instead of looping.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param_is_missing("nextPageToken"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("1", "TEST-1", "Issue 1"),
+                    mock_jira_issue_with_id("2", "TEST-2", "Issue 2")
+                ],
+                "nextPageToken": "t2"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("nextPageToken", "t2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("1", "TEST-1", "Issue 1"),
+                    mock_jira_issue_with_id("2", "TEST-2", "Issue 2")
+                ],
+                "nextPageToken": "t2"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::{IssueTracker, TrackerError};
+        let result = IssueTracker::search_all_issues(&client, "project = TEST", 1000);
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
+    }
+
+    #[tokio::test]
+    async fn test_search_all_issues_errors_after_no_progress_run() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Always returns the same single issue but a fresh token on every
+        /// request — the cursor "advances" without ever yielding new data.
+        struct FreshTokenSamePage(AtomicUsize);
+        impl wiremock::Respond for FreshTokenSamePage {
+            fn respond(&self, _request: &wiremock::Request) -> ResponseTemplate {
+                let n = self.0.fetch_add(1, Ordering::SeqCst);
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "issues": [mock_jira_issue_with_id("1", "TEST-1", "Issue 1")],
+                    "nextPageToken": format!("t{}", n + 1)
+                }))
+            }
+        }
+
+        let mock_server = MockServer::start().await;
+
+        // Request 1 makes progress (1 new issue); requests 2..=6 each yield
+        // zero new issues with a fresh token, exhausting the no-progress
+        // budget of 5 and failing loudly.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .respond_with(FreshTokenSamePage(AtomicUsize::new(0)))
+            .expect(6)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::{IssueTracker, TrackerError};
+        let result = IssueTracker::search_all_issues(&client, "project = TEST", 1000);
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
+    }
+
+    #[tokio::test]
+    async fn test_search_all_issues_respects_max_results() {
+        let mock_server = MockServer::start().await;
+
+        // max_results = 3: the first request asks for 3, the second for the
+        // remaining 1, and the walk stops without following the last token.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("maxResults", "3"))
+            .and(query_param_is_missing("nextPageToken"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("1", "TEST-1", "Issue 1"),
+                    mock_jira_issue_with_id("2", "TEST-2", "Issue 2")
+                ],
+                "nextPageToken": "t2"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/search/jql"))
+            .and(query_param("maxResults", "1"))
+            .and(query_param("nextPageToken", "t2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("3", "TEST-3", "Issue 3")
+                ],
+                "nextPageToken": "t3"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::IssueTracker;
+        let result = IssueTracker::search_all_issues(&client, "project = TEST", 3).unwrap();
+        assert_eq!(result.len(), 3);
     }
 
     #[tokio::test]

--- a/crates/jira-backend/src/models/issue.rs
+++ b/crates/jira-backend/src/models/issue.rs
@@ -195,14 +195,23 @@ pub struct JiraIssueLinkType {
 
 /// Search result response from `/search/jql` endpoint.
 ///
-/// The new Jira Cloud search endpoint returns `isLast` instead of `total`.
-/// It does not provide a total count of matching issues.
+/// The new Jira Cloud search endpoint is cursor-based: it pages via
+/// `nextPageToken` and does not provide a total count of matching issues.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JiraSearchResult {
-    /// Issues in this page
+    /// Issues in this page (the API marks the field optional, so default
+    /// to empty rather than failing deserialization)
+    #[serde(default)]
     pub issues: Vec<JiraIssue>,
-    /// Whether this is the last page of results
+    /// Continuation token for the next page. Absent (or null) on the last
+    /// page — this is the authoritative last-page signal. Tokens expire
+    /// after 7 days.
+    #[serde(default)]
+    pub next_page_token: Option<String>,
+    /// Whether this is the last page. Not reliably present in live
+    /// responses; `false` may mean "unknown". Only trust `true` — never use
+    /// `false` as a signal that more pages exist.
     #[serde(default)]
     pub is_last: bool,
 }

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -24,21 +24,76 @@ impl IssueTracker for JiraClient {
     }
 
     fn search_issues(&self, query: &str, limit: usize, skip: usize) -> Result<SearchResult<Issue>> {
-        // If query looks like JQL, use it directly; otherwise, try simple conversion
-        let jql = if query.contains('=') || query.contains(" AND ") || query.contains(" OR ") {
-            query.to_string()
-        } else {
-            // Try to convert simple tracker-core query format to JQL
-            convert_simple_query_to_jql(query)
-        };
+        if limit == 0 {
+            return Ok(SearchResult::from_items(Vec::new()));
+        }
 
-        let r = self.search_issues(&jql, limit, skip)?;
+        let jql = to_jql(query);
         let fields = self.get_fields_cached();
-        let items = r
-            .issues
-            .into_iter()
-            .map(|i| jira_issue_to_core(i, &fields))
-            .collect();
+
+        // /search/jql is cursor-based (`startAt` is silently ignored), so an
+        // offset window has to be emulated: walk the token chain, discard
+        // `skip` issues, then collect up to `limit`.
+        let mut items: Vec<Issue> = Vec::new();
+        let mut remaining_skip = skip;
+        let mut token: Option<String> = None;
+        let mut no_progress_pages = 0usize;
+
+        loop {
+            // Ask for exactly what's still needed; the server caps page
+            // sizes (~100 with fields=*all) and may return fewer.
+            let page_size = remaining_skip.saturating_add(limit - items.len()).min(100);
+
+            let r = self.search_issues(&jql, page_size, token.as_deref())?;
+            let page_len = r.issues.len();
+
+            if remaining_skip >= page_len {
+                remaining_skip -= page_len;
+            } else {
+                let need = limit - items.len();
+                items.extend(
+                    r.issues
+                        .into_iter()
+                        .skip(remaining_skip)
+                        .take(need)
+                        .map(|i| jira_issue_to_core(i, &fields)),
+                );
+                remaining_skip = 0;
+            }
+
+            // A short (even empty) page is NOT a stop condition: the server
+            // legitimately returns fewer than `maxResults` rows mid-stream.
+            // Token absence is the authoritative last-page signal; `is_last`
+            // is only trustworthy when true.
+            if items.len() >= limit || r.is_last {
+                break;
+            }
+            match r.next_page_token {
+                None => break,
+                Some(t) if token.as_deref() == Some(t.as_str()) => {
+                    return Err(TrackerError::PaginationStalled(
+                        "server returned the same nextPageToken twice".to_string(),
+                    ));
+                }
+                Some(t) => {
+                    // Non-empty pages always make progress (toward skip or
+                    // items); only a run of empty pages can walk in circles.
+                    if page_len == 0 {
+                        no_progress_pages += 1;
+                        if no_progress_pages >= MAX_NO_PROGRESS_PAGES {
+                            return Err(TrackerError::PaginationStalled(
+                                "server keeps returning empty pages with fresh page tokens"
+                                    .to_string(),
+                            ));
+                        }
+                    } else {
+                        no_progress_pages = 0;
+                    }
+                    token = Some(t);
+                }
+            }
+        }
+
         Ok(SearchResult::from_items(items))
     }
 
@@ -46,6 +101,72 @@ impl IssueTracker for JiraClient {
         // The new /search/jql endpoint does not return a total count,
         // and there is no separate count endpoint on Jira Cloud.
         Ok(None)
+    }
+
+    fn search_all_issues(&self, query: &str, max_results: usize) -> Result<Vec<Issue>> {
+        let jql = to_jql(query);
+        let fields = self.get_fields_cached();
+
+        // Native cursor walk: O(pages) requests, unlike the default
+        // implementation which would re-walk the token chain from page 1
+        // for every offset window.
+        let mut all: Vec<Issue> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        let mut token: Option<String> = None;
+        let mut no_progress_pages = 0usize;
+
+        loop {
+            let remaining = max_results.saturating_sub(all.len());
+            if remaining == 0 {
+                break;
+            }
+
+            // /search/jql hard-caps maxResults at 100 for full-field requests
+            let page_size = remaining.min(100);
+            let r = self.search_issues(&jql, page_size, token.as_deref())?;
+
+            let before = all.len();
+            for ji in r.issues {
+                let issue = jira_issue_to_core(ji, &fields);
+                if seen.insert(issue.id.clone()) {
+                    all.push(issue);
+                }
+            }
+
+            // Termination first (a fully-duplicate or empty FINAL page is a
+            // legitimate end, not a stall), then anomaly detection.
+            if r.is_last {
+                break;
+            }
+            match r.next_page_token {
+                // Absent token = authoritative last page
+                None => break,
+                Some(t) if token.as_deref() == Some(t.as_str()) => {
+                    return Err(TrackerError::PaginationStalled(
+                        "server returned the same nextPageToken twice".to_string(),
+                    ));
+                }
+                Some(t) => {
+                    // Empty or fully-duplicate pages can occur mid-stream;
+                    // keep following fresh tokens, but fail loudly if the
+                    // cursor stops yielding new issues altogether rather
+                    // than returning a silently incomplete result set.
+                    if all.len() == before {
+                        no_progress_pages += 1;
+                        if no_progress_pages >= MAX_NO_PROGRESS_PAGES {
+                            return Err(TrackerError::PaginationStalled(
+                                "cursor pages stopped yielding new issues".to_string(),
+                            ));
+                        }
+                    } else {
+                        no_progress_pages = 0;
+                    }
+                    token = Some(t);
+                }
+            }
+        }
+
+        Ok(all)
     }
 
     fn create_issue(&self, issue: &CreateIssue) -> Result<Issue> {
@@ -302,6 +423,22 @@ impl IssueTracker for JiraClient {
             .into_iter()
             .map(Into::into)
             .collect())
+    }
+}
+
+/// Give up after this many consecutive cursor pages that yield no new
+/// issues. Mid-stream pages may legitimately come back empty (or fully
+/// filtered), but an unbounded run of them means the server is walking us
+/// in circles — fail loudly instead of looping or silently truncating.
+const MAX_NO_PROGRESS_PAGES: usize = 5;
+
+/// If the query already looks like JQL, use it directly; otherwise convert
+/// from the simple tracker-core query format.
+fn to_jql(query: &str) -> String {
+    if query.contains('=') || query.contains(" AND ") || query.contains(" OR ") {
+        query.to_string()
+    } else {
+        convert_simple_query_to_jql(query)
     }
 }
 

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, anyhow};
 use serde::Deserialize;
 use tracker_core::{
     CreateIssue, CustomFieldUpdate, Issue, IssueTracker, ProjectCustomField, UpdateIssue,
-    fetch_all_pages, unicode_eq_ignore_case,
+    fetch_all_pages, get_max_results, unicode_eq_ignore_case,
 };
 
 /// Shared fields for create, update, and batch-update commands.
@@ -839,17 +839,11 @@ fn handle_search(
         resolve_search_query(args.query, args.template, args.project, default_project)?;
 
     let (issues, inline_total) = if args.all {
-        // Auto-paginate using the helper; default page size 100
-        let page_size = 100usize;
-        let res = fetch_all_pages(
-            |offset, page_limit| {
-                client
-                    .search_issues(&actual_query, page_limit, offset)
-                    .map(|r| r.items)
-            },
-            page_size,
-        )
-        .context("Failed to search issues (pagination)")?;
+        // Auto-paginate; backends with cursor-based search override
+        // search_all_issues with a native cursor walk.
+        let res = client
+            .search_all_issues(&actual_query, get_max_results())
+            .context("Failed to search issues (pagination)")?;
         output_progress(&format!("Fetched {} issues", res.len()), format);
         (res, None)
     } else {

--- a/crates/track/tests/jira_integration_tests.rs
+++ b/crates/track/tests/jira_integration_tests.rs
@@ -2203,3 +2203,286 @@ fn test_jira_project_fields_shows_field_ids() {
         "expected at least one field with a customfield_ ID"
     );
 }
+
+// ============================================================================
+// Cursor Pagination Tests (with mock server) — issue #252
+// ============================================================================
+
+/// Like `mock_jira_issue`, but with a distinct internal id. Needed because
+/// `--all` deduplicates by issue id.
+fn mock_jira_issue_with_id(id: &str, key: &str, summary: &str) -> serde_json::Value {
+    let mut issue = mock_jira_issue(key, summary);
+    issue["id"] = serde_json::Value::String(id.to_string());
+    issue
+}
+
+/// Start a mock server that serves `/search/jql` pages keyed by the
+/// `nextPageToken` query parameter and captures each request target.
+///
+/// `pages_by_token` maps an expected token (`None` = first page, no token
+/// param) to the response body served for it. Unmatched requests get a 404
+/// (the backend also probes e.g. `/field`, which tolerates errors).
+fn start_jira_paged_mock_server(
+    pages_by_token: Vec<(Option<&'static str>, String)>,
+    max_requests: usize,
+) -> (thread::JoinHandle<()>, u16, Arc<Mutex<Vec<String>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind to port");
+    let port = listener.local_addr().unwrap().port();
+    let captured_targets = Arc::new(Mutex::new(Vec::new()));
+    let captured_for_thread = Arc::clone(&captured_targets);
+
+    let handle = thread::spawn(move || {
+        use std::io::{Read, Write};
+
+        let timeout = Duration::from_secs(3);
+        for stream in listener.incoming().flatten().take(max_requests) {
+            let mut stream = stream;
+            let _ = stream.set_read_timeout(Some(timeout));
+            let mut buffer = [0; 4096];
+            let size = stream.read(&mut buffer).unwrap_or(0);
+            let request = String::from_utf8_lossy(&buffer[..size]);
+
+            // Request line: "GET /rest/api/3/search/jql?... HTTP/1.1"
+            let target = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .unwrap_or("")
+                .to_string();
+            captured_for_thread.lock().unwrap().push(target.clone());
+
+            let token = target.split_once('?').and_then(|(_, query)| {
+                query
+                    .split('&')
+                    .find_map(|part| part.strip_prefix("nextPageToken=").map(str::to_string))
+            });
+
+            // Only /search/jql is token-paged; other probes (e.g. /field)
+            // get a 404, which the backend tolerates.
+            let body = if target.contains("/search/jql") {
+                pages_by_token
+                    .iter()
+                    .find(|(expected, _)| *expected == token.as_deref())
+                    .map(|(_, body)| body.as_str())
+            } else {
+                None
+            };
+
+            let response = match body {
+                Some(body) => format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                ),
+                None => "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .to_string(),
+            };
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+
+            // Draining the request body before closing is important on Windows
+            // to avoid "Connection forcibly closed by remote host" errors (RST).
+            let _ = stream.shutdown(std::net::Shutdown::Write);
+            let mut discard = [0; 1024];
+            while let Ok(n) = stream.read(&mut discard) {
+                if n == 0 {
+                    break;
+                }
+            }
+        }
+    });
+
+    (handle, port, captured_targets)
+}
+
+fn search_jql_requests(captured: &Mutex<Vec<String>>) -> Vec<String> {
+    captured
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|t| t.contains("/search/jql"))
+        .cloned()
+        .collect()
+}
+
+#[test]
+fn test_jira_search_all_walks_token_chain() {
+    // Three pages chained by nextPageToken; the middle page is deliberately
+    // short (1 issue) — short pages must NOT terminate the walk, only token
+    // absence does.
+    let pages = vec![
+        (
+            None,
+            serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("1", "TEST-1", "Issue 1"),
+                    mock_jira_issue_with_id("2", "TEST-2", "Issue 2")
+                ],
+                "nextPageToken": "tok-1"
+            })
+            .to_string(),
+        ),
+        (
+            Some("tok-1"),
+            serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("3", "TEST-3", "Issue 3")
+                ],
+                "nextPageToken": "tok-2"
+            })
+            .to_string(),
+        ),
+        (
+            Some("tok-2"),
+            serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("4", "TEST-4", "Issue 4"),
+                    mock_jira_issue_with_id("5", "TEST-5", "Issue 5")
+                ]
+            })
+            .to_string(),
+        ),
+    ];
+
+    // 3 search pages + headroom for non-search probes (/field etc.)
+    let (_server, port, captured) = start_jira_paged_mock_server(pages, 6);
+    thread::sleep(Duration::from_millis(50));
+
+    let cfg = write_jira_mock_config(port);
+    let output = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "-o", "json", "--config"])
+        .arg(&cfg)
+        .args(["issue", "search", "project = TEST", "--all"])
+        .timeout(Duration::from_secs(5))
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let issues: Vec<Value> = serde_json::from_str(&stdout).unwrap();
+    let keys: Vec<&str> = issues
+        .iter()
+        .map(|i| i["id_readable"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        keys,
+        vec!["TEST-1", "TEST-2", "TEST-3", "TEST-4", "TEST-5"],
+        "expected every issue exactly once, in page order"
+    );
+
+    let requests = search_jql_requests(&captured);
+    assert_eq!(
+        requests.len(),
+        3,
+        "expected a linear token walk (one request per page), got: {:?}",
+        requests
+    );
+    assert!(
+        !requests[0].contains("nextPageToken") && !requests[0].contains("startAt"),
+        "first request must carry neither a token nor startAt: {}",
+        requests[0]
+    );
+    assert!(
+        requests[1].contains("nextPageToken=tok-1"),
+        "second request must carry the first page's token: {}",
+        requests[1]
+    );
+    assert!(
+        requests[2].contains("nextPageToken=tok-2"),
+        "third request must carry the second page's token: {}",
+        requests[2]
+    );
+}
+
+#[test]
+fn test_jira_search_all_fails_loudly_on_stalled_pagination() {
+    // The server hands out a token but serves identical data for it: the
+    // cursor never advances. --all must fail instead of silently returning
+    // a truncated (or duplicated) result set.
+    let same_page = serde_json::json!({
+        "issues": [
+            mock_jira_issue_with_id("1", "TEST-1", "Issue 1"),
+            mock_jira_issue_with_id("2", "TEST-2", "Issue 2")
+        ],
+        "nextPageToken": "tok-1"
+    })
+    .to_string();
+    let pages = vec![(None, same_page.clone()), (Some("tok-1"), same_page)];
+
+    let (_server, port, _captured) = start_jira_paged_mock_server(pages, 4);
+    thread::sleep(Duration::from_millis(50));
+
+    let cfg = write_jira_mock_config(port);
+    cargo_bin_cmd!("track")
+        .args(["-b", "jira", "--config"])
+        .arg(&cfg)
+        .args(["issue", "search", "project = TEST", "--all"])
+        .timeout(Duration::from_secs(5))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Pagination stalled"));
+}
+
+#[test]
+fn test_jira_search_skip_shifts_window() {
+    // --skip is emulated by walking the token chain and discarding: with
+    // pages of 2+2, --limit 2 --skip 2 must return exactly the second page.
+    let pages = vec![
+        (
+            None,
+            serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("1", "TEST-1", "Issue 1"),
+                    mock_jira_issue_with_id("2", "TEST-2", "Issue 2")
+                ],
+                "nextPageToken": "tok-1"
+            })
+            .to_string(),
+        ),
+        (
+            Some("tok-1"),
+            serde_json::json!({
+                "issues": [
+                    mock_jira_issue_with_id("3", "TEST-3", "Issue 3"),
+                    mock_jira_issue_with_id("4", "TEST-4", "Issue 4")
+                ]
+            })
+            .to_string(),
+        ),
+    ];
+
+    let (_server, port, _captured) = start_jira_paged_mock_server(pages, 4);
+    thread::sleep(Duration::from_millis(50));
+
+    let cfg = write_jira_mock_config(port);
+    let output = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "-o", "json", "--config"])
+        .arg(&cfg)
+        .args([
+            "issue",
+            "search",
+            "project = TEST",
+            "--limit",
+            "2",
+            "--skip",
+            "2",
+        ])
+        .timeout(Duration::from_secs(5))
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let issues: Vec<Value> = serde_json::from_str(&stdout).unwrap();
+    let keys: Vec<&str> = issues
+        .iter()
+        .map(|i| i["id_readable"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        keys,
+        vec!["TEST-3", "TEST-4"],
+        "--skip 2 must shift the window past the first page"
+    );
+}

--- a/crates/tracker-core/src/error.rs
+++ b/crates/tracker-core/src/error.rs
@@ -27,6 +27,9 @@ pub enum TrackerError {
     #[error("Parse error: {0}")]
     Parse(String),
 
+    #[error("Pagination stalled: {0}")]
+    PaginationStalled(String),
+
     #[error("IO error: {0}")]
     Io(String),
 }

--- a/crates/tracker-core/src/lib.rs
+++ b/crates/tracker-core/src/lib.rs
@@ -6,6 +6,6 @@ pub mod traits;
 
 pub use error::{Result, TrackerError};
 pub use models::*;
-pub use pagination::{fetch_all_pages, get_max_results};
+pub use pagination::{fetch_all_pages, fetch_all_pages_keyed, get_max_results};
 pub use strings::{case_key, unicode_eq_ignore_case};
 pub use traits::{IssueTracker, KnowledgeBase};

--- a/crates/tracker-core/src/pagination.rs
+++ b/crates/tracker-core/src/pagination.rs
@@ -1,4 +1,5 @@
-use crate::error::Result;
+use crate::error::{Result, TrackerError};
+use std::collections::HashSet;
 use std::env;
 
 pub const DEFAULT_MAX_RESULTS: usize = 1000;
@@ -40,6 +41,74 @@ where
             break;
         }
 
+        current_offset += page_len;
+    }
+
+    Ok(all_results)
+}
+
+/// Like [`fetch_all_pages`], but deduplicates items by `key` and fails loudly
+/// when pagination stalls.
+///
+/// Pages that partially overlap the results collected so far (e.g. rows
+/// shifting between requests under concurrent writes) are deduplicated and
+/// the loop continues. A *full* page that contributes zero new keys means
+/// the backend's pagination is not advancing (e.g. an offset parameter the
+/// server ignores); returning the partial set would silently truncate the
+/// results, so this returns [`TrackerError::PaginationStalled`] instead.
+/// (A partial page that adds nothing new is a legitimate end of results —
+/// the offset-paging contract already treats partial pages as final.)
+///
+/// Unlike `fetch_all_pages`, `max_results` is passed explicitly — callers
+/// typically pass [`get_max_results`].
+pub fn fetch_all_pages_keyed<T, F, K>(
+    mut fetch_page: F,
+    page_size: usize,
+    max_results: usize,
+    mut key: K,
+) -> Result<Vec<T>>
+where
+    F: FnMut(usize, usize) -> Result<Vec<T>>,
+    K: FnMut(&T) -> String,
+{
+    let mut seen = HashSet::new();
+    let mut all_results: Vec<T> = Vec::new();
+    let mut current_offset = 0;
+
+    loop {
+        let remaining = max_results.saturating_sub(all_results.len());
+        if remaining == 0 {
+            break;
+        }
+
+        let limit = std::cmp::min(page_size, remaining);
+        let page_results = fetch_page(current_offset, limit)?;
+        let page_len = page_results.len();
+
+        if page_len == 0 {
+            break;
+        }
+
+        let before = all_results.len();
+        for item in page_results {
+            if seen.insert(key(&item)) {
+                all_results.push(item);
+            }
+        }
+
+        // Partial page = legitimate last page under the offset contract,
+        // even if everything on it was already seen.
+        if page_len < limit {
+            break;
+        }
+        if all_results.len() == before {
+            return Err(TrackerError::PaginationStalled(
+                "page returned no new results; backend pagination may be broken".to_string(),
+            ));
+        }
+
+        // Offset is a server-side row position: advance by the raw page
+        // length, not the unique count.
         current_offset += page_len;
     }
 
@@ -134,6 +203,137 @@ mod tests {
             5,
         );
         // Assert: error propagated
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_all_pages_keyed_collects_unique_across_pages() {
+        // Arrange: 25 distinct items, page size 10
+        let data: Vec<i32> = (1..=25).collect();
+        // Act
+        let result = fetch_all_pages_keyed(
+            |offset, limit| Ok(data[offset..].iter().copied().take(limit).collect()),
+            10,
+            1000,
+            |item| item.to_string(),
+        )
+        .unwrap();
+        // Assert: all items, in order, no duplicates
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn fetch_all_pages_keyed_dedups_overlapping_pages() {
+        // Arrange: each page re-includes the previous page's last 2 items
+        // (rows shifting under concurrent writes)
+        let data: Vec<i32> = (1..=20).collect();
+        let result = fetch_all_pages_keyed(
+            |offset, limit| {
+                let start = offset.saturating_sub(2);
+                Ok(data[start..].iter().copied().take(limit).collect())
+            },
+            10,
+            1000,
+            |item| item.to_string(),
+        )
+        .unwrap();
+        // Assert: overlap deduplicated, loop continued while progress was made
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn fetch_all_pages_keyed_errors_when_page_has_no_new_keys() {
+        // Arrange: server ignores the offset and always returns the same page
+        // (the broken-pagination failure mode from issue #252)
+        let mut call_count = 0;
+        let result = fetch_all_pages_keyed(
+            |_, limit| {
+                call_count += 1;
+                Ok((1..=limit as i32).collect())
+            },
+            10,
+            1000,
+            |item: &i32| item.to_string(),
+        );
+        // Assert: fails loudly instead of returning truncated data
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
+        assert_eq!(call_count, 2);
+    }
+
+    #[test]
+    fn fetch_all_pages_keyed_accepts_duplicate_partial_final_page() {
+        // Arrange: the final page is partial AND consists entirely of
+        // already-seen rows (rows shifted back between requests). That is a
+        // legitimate end of results, not a stall.
+        let result = fetch_all_pages_keyed(
+            |offset, _| {
+                if offset == 0 {
+                    Ok((1..=10).collect())
+                } else {
+                    Ok((6..=10).collect())
+                }
+            },
+            10,
+            1000,
+            |item: &i32| item.to_string(),
+        )
+        .unwrap();
+        assert_eq!(result, (1..=10).collect::<Vec<i32>>());
+    }
+
+    #[test]
+    fn fetch_all_pages_keyed_respects_max_results_param() {
+        // Arrange: plenty of data but cap at 15
+        let data: Vec<i32> = (1..=100).collect();
+        let mut limits = Vec::new();
+        let result = fetch_all_pages_keyed(
+            |offset, limit| {
+                limits.push(limit);
+                Ok(data[offset..].iter().copied().take(limit).collect())
+            },
+            10,
+            15,
+            |item| item.to_string(),
+        )
+        .unwrap();
+        // Assert: capped at 15; second request shrank to the remainder
+        assert_eq!(result.len(), 15);
+        assert_eq!(limits, vec![10, 5]);
+    }
+
+    #[test]
+    fn fetch_all_pages_keyed_stops_on_partial_page() {
+        // Arrange: 15 items, page size 10 — second page returns 5 (< limit)
+        let data: Vec<i32> = (1..=15).collect();
+        let result = fetch_all_pages_keyed(
+            |offset, limit| Ok(data[offset..].iter().copied().take(limit).collect()),
+            10,
+            1000,
+            |item| item.to_string(),
+        )
+        .unwrap();
+        assert_eq!(result.len(), 15);
+    }
+
+    #[test]
+    fn fetch_all_pages_keyed_propagates_error() {
+        let mut call_count = 0;
+        let result: crate::error::Result<Vec<i32>> = fetch_all_pages_keyed(
+            |_, _| {
+                call_count += 1;
+                if call_count == 1 {
+                    Ok(vec![1, 2, 3, 4, 5])
+                } else {
+                    Err(crate::error::TrackerError::Api {
+                        status: 500,
+                        message: "Server error".to_string(),
+                    })
+                }
+            },
+            5,
+            1000,
+            |item| item.to_string(),
+        );
         assert!(result.is_err());
     }
 }

--- a/crates/tracker-core/src/traits.rs
+++ b/crates/tracker-core/src/traits.rs
@@ -22,6 +22,24 @@ pub trait IssueTracker: Send + Sync {
         Ok(None)
     }
 
+    /// Fetch all issues matching `query`, auto-paginating up to `max_results`.
+    ///
+    /// The default implementation pages through [`Self::search_issues`] in
+    /// offset windows of 100, deduplicating by issue id and failing with
+    /// [`crate::TrackerError::PaginationStalled`] if a full page yields no
+    /// new issues. Backends with cursor-based search APIs (Jira Cloud
+    /// `/search/jql`, Linear) should override this with a native cursor walk
+    /// so a full scan costs O(pages) requests instead of O(pages²) through
+    /// offset emulation.
+    fn search_all_issues(&self, query: &str, max_results: usize) -> Result<Vec<Issue>> {
+        crate::pagination::fetch_all_pages_keyed(
+            |offset, limit| self.search_issues(query, limit, offset).map(|r| r.items),
+            100,
+            max_results,
+            |issue: &Issue| issue.id.clone(),
+        )
+    }
+
     /// Create a new issue
     fn create_issue(&self, issue: &CreateIssue) -> Result<Issue>;
 
@@ -326,5 +344,139 @@ pub trait KnowledgeBase: Send + Sync {
     /// Whether this backend supports native attachments on article comments.
     fn supports_article_comment_attachments(&self) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::TrackerError;
+    use std::sync::Mutex;
+
+    fn test_issue(n: usize) -> Issue {
+        Issue {
+            id: format!("id-{n}"),
+            id_readable: format!("TEST-{n}"),
+            summary: format!("Issue {n}"),
+            description: None,
+            project: ProjectRef {
+                id: "proj-1".to_string(),
+                name: None,
+                short_name: None,
+            },
+            custom_fields: Vec::new(),
+            tags: Vec::new(),
+            created: chrono::Utc::now(),
+            updated: chrono::Utc::now(),
+        }
+    }
+
+    /// Offset-window search stub. `ignore_skip` simulates the issue #252
+    /// failure mode where the server ignores the offset parameter.
+    struct StubTracker {
+        issues: Vec<Issue>,
+        ignore_skip: bool,
+        calls: Mutex<Vec<(usize, usize)>>,
+    }
+
+    impl StubTracker {
+        fn new(count: usize, ignore_skip: bool) -> Self {
+            Self {
+                issues: (1..=count).map(test_issue).collect(),
+                ignore_skip,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl IssueTracker for StubTracker {
+        fn get_issue(&self, _: &str) -> Result<Issue> {
+            unimplemented!()
+        }
+        fn search_issues(
+            &self,
+            _query: &str,
+            limit: usize,
+            skip: usize,
+        ) -> Result<SearchResult<Issue>> {
+            self.calls.lock().unwrap().push((skip, limit));
+            let skip = if self.ignore_skip { 0 } else { skip };
+            let items = self.issues.iter().skip(skip).take(limit).cloned().collect();
+            Ok(SearchResult::from_items(items))
+        }
+        fn create_issue(&self, _: &CreateIssue) -> Result<Issue> {
+            unimplemented!()
+        }
+        fn update_issue(&self, _: &str, _: &UpdateIssue) -> Result<Issue> {
+            unimplemented!()
+        }
+        fn delete_issue(&self, _: &str) -> Result<()> {
+            unimplemented!()
+        }
+        fn list_projects(&self) -> Result<Vec<Project>> {
+            unimplemented!()
+        }
+        fn get_project(&self, _: &str) -> Result<Project> {
+            unimplemented!()
+        }
+        fn create_project(&self, _: &CreateProject) -> Result<Project> {
+            unimplemented!()
+        }
+        fn resolve_project_id(&self, _: &str) -> Result<String> {
+            unimplemented!()
+        }
+        fn get_project_custom_fields(&self, _: &str) -> Result<Vec<ProjectCustomField>> {
+            unimplemented!()
+        }
+        fn list_tags(&self) -> Result<Vec<IssueTag>> {
+            unimplemented!()
+        }
+        fn get_issue_links(&self, _: &str) -> Result<Vec<IssueLink>> {
+            unimplemented!()
+        }
+        fn link_issues(&self, _: &str, _: &str, _: &str, _: &str) -> Result<()> {
+            unimplemented!()
+        }
+        fn link_subtask(&self, _: &str, _: &str) -> Result<()> {
+            unimplemented!()
+        }
+        fn add_comment(&self, _: &str, _: &str) -> Result<Comment> {
+            unimplemented!()
+        }
+        fn get_comments(&self, _: &str) -> Result<Vec<Comment>> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn search_all_issues_default_pages_with_offset() {
+        let tracker = StubTracker::new(250, false);
+        let result = tracker.search_all_issues("query", 1000).unwrap();
+        assert_eq!(result.len(), 250);
+        assert_eq!(result[0].id, "id-1");
+        assert_eq!(result[249].id, "id-250");
+        // Same request sequence the old fetch_all_pages closure produced
+        assert_eq!(
+            *tracker.calls.lock().unwrap(),
+            vec![(0, 100), (100, 100), (200, 100)]
+        );
+    }
+
+    #[test]
+    fn search_all_issues_default_respects_max_results() {
+        let tracker = StubTracker::new(250, false);
+        let result = tracker.search_all_issues("query", 150).unwrap();
+        assert_eq!(result.len(), 150);
+        assert_eq!(*tracker.calls.lock().unwrap(), vec![(0, 100), (100, 50)]);
+    }
+
+    #[test]
+    fn search_all_issues_default_errors_when_backend_ignores_skip() {
+        // The issue #252 regression: offset ignored => same page forever.
+        // Must fail loudly instead of returning truncated data.
+        let tracker = StubTracker::new(250, true);
+        let result = tracker.search_all_issues("query", 1000);
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
+        assert_eq!(tracker.calls.lock().unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #252 — on the Jira backend, `issue search --all` returned page 1 repeated ~10× (1000 rows, ~100 unique), `--skip` was ignored, and `--limit` capped at 100.

**Root cause:** the backend was migrated to Jira Cloud's cursor-based `GET /rest/api/3/search/jql` endpoint but still paginated with the legacy `startAt` offset param, which that endpoint silently ignores; the response's `nextPageToken` was never deserialized, so no caller could advance the cursor.

## Changes

### jira-backend
- `client.rs::search_issues` now takes `next_page_token: Option<&str>` (percent-encoded into the URL) instead of `start_at`; `startAt` is gone.
- `JiraSearchResult` deserializes `nextPageToken` (and tolerates a missing `issues` field).
- The trait-level `search_issues(query, limit, skip)` walks the token chain and emulates the offset window (same pattern as the Linear backend) — fixes `--skip` and `--limit > 100`.
- A native `search_all_issues` override makes `--all` a **linear** token walk: 10 requests per 1000 issues instead of O(pages²) skip-emulation.
- Per Atlassian's contract, **token absence is the only authoritative last-page signal**: short/empty pages mid-stream are followed (`isLast` is trusted only when `true`), with a bounded no-progress budget and `PaginationStalled` errors on repeated/circling tokens so an anomalous server fails loudly instead of hanging or silently truncating.

### tracker-core
- New `TrackerError::PaginationStalled`.
- New `fetch_all_pages_keyed`: dedups by key and hard-errors when a *full* page yields zero new items (a partial page that adds nothing is a legitimate end). `fetch_all_pages` is untouched, so comments/articles call sites are unchanged.
- New `IssueTracker::search_all_issues` default method built on it — reproduces the exact request sequence the CLI's old `--all` closure issued, so YouTrack/GitHub/GitLab/Linear/tracker-mock behavior is preserved (now with dedup + loud stall detection).

### track CLI
- The `--all` arm calls `client.search_all_issues(&query, get_max_results())`; non-`--all` path unchanged (`TRACK_MAX_RESULTS` semantics identical).
- Version bumped to 1.10.2.

## Tests

- wiremock unit tests: token round-trip, no `startAt` on the wire, skip across page boundaries, termination on missing token, `--limit > 100` accumulation, token percent-encoding (`+/=&`), `max_results` cap binding, repeated-token and no-progress stall errors, empty-page-with-fresh-token continuation, skip-beyond-end, `limit == 0`.
- tracker-core unit tests for the keyed pager and the default trait method, including a stub that reproduces the #252 failure mode (offset ignored) and must now error instead of returning duplicates.
- CLI integration tests against a token-paged mock server: `--all` walks the chain linearly (request targets asserted), `--all` exits non-zero on a stalled cursor, `--skip` shifts the window.

## Follow-ups (out of scope)

- Linear `--all` is quadratic-but-correct today; it could get its own native `search_all_issues` override.
- Comments/articles call sites could migrate from `fetch_all_pages` to the keyed variant.

## Live verification

Verified end-to-end with this branch's build against a real Jira Cloud instance, on a project with 896 matching issues (anonymized):

| Check | Before (1.10.1, per #252) | This branch |
|---|---|---|
| `--all` | 1000 rows, only 100 unique (page 1 ×10) | 896 rows, 896 unique — every issue exactly once |
| `--skip` at three offsets (0 / 5 / near-end) | identical first page at every offset | three distinct, correctly shifted windows; the near-end offset returned the project's oldest issues, unreachable before |
| `--limit 500` | capped at 100 | 500 rows |
| `--skip` past the end of the result set | n/a | clean empty result, exit 0 |

The first-page window matched the repro output in #252 exactly, confirming the same dataset the bug was filed against.
