### PR TITLE
fix(jira): parse real created/updated dates and surface resolution date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/github-backend/src/convert.rs
+++ b/crates/github-backend/src/convert.rs
@@ -71,6 +71,7 @@ pub fn github_issue_to_core(issue: GitHubIssue, owner: &str, repo: &str) -> Issu
         tags,
         created: parse_github_datetime(&issue.created_at).unwrap_or_else(Utc::now),
         updated: parse_github_datetime(&issue.updated_at).unwrap_or_else(Utc::now),
+        resolved: issue.closed_at.as_deref().and_then(parse_github_datetime),
     }
 }
 

--- a/crates/gitlab-backend/src/convert.rs
+++ b/crates/gitlab-backend/src/convert.rs
@@ -61,6 +61,7 @@ pub fn gitlab_issue_to_core(issue: GitLabIssue, project_id: &str) -> tracker_cor
         tags,
         created: parse_gitlab_datetime(&issue.created_at).unwrap_or_else(Utc::now),
         updated: parse_gitlab_datetime(&issue.updated_at).unwrap_or_else(Utc::now),
+        resolved: parse_gitlab_datetime(&issue.closed_at),
     }
 }
 

--- a/crates/jira-backend/src/confluence_impl.rs
+++ b/crates/jira-backend/src/confluence_impl.rs
@@ -1,12 +1,13 @@
 //! Implementation of tracker-core KnowledgeBase trait for ConfluenceClient
 
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use tracker_core::{
     Article, ArticleAttachment, ArticleRef, AttachmentUpload, Comment, CommentAuthor,
     CreateArticle, KnowledgeBase, ProjectRef, Result, TrackerError, UpdateArticle,
 };
 
 use crate::confluence::ConfluenceClient;
+use crate::convert::parse_jira_datetime;
 use crate::markdown::storage::{markdown_to_storage, storage_to_text};
 use crate::models::confluence::*;
 
@@ -261,19 +262,12 @@ fn confluence_page_to_article(page: ConfluencePage) -> Article {
             .map(|v| storage_to_text(&v))
     });
 
-    let created = page
-        .created_at
-        .as_ref()
-        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-        .map(|d| d.with_timezone(&Utc))
-        .unwrap_or_else(Utc::now);
+    let created = parse_jira_datetime(&page.created_at).unwrap_or_else(Utc::now);
 
     let updated = page
         .version
         .as_ref()
