### PR TITLE
fix(issue): route --field Status to state transitions and close verification gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -1825,4 +1825,92 @@ mod tests {
         let result = client.link_issues("PROJ-1", "PROJ-2", "depends", "OUTWARD");
         assert!(result.is_ok());
     }
+
+    #[tokio::test]
+    async fn test_update_issue_rejects_conflicting_status_values() {
+        // No mocks needed: the conflict is detected before any request is sent
+        // (the /field metadata fetch degrades gracefully to an empty list).
+        let mock_server = MockServer::start().await;
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::{CustomFieldUpdate, IssueTracker, TrackerError, UpdateIssue};
+        let update = UpdateIssue {
+            custom_fields: vec![
+                CustomFieldUpdate::State {
+                    name: "State".to_string(),
+                    value: "Done".to_string(),
+                },
+                CustomFieldUpdate::State {
+                    name: "Status".to_string(),
+                    value: "In Progress".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let err = IssueTracker::update_issue(&client, "TEST-1", &update).unwrap_err();
+        match err {
+            TrackerError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("Done") && msg.contains("In Progress"),
+                    "{}",
+                    msg
+                );
+            }
+            other => panic!("expected InvalidInput, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_issue_collapses_duplicate_status_values() {
+        // Two State updates carrying the same value are not a conflict:
+        // exactly one transition must fire.
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-1/transitions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "transitions": [
+                    { "id": "31", "name": "Done", "to": { "id": "3", "name": "Done" } }
+                ]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/issue/TEST-1/transitions"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-1"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(mock_jira_issue("TEST-1", "Test")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+
+        use tracker_core::{CustomFieldUpdate, IssueTracker, UpdateIssue};
+        let update = UpdateIssue {
+            custom_fields: vec![
+                CustomFieldUpdate::State {
+                    name: "State".to_string(),
+                    value: "Done".to_string(),
+                },
+                CustomFieldUpdate::State {
+                    name: "Status".to_string(),
+                    value: "Done".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let issue = IssueTracker::update_issue(&client, "TEST-1", &update).unwrap();
+        assert_eq!(issue.id_readable, "TEST-1");
+    }
 }

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -776,7 +776,7 @@ fn dropped_reserved_field_warning(name: &str, silently_handled: &[&str]) -> Opti
         ""
     };
     Some(format!(
-        "Field '{}' was not applied: it is reserved on Jira and cannot be set through a field edit.{}",
+        "Field '{}' was not applied: the Jira backend does not set it through field edits.{}",
         name, hint
     ))
 }

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -424,7 +424,7 @@ pub fn create_issue_to_jira(
 
     let issue_type = issue_type_opt.unwrap_or_else(|| "Task".to_string());
 
-    let extra = resolve_extra_fields(&issue.custom_fields, jira_fields)?;
+    let extra = resolve_extra_fields(&issue.custom_fields, jira_fields, CREATE_HANDLED_FIELDS)?;
 
     Ok(CreateJiraIssue {
         fields: CreateJiraIssueFields {
@@ -475,7 +475,7 @@ pub fn update_issue_to_jira(
         _ => None,
     });
 
-    let extra = resolve_extra_fields(&update.custom_fields, jira_fields)?;
+    let extra = resolve_extra_fields(&update.custom_fields, jira_fields, UPDATE_HANDLED_FIELDS)?;
 
     Ok(UpdateJiraIssue {
         fields: UpdateJiraIssueFields {
@@ -749,6 +749,38 @@ fn is_reserved_field(name: &str) -> bool {
         .any(|&r| r.eq_ignore_ascii_case(name))
 }
 
+/// Reserved fields the create path consumes through the typed request struct;
+/// dropping them from "extra" is expected and must stay silent.
+const CREATE_HANDLED_FIELDS: &[&str] = &["priority", "type", "issuetype"];
+
+/// Reserved fields the update path consumes through the typed request struct.
+/// Status/state never legitimately reach `resolve_extra_fields` on this path:
+/// `CustomFieldUpdate::State` is partitioned out upstream and routed to the
+/// /transitions endpoint, so a status-named field seen here was mistyped
+/// (e.g. SingleEnum) and is about to be dropped.
+const UPDATE_HANDLED_FIELDS: &[&str] = &["priority"];
+
+/// Warning for a reserved-name field that is about to be silently dropped, or
+/// None when the caller's typed struct already carries it.
+fn dropped_reserved_field_warning(name: &str, silently_handled: &[&str]) -> Option<String> {
+    if silently_handled
+        .iter()
+        .any(|h| h.eq_ignore_ascii_case(name))
+    {
+        return None;
+    }
+    let hint = if name.eq_ignore_ascii_case("status") || name.eq_ignore_ascii_case("state") {
+        " Jira changes status through workflow transitions, not field edits: \
+         use `issue update --state <value>` or `issue start`/`issue complete`."
+    } else {
+        ""
+    };
+    Some(format!(
+        "Field '{}' was not applied: it is reserved on Jira and cannot be set through a field edit.{}",
+        name, hint
+    ))
+}
+
 /// Resolve custom field updates to Jira extra fields using field metadata.
 /// Returns a map of field_id → JSON value for fields not handled by the standard struct.
 fn insert_resolved_field(
@@ -798,6 +830,7 @@ fn insert_resolved_field(
 pub fn resolve_extra_fields(
     custom_fields: &[CustomFieldUpdate],
     jira_fields: &[JiraField],
+    silently_handled: &[&str],
 ) -> tracker_core::Result<HashMap<String, serde_json::Value>> {
     let field_id_map = build_field_id_map(jira_fields);
     let schema_map: HashMap<&str, &JiraFieldSchema> = jira_fields
@@ -813,6 +846,9 @@ pub fn resolve_extra_fields(
             | CustomFieldUpdate::State { name, value }
             | CustomFieldUpdate::SingleUser { name, login: value } => {
                 if is_reserved_field(name) {
+                    if let Some(msg) = dropped_reserved_field_warning(name, silently_handled) {
+                        eprintln!("Warning: {}", msg);
+                    }
                     continue;
                 }
                 if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
@@ -823,6 +859,9 @@ pub fn resolve_extra_fields(
             CustomFieldUpdate::MultiEnum { name, values } => {
                 let joined = values.join(",");
                 if is_reserved_field(name) {
+                    if let Some(msg) = dropped_reserved_field_warning(name, silently_handled) {
+                        eprintln!("Warning: {}", msg);
+                    }
                     continue;
                 }
                 if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
@@ -1023,7 +1062,8 @@ mod tests {
             },
         ];
 
-        let extra = resolve_extra_fields(&custom_fields, &jira_fields).unwrap();
+        let extra =
+            resolve_extra_fields(&custom_fields, &jira_fields, UPDATE_HANDLED_FIELDS).unwrap();
 
         assert!(!extra.contains_key("timeoriginalestimate"));
         assert!(!extra.contains_key("timeestimate"));
@@ -1052,7 +1092,8 @@ mod tests {
             }),
         }];
 
-        let extra = resolve_extra_fields(&custom_fields, &jira_fields).unwrap();
+        let extra =
+            resolve_extra_fields(&custom_fields, &jira_fields, UPDATE_HANDLED_FIELDS).unwrap();
 
         assert!(!extra.contains_key("timeoriginalestimate"));
         assert!(extra.contains_key("timetracking"));
@@ -1102,12 +1143,44 @@ mod tests {
             },
         ];
 
-        let extra = resolve_extra_fields(&custom_fields, &jira_fields).unwrap();
+        let extra =
+            resolve_extra_fields(&custom_fields, &jira_fields, UPDATE_HANDLED_FIELDS).unwrap();
         // Priority and State should be skipped (handled by struct/transitions),
         // Story Points should be resolved
         assert!(!extra.contains_key("priority"));
         assert!(!extra.contains_key("customfield_11315")); // "State" custom field should be skipped
         assert_eq!(extra["customfield_10016"], serde_json::json!(3.0));
+    }
+
+    #[test]
+    fn dropped_status_field_warns_on_update_with_transition_hint() {
+        let msg = dropped_reserved_field_warning("Status", UPDATE_HANDLED_FIELDS)
+            .expect("dropping a status field edit must warn");
+        assert!(msg.contains("Status"));
+        assert!(msg.contains("transition"));
+        // "state" alias gets the same treatment, in any case
+        assert!(dropped_reserved_field_warning("STATE", UPDATE_HANDLED_FIELDS).is_some());
+    }
+
+    #[test]
+    fn typed_struct_fields_drop_silently_per_call_site() {
+        // priority is consumed by the typed struct on both paths
+        assert!(dropped_reserved_field_warning("Priority", UPDATE_HANDLED_FIELDS).is_none());
+        assert!(dropped_reserved_field_warning("priority", CREATE_HANDLED_FIELDS).is_none());
+        // issue type is only consumed at create; dropping it from an update is a real loss
+        assert!(dropped_reserved_field_warning("Type", CREATE_HANDLED_FIELDS).is_none());
+        assert!(dropped_reserved_field_warning("issuetype", CREATE_HANDLED_FIELDS).is_none());
+        assert!(dropped_reserved_field_warning("Type", UPDATE_HANDLED_FIELDS).is_some());
+        // status can never be set through a field edit, even at create
+        assert!(dropped_reserved_field_warning("status", CREATE_HANDLED_FIELDS).is_some());
+    }
+
+    #[test]
+    fn dropped_assignee_warns_without_transition_hint() {
+        let msg = dropped_reserved_field_warning("Assignee", UPDATE_HANDLED_FIELDS)
+            .expect("dropping an assignee field edit must warn");
+        assert!(msg.contains("Assignee"));
+        assert!(!msg.contains("transition"));
     }
 
     #[test]

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -188,10 +188,23 @@ impl IssueTracker for JiraClient {
             .cloned()
             .partition(|cf| matches!(cf, CustomFieldUpdate::State { .. }));
 
-        let status_target = status_update.into_iter().next().and_then(|cf| match cf {
-            CustomFieldUpdate::State { value, .. } => Some(value),
-            _ => None,
-        });
+        let mut status_targets: Vec<String> = status_update
+            .into_iter()
+            .filter_map(|cf| match cf {
+                CustomFieldUpdate::State { value, .. } => Some(value),
+                _ => None,
+            })
+            .collect();
+        status_targets.sort();
+        status_targets.dedup();
+        if status_targets.len() > 1 {
+            return Err(TrackerError::InvalidInput(format!(
+                "Conflicting status values requested in one update ({}). \
+                 Jira supports a single status transition per update.",
+                status_targets.join(", ")
+            )));
+        }
+        let status_target = status_targets.pop();
 
         let stripped = UpdateIssue {
             custom_fields: other_fields,

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.10.4"
+version = "1.10.5"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/cli.rs
+++ b/crates/track/src/cli.rs
@@ -564,7 +564,7 @@ pub enum IssueCommands {
         /// Issue ID(s) - comma-separated for batch (e.g., PROJ-123 or PROJ-1,PROJ-2,PROJ-3)
         #[arg(value_delimiter = ',')]
         ids: Vec<String>,
-        /// State field name (default: "Stage")
+        /// State field name; "State"/"Stage"/"Status" route to workflow transitions (default: "Stage")
         #[arg(long, default_value = "Stage")]
         field: String,
         /// State value for in-progress (default: "Develop")
@@ -577,7 +577,7 @@ pub enum IssueCommands {
         /// Issue ID(s) - comma-separated for batch (e.g., PROJ-123 or PROJ-1,PROJ-2,PROJ-3)
         #[arg(value_delimiter = ',')]
         ids: Vec<String>,
-        /// State field name (default: "Stage")
+        /// State field name; "State"/"Stage"/"Status" route to workflow transitions (default: "Stage")
         #[arg(long, default_value = "Stage")]
         field: String,
         /// State value for done (default: "Done")

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -1229,6 +1229,28 @@ fn handle_unlink(
     Ok(())
 }
 
+/// Build the custom field update for a state transition (`issue start`/`issue complete`).
+///
+/// State-typed field names get the State variant so backends route them to their
+/// workflow-transition machinery: "State"/"Stage" (YouTrack), "Status" (Jira).
+/// Anything else falls back to SingleEnum.
+fn build_state_field_update(field: &str, state: &str) -> CustomFieldUpdate {
+    if field.eq_ignore_ascii_case("State")
+        || field.eq_ignore_ascii_case("Stage")
+        || field.eq_ignore_ascii_case("Status")
+    {
+        CustomFieldUpdate::State {
+            name: field.to_string(),
+            value: state.to_string(),
+        }
+    } else {
+        CustomFieldUpdate::SingleEnum {
+            name: field.to_string(),
+            value: state.to_string(),
+        }
+    }
+}
+
 fn handle_state_transition(
     client: &dyn IssueTracker,
     id: &str,
@@ -1237,25 +1259,10 @@ fn handle_state_transition(
     action: &str,
     format: OutputFormat,
 ) -> Result<()> {
-    // Build the custom field update based on field name
-    let custom_field = if field.eq_ignore_ascii_case("State") || field.eq_ignore_ascii_case("Stage")
-    {
-        CustomFieldUpdate::State {
-            name: field.to_string(),
-            value: state.to_string(),
-        }
-    } else {
-        // For non-State fields, treat as SingleEnum
-        CustomFieldUpdate::SingleEnum {
-            name: field.to_string(),
-            value: state.to_string(),
-        }
-    };
-
     let update = UpdateIssue {
         summary: None,
         description: None,
-        custom_fields: vec![custom_field],
+        custom_fields: vec![build_state_field_update(field, state)],
         tags: vec![],
         parent: None,
     };
@@ -1263,6 +1270,9 @@ fn handle_state_transition(
     let issue = client
         .update_issue(id, &update)
         .with_context(|| format!("Failed to update issue '{}' state to '{}'", id, state))?;
+
+    let warnings = verify_issue_update(&update, &issue);
+    crate::output::output_verification_warnings(&warnings, format);
 
     match format {
         OutputFormat::Json => {
@@ -1330,7 +1340,7 @@ fn handle_update_batch(
                 .and_then(|update| validate_update(client, id, &update))
                 .map(|_| None)
         } else {
-            handle_update_single(client, id, args).map(Some)
+            handle_update_single(client, id, args, format).map(Some)
         };
 
         match result {
@@ -1363,6 +1373,7 @@ fn handle_update_single(
     client: &dyn IssueTracker,
     id: &str,
     args: &IssueFieldArgs,
+    format: OutputFormat,
 ) -> Result<Issue> {
     let update = build_update(client, id, args)?;
 
@@ -1374,7 +1385,18 @@ fn handle_update_single(
         .update_issue(id, &update)
         .with_context(|| format!("Failed to update issue '{}'", id))?;
 
+    let warnings = prefix_warnings(id, verify_issue_update(&update, &issue));
+    crate::output::output_verification_warnings(&warnings, format);
+
     Ok(issue)
+}
+
+/// Prefix verification warnings with the issue ID so batch output stays attributable.
+fn prefix_warnings(id: &str, warnings: Vec<String>) -> Vec<String> {
+    warnings
+        .into_iter()
+        .map(|w| format!("{}: {}", id, w))
+        .collect()
 }
 
 fn handle_delete_batch(
@@ -1430,24 +1452,10 @@ fn handle_state_transition_batch(
         return handle_state_transition(client, &ids[0], field, state, action, format);
     }
 
-    // Build the custom field update
-    let custom_field = if field.eq_ignore_ascii_case("State") || field.eq_ignore_ascii_case("Stage")
-    {
-        CustomFieldUpdate::State {
-            name: field.to_string(),
-            value: state.to_string(),
-        }
-    } else {
-        CustomFieldUpdate::SingleEnum {
-            name: field.to_string(),
-            value: state.to_string(),
-        }
-    };
-
     let update = UpdateIssue {
         summary: None,
         description: None,
-        custom_fields: vec![custom_field],
+        custom_fields: vec![build_state_field_update(field, state)],
         tags: vec![],
         parent: None,
     };
@@ -1460,6 +1468,8 @@ fn handle_state_transition_batch(
 
         match result {
             Ok(issue) => {
+                let warnings = prefix_warnings(id, verify_issue_update(&update, &issue));
+                crate::output::output_verification_warnings(&warnings, format);
                 results.push(BatchResult {
                     id: id.clone(),
                     success: true,
@@ -1618,6 +1628,21 @@ fn verify_field_match(
         CustomField::Unknown { name } => unicode_eq_ignore_case(name, req_name),
     });
 
+    // A State update targets the tracker's workflow state field whatever the backend
+    // names it (YouTrack "State"/"Stage", Jira "Status"). When the requested name has
+    // no match, fall back to the result's State-typed field — but only when there is
+    // exactly one, so we never verify against the wrong field.
+    let actual = actual.or_else(|| {
+        if !matches!(requested, CustomFieldUpdate::State { .. }) {
+            return None;
+        }
+        let mut states = actual_fields
+            .iter()
+            .filter(|f| matches!(f, CustomField::State { .. }));
+        let first = states.next();
+        if states.next().is_none() { first } else { None }
+    });
+
     match (requested, actual) {
         (
             CustomFieldUpdate::SingleEnum { name, value },
@@ -1655,15 +1680,17 @@ fn verify_field_match(
             }
         }
         (
-            CustomFieldUpdate::State { name, value },
+            CustomFieldUpdate::State { value, .. },
             Some(CustomField::State {
-                value: actual_val, ..
+                name: actual_name,
+                value: actual_val,
+                ..
             }),
         ) => {
             if actual_val.as_deref().unwrap_or("") != value {
                 Some(format!(
                     "Field '{}': expected '{}', got '{}'",
-                    name,
+                    actual_name,
                     value,
                     actual_val.as_deref().unwrap_or("None")
                 ))
@@ -2007,5 +2034,108 @@ mod tests {
         assert_eq!(warnings.len(), 2);
         assert!(warnings[0].contains("Summary"));
         assert!(warnings[1].contains("State"));
+    }
+
+    #[test]
+    fn state_field_update_routes_status_state_and_stage_to_state_variant() {
+        for field in ["Status", "status", "State", "Stage", "STAGE"] {
+            assert!(
+                matches!(
+                    build_state_field_update(field, "Done"),
+                    CustomFieldUpdate::State { .. }
+                ),
+                "'{}' should build a State update",
+                field
+            );
+        }
+        assert!(matches!(
+            build_state_field_update("Backlog", "Done"),
+            CustomFieldUpdate::SingleEnum { .. }
+        ));
+    }
+
+    #[test]
+    fn verifies_state_update_against_renamed_state_field() {
+        use tracker_core::CustomField;
+
+        // Jira: the CLI requests "State", the converted issue names the field "Status"
+        let requested = CustomFieldUpdate::State {
+            name: "State".to_string(),
+            value: "Done".to_string(),
+        };
+        let actual = vec![CustomField::State {
+            name: "Status".to_string(),
+            value: Some("Done".to_string()),
+            is_resolved: true,
+        }];
+
+        assert!(verify_field_match(&requested, &actual).is_none());
+    }
+
+    #[test]
+    fn detects_state_mismatch_against_renamed_state_field() {
+        use tracker_core::CustomField;
+
+        let requested = CustomFieldUpdate::State {
+            name: "State".to_string(),
+            value: "Done".to_string(),
+        };
+        let actual = vec![CustomField::State {
+            name: "Status".to_string(),
+            value: Some("New".to_string()),
+            is_resolved: false,
+        }];
+
+        let warning = verify_field_match(&requested, &actual).expect("mismatch must warn");
+        assert!(
+            warning.contains("Status"),
+            "warning should name the actual field: {}",
+            warning
+        );
+        assert!(warning.contains("Done") && warning.contains("New"));
+    }
+
+    #[test]
+    fn state_fallback_requires_unique_state_field() {
+        use tracker_core::CustomField;
+
+        let requested = CustomFieldUpdate::State {
+            name: "Phase".to_string(),
+            value: "Done".to_string(),
+        };
+        let actual = vec![
+            CustomField::State {
+                name: "State".to_string(),
+                value: Some("Done".to_string()),
+                is_resolved: true,
+            },
+            CustomField::State {
+                name: "Stage".to_string(),
+                value: Some("Develop".to_string()),
+                is_resolved: false,
+            },
+        ];
+
+        // Two state fields and no name match: never guess, report as ignored
+        let warning = verify_field_match(&requested, &actual).expect("ambiguity must warn");
+        assert!(warning.contains("ignored"));
+    }
+
+    #[test]
+    fn non_state_updates_do_not_fall_back_to_state_field() {
+        use tracker_core::CustomField;
+
+        let requested = CustomFieldUpdate::SingleEnum {
+            name: "Component".to_string(),
+            value: "UI".to_string(),
+        };
+        let actual = vec![CustomField::State {
+            name: "Status".to_string(),
+            value: Some("Done".to_string()),
+            is_resolved: true,
+        }];
+
+        let warning = verify_field_match(&requested, &actual).expect("missing field must warn");
+        assert!(warning.contains("ignored"));
     }
 }

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -818,6 +818,28 @@ mod tests {
     }
 
     #[test]
+    fn change_summary_with_renamed_state_field_smoke() {
+        // Jira shape: `--state Done` requests "State", the issue carries "Status".
+        // Exercises the full summary path (display assertions aren't capturable here;
+        // the name resolution itself is covered by the tests above).
+        let old = issue_with_custom_fields(vec![CustomField::State {
+            name: "Status".into(),
+            value: Some("New".into()),
+            is_resolved: false,
+        }]);
+        let new = issue_with_custom_fields(vec![CustomField::State {
+            name: "Status".into(),
+            value: Some("Done".into()),
+            is_resolved: true,
+        }]);
+        let update = tracker_core::UpdateIssue {
+            custom_fields: vec![state_update("State")],
+            ..Default::default()
+        };
+        output_change_summary(Some(&old), &new, Some(&update), None, OutputFormat::Text);
+    }
+
+    #[test]
     fn non_state_request_never_resolves_to_state_field() {
         let issue = issue_with_custom_fields(vec![CustomField::State {
             name: "Status".into(),

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -100,13 +100,7 @@ pub fn output_change_summary(
             requested_fields.insert(case_key("Parent"));
         }
         for f in &u.custom_fields {
-            let name = match f {
-                tracker_core::CustomFieldUpdate::SingleEnum { name, .. } => name,
-                tracker_core::CustomFieldUpdate::MultiEnum { name, .. } => name,
-                tracker_core::CustomFieldUpdate::State { name, .. } => name,
-                tracker_core::CustomFieldUpdate::SingleUser { name, .. } => name,
-            };
-            requested_fields.insert(case_key(name));
+            requested_fields.insert(case_key(resolve_requested_field_name(f, new)));
         }
     }
     if let Some(c) = create {
@@ -118,13 +112,7 @@ pub fn output_change_summary(
             requested_fields.insert(case_key("Parent"));
         }
         for f in &c.custom_fields {
-            let name = match f {
-                tracker_core::CustomFieldUpdate::SingleEnum { name, .. } => name,
-                tracker_core::CustomFieldUpdate::MultiEnum { name, .. } => name,
-                tracker_core::CustomFieldUpdate::State { name, .. } => name,
-                tracker_core::CustomFieldUpdate::SingleUser { name, .. } => name,
-            };
-            requested_fields.insert(case_key(name));
+            requested_fields.insert(case_key(resolve_requested_field_name(f, new)));
         }
     }
 
@@ -161,14 +149,7 @@ pub fn output_change_summary(
 
     // Check Custom Fields
     for new_cf in &new.custom_fields {
-        let name = match new_cf {
-            CustomField::SingleEnum { name, .. } => name,
-            CustomField::State { name, .. } => name,
-            CustomField::SingleUser { name, .. } => name,
-            CustomField::Text { name, .. } => name,
-            CustomField::MultiEnum { name, .. } => name,
-            CustomField::Unknown { name, .. } => name,
-        };
+        let name = custom_field_name(new_cf);
 
         let old_val = old.and_then(|o| find_field_value(o, name));
         let new_val = find_field_value(new, name);
@@ -229,18 +210,57 @@ fn display_change(name: &str, old: Option<&str>, new: Option<&str>, requested: &
     }
 }
 
+/// Resolve a requested custom field update to the field name the issue actually
+/// carries. A State update targets the tracker's workflow state field whatever the
+/// backend names it (YouTrack "State"/"Stage", Jira "Status"): when the requested
+/// name doesn't appear on the issue but the issue has exactly one State-typed field,
+/// the request resolves to that field so the change summary attributes it correctly
+/// instead of reporting "(Side Effect)" plus a bogus "Ignored" row.
+fn resolve_requested_field_name<'a>(
+    requested: &'a tracker_core::CustomFieldUpdate,
+    issue: &'a Issue,
+) -> &'a str {
+    let name = match requested {
+        tracker_core::CustomFieldUpdate::SingleEnum { name, .. } => name,
+        tracker_core::CustomFieldUpdate::MultiEnum { name, .. } => name,
+        tracker_core::CustomFieldUpdate::State { name, .. } => name,
+        tracker_core::CustomFieldUpdate::SingleUser { name, .. } => name,
+    };
+
+    let name_exists = issue
+        .custom_fields
+        .iter()
+        .any(|f| unicode_eq_ignore_case(custom_field_name(f), name));
+    if !matches!(requested, tracker_core::CustomFieldUpdate::State { .. }) || name_exists {
+        return name;
+    }
+
+    let mut states = issue.custom_fields.iter().filter_map(|f| match f {
+        CustomField::State { name, .. } => Some(name.as_str()),
+        _ => None,
+    });
+    match (states.next(), states.next()) {
+        (Some(state_name), None) => state_name,
+        _ => name,
+    }
+}
+
+fn custom_field_name(f: &CustomField) -> &str {
+    match f {
+        CustomField::SingleEnum { name, .. } => name,
+        CustomField::State { name, .. } => name,
+        CustomField::SingleUser { name, .. } => name,
+        CustomField::Text { name, .. } => name,
+        CustomField::MultiEnum { name, .. } => name,
+        CustomField::Unknown { name, .. } => name,
+    }
+}
+
 fn find_field_value(issue: &Issue, name: &str) -> Option<String> {
     issue
         .custom_fields
         .iter()
-        .find(|f| match f {
-            CustomField::SingleEnum { name: n, .. } => unicode_eq_ignore_case(n, name),
-            CustomField::State { name: n, .. } => unicode_eq_ignore_case(n, name),
-            CustomField::SingleUser { name: n, .. } => unicode_eq_ignore_case(n, name),
-            CustomField::Text { name: n, .. } => unicode_eq_ignore_case(n, name),
-            CustomField::MultiEnum { name: n, .. } => unicode_eq_ignore_case(n, name),
-            CustomField::Unknown { name: n, .. } => unicode_eq_ignore_case(n, name),
-        })
+        .find(|f| unicode_eq_ignore_case(custom_field_name(f), name))
         .and_then(|f| match f {
             CustomField::SingleEnum { value, .. } => value.clone(),
             CustomField::State { value, .. } => value.clone(),
@@ -727,5 +747,90 @@ mod tests {
     fn find_field_value_misses_when_truly_different() {
         let issue = issue_with_field("Geöffnet", "value");
         assert_eq!(find_field_value(&issue, "Geschlossen"), None);
+    }
+
+    fn issue_with_custom_fields(custom_fields: Vec<CustomField>) -> Issue {
+        Issue {
+            custom_fields,
+            ..issue_with_field("unused", "unused")
+        }
+    }
+
+    fn state_update(name: &str) -> tracker_core::CustomFieldUpdate {
+        tracker_core::CustomFieldUpdate::State {
+            name: name.into(),
+            value: "Done".into(),
+        }
+    }
+
+    #[test]
+    fn state_request_resolves_to_renamed_state_field() {
+        // Jira names its state field "Status"; a `--state` request arrives as "State"
+        let issue = issue_with_custom_fields(vec![CustomField::State {
+            name: "Status".into(),
+            value: Some("Done".into()),
+            is_resolved: true,
+        }]);
+        assert_eq!(
+            resolve_requested_field_name(&state_update("State"), &issue),
+            "Status"
+        );
+    }
+
+    #[test]
+    fn state_request_keeps_name_when_it_exists_on_issue() {
+        let issue = issue_with_custom_fields(vec![
+            CustomField::State {
+                name: "Stage".into(),
+                value: Some("Done".into()),
+                is_resolved: true,
+            },
+            CustomField::State {
+                name: "State".into(),
+                value: Some("Open".into()),
+                is_resolved: false,
+            },
+        ]);
+        assert_eq!(
+            resolve_requested_field_name(&state_update("Stage"), &issue),
+            "Stage"
+        );
+    }
+
+    #[test]
+    fn state_request_keeps_name_when_state_fields_ambiguous() {
+        let issue = issue_with_custom_fields(vec![
+            CustomField::State {
+                name: "Stage".into(),
+                value: Some("Done".into()),
+                is_resolved: true,
+            },
+            CustomField::State {
+                name: "Status".into(),
+                value: Some("Open".into()),
+                is_resolved: false,
+            },
+        ]);
+        assert_eq!(
+            resolve_requested_field_name(&state_update("Phase"), &issue),
+            "Phase"
+        );
+    }
+
+    #[test]
+    fn non_state_request_never_resolves_to_state_field() {
+        let issue = issue_with_custom_fields(vec![CustomField::State {
+            name: "Status".into(),
+            value: Some("Done".into()),
+            is_resolved: true,
+        }]);
+        let requested = tracker_core::CustomFieldUpdate::SingleEnum {
+            name: "Component".into(),
+            value: "UI".into(),
+        };
+        assert_eq!(
+            resolve_requested_field_name(&requested, &issue),
+            "Component"
+        );
     }
 }


### PR DESCRIPTION
Closes #257.

`issue complete/start --field Status` built a `SingleEnum` update that the Jira backend silently dropped (reserved field), reporting `✓ N issues completed` for a server-side no-op. Meanwhile the one path that did verify (`issue update --state`) emitted a *false* "update was ignored" warning on Jira because it looked the field up by the request name `State` while the converted issue names it `Status`.

## Fixes (matching the issue's four-link chain)

1. **State-field allowlist** — `build_state_field_update` (shared by single/batch transition paths) now maps `Status` — Jira's state field name — to `CustomFieldUpdate::State` alongside `State`/`Stage`, so it routes to the `/transitions` endpoint instead of a silently-dropped field edit. The `--field` help text documents the routing names.
2. **Variant-aware verification** — `verify_field_match`: a requested `State` update whose name matches nothing falls back to the result's State-typed field **only when exactly one exists**, so Jira's `State`→`Status` rename verifies by value instead of warning "ignored". Mismatch warnings name the actual field.
3. **Verification everywhere** — `complete`/`start` (single + batch) and batch `update` now run `verify_issue_update` and print warnings, ID-prefixed in batch paths. The original command from the issue now warns instead of claiming success.
4. **Change-summary attribution** — a requested `State` name resolves to the issue's actual state field, so the requested change is no longer labeled `(Side Effect)` with a bogus `state (Ignored)` row.
5. **Jira: conflicting transitions** — multiple `State` updates with different values now return `InvalidInput` (previously: first honored, rest silently discarded); identical duplicates collapse.
6. **Jira: reserved-field drops warn** — `resolve_extra_fields` warns on stderr when dropping a reserved-name field, parameterized per call site so typed-struct fields (priority, type at create) stay silent. Status-named drops include a transition hint.

## Testing

- 15 new unit tests across `track` (variant selection, renamed-field verification incl. ambiguity guard, change-summary name resolution) and `jira-backend` (warning classification, conflicting/duplicate transitions via wiremock). Full workspace suite green; clippy clean for touched crates.
- **Live-tested against Jira Cloud (DS project) with disposable issues (since deleted):**
  - `issue done DS-4077,DS-4078 --field Status --state Done` → issues actually transition to Done on the server (re-fetched to confirm). Bonus: when the workflow validator rejected the transition (missing Original Estimate), the command reported `✗ 0/2 issues completed` with the server error — the old code swallowed exactly this class of failure as success.
  - `issue update DS-4079 --state Done -v` → no false warning; summary reads `Status: New -> Done` with no `(Side Effect)` prefix and no `state (Ignored)` row.
  - `issue create --state Done` → now warns twice (backend drop + verification mismatch) where it was previously silent.
  - Conflicting `--state "In Progress" --field "Status=To Do"` → clean `InvalidInput` error naming both values.
  - Single-ID `issue start --field Status`, schema-detected `--field Status=Done` → both transition correctly.

## Notes

- Adversarial review flagged one theoretical YouTrack edge: a project with a custom **enum** field literally named `Status` passed via `--field Status` now routes through the State variant (YouTrack applies it via the Commands API, which is field-type agnostic, and verification stays silent on the type mismatch) — no false warning, behavior preserved.
- Pre-existing, out of scope (now at least *surfaced* by fix 6's warning instead of silently dropped): `--assignee` is not mapped by the Jira backend on create or update.

## Release

- Bumps `track` `1.10.4` → `1.10.5` (`crates/track/Cargo.toml` + `Cargo.lock`).