-        .and_then(|v| v.created_at.as_ref())
-        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-        .map(|d| d.with_timezone(&Utc))
+        .and_then(|v| parse_jira_datetime(&v.created_at))
         .unwrap_or(created);
 
     Article {
@@ -329,11 +323,7 @@ fn search_content_to_article(content: ConfluenceSearchContent) -> Article {
 }
 
 fn confluence_attachment_to_article_attachment(att: ConfluenceAttachment) -> ArticleAttachment {
-    let created = att
-        .created_at
-        .as_ref()
-        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-        .map(|d| d.with_timezone(&Utc));
+    let created = parse_jira_datetime(&att.created_at);
 
     ArticleAttachment {
         id: att.id,
@@ -351,9 +341,7 @@ fn confluence_uploaded_attachment_to_article_attachment(
     let created = att
         .version
         .as_ref()
-        .and_then(|v| v.when.as_ref())
-        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-        .map(|d| d.with_timezone(&Utc));
+        .and_then(|v| parse_jira_datetime(&v.when));
 
     let (mime_type, size) = att
         .metadata
@@ -387,11 +375,7 @@ fn confluence_comment_to_comment(comment: ConfluenceComment) -> Comment {
         .map(|v| storage_to_text(&v))
         .unwrap_or_default();
 
-    let created = comment
-        .created_at
-        .as_ref()
-        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-        .map(|d| d.with_timezone(&Utc));
+    let created = parse_jira_datetime(&comment.created_at);
 
     let author = comment.version.and_then(|v| {
         v.author_id.map(|id| CommentAuthor {

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -151,6 +151,7 @@ pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
             .collect(),
         created: parse_jira_datetime(&j.fields.created).unwrap_or_else(Utc::now),
         updated: parse_jira_datetime(&j.fields.updated).unwrap_or_else(Utc::now),
+        resolved: parse_jira_datetime(&j.fields.resolution_date),
     }
 }
 
@@ -496,9 +497,13 @@ pub fn update_issue_to_jira(
 }
 
 /// Parse Jira datetime string to chrono DateTime
+///
+/// Jira Cloud emits offsets without a colon (`2024-01-15T10:00:00.000+0000`),
+/// which strict RFC 3339 parsing rejects, so fall back to a `%z`-based format.
 fn parse_jira_datetime(dt: &Option<String>) -> Option<DateTime<Utc>> {
     dt.as_ref().and_then(|s| {
         chrono::DateTime::parse_from_rfc3339(s)
+            .or_else(|_| chrono::DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f%z"))
             .ok()
             .map(|d| d.with_timezone(&Utc))
     })
@@ -1256,6 +1261,7 @@ mod tests {
                 labels: vec![],
                 created: Some("2024-01-15T10:00:00.000+0000".to_string()),
                 updated: Some("2024-01-15T12:00:00.000+0000".to_string()),
+                resolution_date: None,
                 subtasks: vec![],
                 parent: None,
                 issuelinks: vec![],
@@ -1293,6 +1299,65 @@ mod tests {
         assert!(
             matches!(priority, CustomField::SingleEnum { value: Some(v), .. } if v == "Medium")
         );
+
+        // Real dates from the fixture, not marshal time (regression for the
+        // strict-RFC3339 bug that stamped every issue with Utc::now())
+        use chrono::TimeZone;
+        assert_eq!(
+            core.created,
+            Utc.with_ymd_and_hms(2024, 1, 15, 10, 0, 0).unwrap()
+        );
+        assert_eq!(
+            core.updated,
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap()
+        );
+        assert_eq!(core.resolved, None);
+    }
+
+    #[test]
+    fn jira_issue_to_core_maps_resolution_date() {
+        use chrono::TimeZone;
+        let mut issue = mock_jira_issue_for_conversion(Default::default());
+        issue.fields.resolution_date = Some("2024-02-01T08:30:00.000+0000".to_string());
+
+        let core = jira_issue_to_core(issue, &[]);
+        assert_eq!(
+            core.resolved,
+            Some(Utc.with_ymd_and_hms(2024, 2, 1, 8, 30, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_jira_datetime_handles_jira_cloud_offsets() {
+        use chrono::TimeZone;
+        // Jira Cloud emits colon-less offsets, which strict RFC 3339 rejects
+        assert_eq!(
+            parse_jira_datetime(&Some("2024-01-15T10:00:00.000+0000".to_string())),
+            Some(Utc.with_ymd_and_hms(2024, 1, 15, 10, 0, 0).unwrap())
+        );
+        assert_eq!(
+            parse_jira_datetime(&Some("2024-01-15T10:00:00.000-0500".to_string())),
+            Some(Utc.with_ymd_and_hms(2024, 1, 15, 15, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_jira_datetime_handles_rfc3339() {
+        use chrono::TimeZone;
+        assert_eq!(
+            parse_jira_datetime(&Some("2024-01-15T10:00:00Z".to_string())),
+            Some(Utc.with_ymd_and_hms(2024, 1, 15, 10, 0, 0).unwrap())
+        );
+        assert_eq!(
+            parse_jira_datetime(&Some("2024-01-15T10:00:00.000+00:00".to_string())),
+            Some(Utc.with_ymd_and_hms(2024, 1, 15, 10, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_jira_datetime_rejects_invalid() {
+        assert_eq!(parse_jira_datetime(&Some("not a date".to_string())), None);
+        assert_eq!(parse_jira_datetime(&None), None);
     }
 
     #[test]

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -496,11 +496,11 @@ pub fn update_issue_to_jira(
     })
 }
 
-/// Parse Jira datetime string to chrono DateTime
+/// Parse an Atlassian (Jira/Confluence) datetime string to chrono DateTime
 ///
 /// Jira Cloud emits offsets without a colon (`2024-01-15T10:00:00.000+0000`),
 /// which strict RFC 3339 parsing rejects, so fall back to a `%z`-based format.
-fn parse_jira_datetime(dt: &Option<String>) -> Option<DateTime<Utc>> {
+pub(crate) fn parse_jira_datetime(dt: &Option<String>) -> Option<DateTime<Utc>> {
     dt.as_ref().and_then(|s| {
         chrono::DateTime::parse_from_rfc3339(s)
             .or_else(|_| chrono::DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f%z"))

--- a/crates/jira-backend/src/models/issue.rs
+++ b/crates/jira-backend/src/models/issue.rs
@@ -48,6 +48,9 @@ pub struct JiraIssueFields {
     pub created: Option<String>,
     /// Last update timestamp
     pub updated: Option<String>,
+    /// Resolution timestamp (Jira sends this field as all-lowercase)
+    #[serde(rename = "resolutiondate", default)]
+    pub resolution_date: Option<String>,
     /// Subtasks
     #[serde(default)]
     pub subtasks: Vec<JiraIssueRef>,

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -9,7 +9,7 @@ use tracker_core::{
 use crate::client::JiraClient;
 use crate::convert::{
     create_issue_to_jira, get_standard_custom_fields, jira_field_to_project_custom_field,
-    jira_issue_to_core, merge_fields, update_issue_to_jira,
+    jira_issue_to_core, merge_fields, parse_jira_datetime, update_issue_to_jira,
 };
 use crate::models::{
     CreateJiraIssueLink, IssueKeyRef, IssueLinkTypeName, ParentId, UpdateJiraIssue,
@@ -488,11 +488,7 @@ fn convert_simple_query_to_jql(query: &str) -> String {
 }
 
 fn jira_attachment_to_core(attachment: crate::models::JiraAttachment) -> IssueAttachment {
-    let created = attachment
-        .created
-        .as_deref()
-        .and_then(|created| chrono::DateTime::parse_from_rfc3339(created).ok())
-        .map(|created| created.with_timezone(&chrono::Utc));
+    let created = parse_jira_datetime(&attachment.created);
 
     IssueAttachment {
         id: attachment.id,
@@ -535,5 +531,25 @@ mod tests {
         let pure_keyword = "bug fixing";
         let jql_pure_keyword = convert_simple_query_to_jql(pure_keyword);
         assert_eq!(jql_pure_keyword, "text ~ \"bug fixing\"");
+    }
+
+    #[test]
+    fn attachment_created_parses_jira_cloud_offset() {
+        use chrono::TimeZone;
+        let attachment = crate::models::JiraAttachment {
+            id: "10000".to_string(),
+            filename: "log.txt".to_string(),
+            size: 42,
+            mime_type: None,
+            content: None,
+            created: Some("2024-01-15T10:00:00.000+0000".to_string()),
+            author: None,
+        };
+
+        let core = jira_attachment_to_core(attachment);
+        assert_eq!(
+            core.created,
+            Some(chrono::Utc.with_ymd_and_hms(2024, 1, 15, 10, 0, 0).unwrap())
+        );
     }
 }

--- a/crates/linear-backend/src/client.rs
+++ b/crates/linear-backend/src/client.rs
@@ -19,6 +19,8 @@ const ISSUE_FIELDS: &str = r#"
     url
     createdAt
     updatedAt
+    completedAt
+    canceledAt
     team { id key name description }
     state { id name type position }
     assignee { id name displayName email }

--- a/crates/linear-backend/src/convert.rs
+++ b/crates/linear-backend/src/convert.rs
@@ -86,6 +86,7 @@ pub fn linear_issue_to_core(issue: LinearIssue) -> Issue {
         tags,
         created: issue.created_at,
         updated: issue.updated_at,
+        resolved: issue.completed_at.or(issue.canceled_at),
     }
 }
 

--- a/crates/linear-backend/src/models.rs
+++ b/crates/linear-backend/src/models.rs
@@ -99,6 +99,10 @@ pub struct LinearIssue {
     pub url: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub canceled_at: Option<DateTime<Utc>>,
     pub team: LinearTeam,
     pub state: Option<LinearWorkflowState>,
     pub assignee: Option<LinearUser>,

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.10.2"
+version = "1.10.3"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -1961,6 +1961,7 @@ mod tests {
             tags: vec![],
             created: chrono::Utc::now(),
             updated: chrono::Utc::now(),
+            resolved: None,
         };
 
         let warnings = verify_issue_update(&requested, &result);
@@ -1999,6 +2000,7 @@ mod tests {
             tags: vec![],
             created: chrono::Utc::now(),
             updated: chrono::Utc::now(),
+            resolved: None,
         };
 
         let warnings = verify_issue_update(&requested, &result);

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -355,6 +355,14 @@ impl Displayable for Issue {
                 .dimmed()
         );
 
+        if let Some(resolved) = &self.resolved {
+            output.push_str(&format!(
+                "\n  {}: {}",
+                "Resolved".dimmed(),
+                resolved.format("%Y-%m-%d %H:%M:%S").to_string().dimmed()
+            ));
+        }
+
         if let Some(desc) = &self.description {
             output.push_str(&format!("\n  {}: {}", "Description".dimmed(), desc));
         }
@@ -694,6 +702,7 @@ mod tests {
             tags: vec![],
             created: chrono::Utc::now(),
             updated: chrono::Utc::now(),
+            resolved: None,
         }
     }
 

--- a/crates/tracker-core/src/models.rs
+++ b/crates/tracker-core/src/models.rs
@@ -23,6 +23,9 @@ pub struct Issue {
     pub created: DateTime<Utc>,
     /// Last update timestamp
     pub updated: DateTime<Utc>,
+    /// Resolution timestamp (None if unresolved)
+    #[serde(default)]
+    pub resolved: Option<DateTime<Utc>>,
 }
 
 /// Reference to a project (minimal fields)

--- a/crates/tracker-core/src/models.rs
+++ b/crates/tracker-core/src/models.rs
@@ -23,7 +23,11 @@ pub struct Issue {
     pub created: DateTime<Utc>,
     /// Last update timestamp
     pub updated: DateTime<Utc>,
-    /// Resolution timestamp (None if unresolved)
+    /// Resolution timestamp. This is when the backend recorded a resolution,
+    /// not a general "is closed" flag — an issue can sit in a resolved/done
+    /// state with no resolution date set (e.g. a Jira workflow without a
+    /// "Set Resolution" post-function). Use the State custom field's
+    /// `is_resolved` to test closedness.
     #[serde(default)]
     pub resolved: Option<DateTime<Utc>>,
 }

--- a/crates/tracker-core/src/traits.rs
+++ b/crates/tracker-core/src/traits.rs
@@ -368,6 +368,7 @@ mod tests {
             tags: Vec::new(),
             created: chrono::Utc::now(),
             updated: chrono::Utc::now(),
+            resolved: None,
         }
     }
 

--- a/crates/youtrack-backend/src/client.rs
+++ b/crates/youtrack-backend/src/client.rs
@@ -6,7 +6,7 @@ use tracker_core::{AttachmentUpload, unicode_eq_ignore_case};
 use ureq::Agent;
 use ureq::unversioned::multipart::{Form, Part};
 
-const DEFAULT_ISSUE_FIELDS: &str = "id,idReadable,summary,description,project(id,name,shortName),customFields(name,$type,value(name,login,isResolved,text)),tags(id,name),created,updated";
+const DEFAULT_ISSUE_FIELDS: &str = "id,idReadable,summary,description,project(id,name,shortName),customFields(name,$type,value(name,login,isResolved,text)),tags(id,name),created,updated,resolved";
 const DEFAULT_PROJECT_FIELDS: &str = "id,name,shortName,description";
 const DEFAULT_ARTICLE_FIELDS: &str = "id,idReadable,summary,content,project(id,name,shortName),parentArticle(id,idReadable,summary),hasChildren,tags(id,name),created,updated,reporter(login,name)";
 

--- a/crates/youtrack-backend/src/convert.rs
+++ b/crates/youtrack-backend/src/convert.rs
@@ -20,6 +20,7 @@ impl From<yt::Issue> for core::Issue {
             tags: issue.tags.into_iter().map(Into::into).collect(),
             created: issue.created,
             updated: issue.updated,
+            resolved: issue.resolved,
         }
     }
 }

--- a/crates/youtrack-backend/src/models/issue.rs
+++ b/crates/youtrack-backend/src/models/issue.rs
@@ -18,6 +18,8 @@ pub struct Issue {
     pub created: DateTime<Utc>,
     #[serde(with = "chrono::serde::ts_milliseconds")]
     pub updated: DateTime<Utc>,
+    #[serde(default, with = "chrono::serde::ts_milliseconds_option")]
+    pub resolved: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
## Summary

Fixes two data-quality defects found while building reporting tooling against `track` on Jira Cloud (issues #2 and #3 from that audit; follow-up to the pagination fix in #253):

### 1. `created`/`updated` were extraction-time stamps, not the issue's real dates

Jira Cloud emits datetime offsets without a colon (`2024-01-15T10:00:00.000+0000`). `parse_jira_datetime` used strict `parse_from_rfc3339`, which requires `+00:00`, so parsing silently failed on **every** Jira date and the `unwrap_or_else(Utc::now)` fallback stamped each row with its marshal time. The existing test fixture already used the `+0000` shape but never asserted on dates, which is why this went unnoticed.

Fixed by falling back to `parse_from_str` with `%Y-%m-%dT%H:%M:%S%.f%z` (chrono's `%z` accepts colon-less offsets). Comment timestamps share the same parser and are repaired too.

### 2. Resolution date was never surfaced

The core `Issue` struct had no `resolved` field. Added `resolved: Option<DateTime<Utc>>` (`#[serde(default)]` — additive and backward compatible with previously serialized issues), populated by all five backends:

| Backend | Source |
|---|---|
| Jira | `resolutiondate` (explicit serde rename — the API field is all-lowercase) |
| GitHub | `closed_at` (already fetched, previously unused) |
| GitLab | `closed_at` (already fetched, previously unused) |
| YouTrack | `resolved` (added to `DEFAULT_ISSUE_FIELDS`) |
| Linear | `completedAt ?? canceledAt` (added to the GraphQL fragment; matches Linear's own resolved-state semantics) |

Human-readable issue output shows a `Resolved:` line when present; JSON output picks the field up automatically.

Also bumps `track` to 1.10.3.

## Verification

- `cargo test --workspace`: 696 passed, 0 failed. New unit tests cover the `+0000` offset shape, RFC 3339 variants, invalid input, and `resolutiondate` mapping, plus a regression assert that the existing `+0000` fixture yields its real dates instead of "now".
- `cargo clippy --workspace --all-targets`: no new warnings (remaining ones pre-exist on main).
- Verified live against Jira Cloud: the oldest issue in a 2023-era project now reports `created: 2023-02-16T03:29:48.492Z` (previously: the current second) with non-null `resolved`; unresolved issues report `resolved: null`.
