### PR TITLE
feat(issue): add `issue history` command for change/transition timeline (#260)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -301,6 +301,20 @@ track issue comments PROJ-123 --limit 10
 ```
 
 
+### History
+
+Show an issue's change history — the time-ordered timeline of field transitions
+(status changes, assignee changes, etc.) with timestamps and authors.
+**Jira only** for now; other backends report "not supported".
+
+```bash
+track -b j issue history PROJ-123                 # Full timeline, newest first
+track -b j i hist PROJ-123 --field status         # Only status transitions
+track -b j i history PROJ-123 --since 7d           # Last 7 days (s/m/h/d/w)
+track -b j -o json i history PROJ-123              # {"issue": id, "changes": [...]}
+```
+
+
 ### Links
 
 ```bash
@@ -469,6 +483,7 @@ Single command to get all relevant data: projects, fields, users, query template
 | `track issue search` | `track i s`, `track i find` |
 | `track issue delete` | `track i rm`, `track i del` |
 | `track issue comment` | `track i cmt` |
+| `track issue history` | `track i history`, `track i hist` |
 | `track issue complete` | `track i done`, `track i resolve` |
 | `track issue start` | `track i start` |
 | `track issue link` | `track i link` |

--- a/agent-skills/SKILL.md
+++ b/agent-skills/SKILL.md
@@ -176,6 +176,7 @@ track config clear [-g]        # Delete a config file
 | Unlink | `track i ul PROJ-1 <link-id>` | `track -b j i ul PROJ-1 <link-id>` | Not supported | `track -b gl i ul 42 <link-id>` |
 | Start | `track i start PROJ-123` | `track -b j i start PROJ-123 --field Status --state "In Progress"` | `track -b gh i start 42` | `track -b gl i start 42` |
 | Complete | `track i done PROJ-123` | `track -b j i done PROJ-123 --field Status --state Done` | `track -b gh i done 42` (closes) | `track -b gl i done 42` (closes) |
+| History | Not supported | `track -b j i history PROJ-123 --field status --since 7d` | Not supported | Not supported |
 
 **Bare-ID shortcut**: `track PROJ-123` = `track issue get PROJ-123`, but it only fires for IDs shaped `ALPHANUM-DIGITS` with **exactly one dash** (`PROJ-123`, `my2proj-99`). Purely numeric IDs must use `track i g 42`. Global flags (`-b`, `-o`, ...) must come **before** the ID; the only flag recognized after the ID is `--full`.
 
@@ -329,6 +330,7 @@ Default mappings:
 | `track issue delete` | `track i rm`, `track i del` |
 | `track issue comment` | `track i cmt` |
 | `track issue comments` | `track i comments` |
+| `track issue history` | `track i history`, `track i hist` |
 | `track issue complete` | `track i done`, `track i resolve` |
 | `track issue start` | `track i start` |
 | `track issue link` | `track i link` |
@@ -382,6 +384,26 @@ track completions zsh      # Shell completions (bash|zsh|fish|powershell|elvish)
 - **`--full`** wraps the issue in an envelope: `{"issue": {...}, "links": [{"id", "direction", "link_type", "issues": [...]}], "comments": [{"id", "text", "author", "created"}]}`. Attachments are NOT included — use `track i attachments`.
 - **`i s -o json`** returns a bare array — no total or pagination metadata (hints go to stderr in text mode only).
 - **`i del -o json`** returns `{"success": true, "message": "..."}`.
+
+**History** (`i history`, **Jira only** — other backends error with "not supported"):
+```json
+{
+  "issue": "PROJ-123",
+  "changes": [
+    {
+      "at": "2026-05-01T12:03:44Z",
+      "author": {"login": "712020:...", "name": "Jane Doe"},  // null if unknown
+      "field": "status",        // canonical; "status" is normalized across backends
+      "from": "In Progress",    // human-readable; null on first set
+      "to": "Done"
+    }
+  ]
+}
+```
+
+- Ordered **newest-first**. `author` reuses the comment-author shape (`{login, name}`).
+- Filter at the source: `--field status` (canonical name) and `--since 7d` (`s`/`m`/`h`/`d`/`w`).
+- No batch form — one call per issue. For flow metrics across a board, search for the candidate set first, then call `i history` per issue.
 
 ---
 

--- a/crates/jira-backend/src/client.rs
+++ b/crates/jira-backend/src/client.rs
@@ -407,6 +407,68 @@ impl JiraClient {
         Ok(comments.comments)
     }
 
+    // ==================== History Operations ====================
+
+    /// Fetch one page of an issue's changelog.
+    ///
+    /// `GET /issue/{key}/changelog` is offset-paged (`startAt`/`maxResults`),
+    /// unlike the cursor-based issue search.
+    pub fn get_issue_changelog_page(
+        &self,
+        key: &str,
+        start_at: usize,
+        max_results: usize,
+    ) -> Result<JiraChangelogPage> {
+        let url = format!(
+            "{}?startAt={}&maxResults={}",
+            self.api_url(&format!("/issue/{}/changelog", key)),
+            start_at,
+            max_results
+        );
+
+        let response = self
+            .agent
+            .get(&url)
+            .header("Authorization", &self.auth_header)
+            .header("Accept", "application/json")
+            .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let page: JiraChangelogPage = response.body_mut().read_json()?;
+        Ok(page)
+    }
+
+    /// Fetch an issue's complete changelog, paging through every entry.
+    ///
+    /// Jira returns changelog entries oldest-first; that order is preserved
+    /// here (the caller re-sorts as needed).
+    pub fn get_issue_changelog(&self, key: &str) -> Result<Vec<JiraChangelogEntry>> {
+        const PAGE: usize = 100;
+        // Generous backstop: real changelogs are orders of magnitude smaller.
+        // It guards against a server that ignores `startAt` or never sets
+        // `isLast` (which would otherwise loop forever) without silently
+        // truncating a legitimately large history. We do NOT stop on a short
+        // page — Jira may cap `maxResults` below what we asked, so a short page
+        // is not a reliable end-of-data signal; `isLast`/`total` are.
+        const MAX_PAGES: usize = 10_000;
+        let mut entries = Vec::new();
+        let mut start_at = 0;
+        for _ in 0..MAX_PAGES {
+            let page = self.get_issue_changelog_page(key, start_at, PAGE)?;
+            let fetched = page.values.len();
+            entries.extend(page.values);
+            if page.is_last || fetched == 0 || (page.total > 0 && entries.len() >= page.total) {
+                return Ok(entries);
+            }
+            start_at += fetched;
+        }
+        Err(JiraError::PaginationStalled(format!(
+            "issue '{}' changelog did not terminate after {} pages",
+            key, MAX_PAGES
+        )))
+    }
+
     // ==================== Link Operations ====================
 
     /// Create a link between two issues

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -670,6 +670,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_issue_history_paginates_and_sorts() {
+        use tracker_core::IssueTracker;
+
+        let mock_server = MockServer::start().await;
+
+        // Page 1: two entries, not the last page.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-123/changelog"))
+            .and(query_param("startAt", "0"))
+            .and(query_param("maxResults", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "startAt": 0,
+                "maxResults": 2,
+                "total": 3,
+                "isLast": false,
+                "values": [
+                    {
+                        "id": "1",
+                        "author": { "accountId": "acc-1", "displayName": "Alice" },
+                        "created": "2024-01-10T09:00:00.000+0000",
+                        "items": [
+                            { "field": "status", "fromString": "To Do", "toString": "In Progress" }
+                        ]
+                    },
+                    {
+                        "id": "2",
+                        "author": { "accountId": "acc-2", "displayName": "Bob" },
+                        "created": "2024-01-12T11:00:00.000+0000",
+                        "items": [
+                            { "field": "assignee", "fromString": null, "toString": "Alice" }
+                        ]
+                    }
+                ]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Page 2: the final entry (newest), isLast=true.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-123/changelog"))
+            .and(query_param("startAt", "2"))
+            .and(query_param("maxResults", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "startAt": 2,
+                "maxResults": 2,
+                "total": 3,
+                "isLast": true,
+                "values": [
+                    {
+                        "id": "3",
+                        "author": { "accountId": "acc-1", "displayName": "Alice" },
+                        "created": "2024-01-15T14:00:00.000+0000",
+                        "items": [
+                            { "field": "status", "fromString": "In Progress", "toString": "Done" }
+                        ]
+                    }
+                ]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = JiraClient::new(&mock_server.uri(), "test@test.com", "test-token");
+        let events = client.get_issue_history("TEST-123").unwrap();
+
+        // Three entries across two pages, one item each => three events.
+        assert_eq!(events.len(), 3);
+        // Newest-first ordering.
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].to.as_deref(), Some("Done"));
+        assert_eq!(events[2].to.as_deref(), Some("In Progress"));
+        // Author mapping (accountId -> login, displayName -> name).
+        assert_eq!(
+            events[0].author.as_ref().map(|a| a.login.as_str()),
+            Some("acc-1")
+        );
+        // Null fromString maps to None.
+        let assignee = events.iter().find(|e| e.field == "assignee").unwrap();
+        assert_eq!(assignee.from, None);
+    }
+
+    #[tokio::test]
     async fn test_unauthorized_error() {
         let mock_server = MockServer::start().await;
 

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -5,9 +5,9 @@ use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use tracker_core::{
-    Comment, CommentAuthor, CreateIssue, CustomField, CustomFieldUpdate, Issue, IssueLink,
-    IssueLinkType, LinkedIssue, Project, ProjectCustomField, ProjectRef, StateValueInfo, Tag,
-    UpdateIssue, User,
+    Comment, CommentAuthor, CreateIssue, CustomField, CustomFieldUpdate, Issue, IssueHistoryEvent,
+    IssueLink, IssueLinkType, LinkedIssue, Project, ProjectCustomField, ProjectRef, StateValueInfo,
+    Tag, UpdateIssue, User, canonical_field_name,
 };
 
 use crate::markdown::adf::{
@@ -322,6 +322,42 @@ impl From<JiraComment> for Comment {
             created: parse_jira_datetime(&c.created),
         }
     }
+}
+
+/// Convert Jira changelog entries into core history events, newest-first.
+///
+/// Each changelog entry may carry multiple field changes (`items`); every item
+/// becomes one [`IssueHistoryEvent`], sharing the entry's author and timestamp.
+/// `from_string`/`to_string` (human-readable) are used for the values. Entries
+/// whose timestamp cannot be parsed are skipped rather than fabricated, and
+/// field names are canonicalized so `status` is portable across backends.
+pub fn jira_changelog_to_history_events(
+    entries: Vec<JiraChangelogEntry>,
+) -> Vec<IssueHistoryEvent> {
+    let mut events = Vec::new();
+    for entry in entries {
+        let Some(at) = parse_jira_datetime(&entry.created) else {
+            continue;
+        };
+        let author = entry.author.map(|u| CommentAuthor {
+            login: u.account_id.unwrap_or_default(),
+            name: u.display_name,
+        });
+        for item in entry.items {
+            events.push(IssueHistoryEvent {
+                at,
+                author: author.clone(),
+                field: canonical_field_name(&item.field),
+                from: item.from_string,
+                to: item.to_string,
+            });
+        }
+    }
+    // Jira returns oldest-first; expose newest-first to match reporting needs.
+    // `sort_by` is a stable sort, so multiple items from one changelog entry
+    // (which share a timestamp) keep their original within-entry order.
+    events.sort_by(|a, b| b.at.cmp(&a.at));
+    events
 }
 
 /// Convert JiraIssueLinkType to tracker-core IssueLinkType
@@ -1679,5 +1715,99 @@ mod tests {
             "3.5"
         );
         assert_eq!(format_number(&serde_json::Number::from(42)), "42");
+    }
+
+    #[test]
+    fn jira_changelog_maps_items_newest_first() {
+        let page: JiraChangelogPage = serde_json::from_value(serde_json::json!({
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 2,
+            "isLast": true,
+            "values": [
+                {
+                    "id": "1",
+                    "author": { "accountId": "acc-1", "displayName": "Alice" },
+                    "created": "2024-01-10T09:00:00.000+0000",
+                    "items": [
+                        { "field": "status", "fromString": "To Do", "toString": "In Progress" }
+                    ]
+                },
+                {
+                    "id": "2",
+                    "author": { "accountId": "acc-2", "displayName": "Bob" },
+                    "created": "2024-01-15T14:30:00.000+0000",
+                    "items": [
+                        { "field": "assignee", "fromString": null, "toString": "Alice" },
+                        { "field": "priority", "fromString": "Medium", "toString": "High" }
+                    ]
+                }
+            ]
+        }))
+        .unwrap();
+
+        let events = jira_changelog_to_history_events(page.values);
+
+        // Two entries, one with two items => three events.
+        assert_eq!(events.len(), 3);
+
+        // Newest entry (2024-01-15) sorts first; its two items preserve order.
+        assert_eq!(events[0].field, "assignee");
+        assert_eq!(events[0].from, None); // null fromString -> None
+        assert_eq!(events[0].to.as_deref(), Some("Alice"));
+        assert_eq!(
+            events[0].author.as_ref().and_then(|a| a.name.as_deref()),
+            Some("Bob")
+        );
+        assert_eq!(
+            events[0].author.as_ref().map(|a| a.login.as_str()),
+            Some("acc-2")
+        );
+        assert_eq!(events[1].field, "priority");
+
+        // Oldest entry sorts last.
+        assert_eq!(events[2].field, "status");
+        assert_eq!(events[2].from.as_deref(), Some("To Do"));
+        assert_eq!(events[2].to.as_deref(), Some("In Progress"));
+    }
+
+    #[test]
+    fn jira_changelog_canonicalizes_state_field() {
+        // A backend that names the field "State" should fold onto "status" so
+        // `--field status` is portable.
+        let page: JiraChangelogPage = serde_json::from_value(serde_json::json!({
+            "values": [
+                {
+                    "created": "2024-02-01T00:00:00.000+0000",
+                    "items": [{ "field": "State", "fromString": "Open", "toString": "Closed" }]
+                }
+            ]
+        }))
+        .unwrap();
+
+        let events = jira_changelog_to_history_events(page.values);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].field, "status");
+    }
+
+    #[test]
+    fn jira_changelog_skips_unparseable_timestamp() {
+        let page: JiraChangelogPage = serde_json::from_value(serde_json::json!({
+            "values": [
+                {
+                    "created": null,
+                    "items": [{ "field": "status", "toString": "Done" }]
+                },
+                {
+                    "created": "2024-03-01T12:00:00.000+0000",
+                    "items": [{ "field": "status", "toString": "Done" }]
+                }
+            ]
+        }))
+        .unwrap();
+
+        let events = jira_changelog_to_history_events(page.values);
+        // The entry with no timestamp is dropped rather than fabricated.
+        assert_eq!(events.len(), 1);
     }
 }

--- a/crates/jira-backend/src/error.rs
+++ b/crates/jira-backend/src/error.rs
@@ -24,6 +24,9 @@ pub enum JiraError {
     #[error("API error ({status}): {message}")]
     Api { status: u16, message: String },
 
+    #[error("Pagination stalled: {0}")]
+    PaginationStalled(String),
+
     #[error(
         "status '{requested}' is not reachable from the current state; available transitions: {available:?}"
     )]
@@ -45,6 +48,7 @@ impl From<JiraError> for TrackerError {
             JiraError::ProjectNotFound(id) => TrackerError::ProjectNotFound(id),
             JiraError::Unauthorized => TrackerError::Unauthorized,
             JiraError::Api { status, message } => TrackerError::Api { status, message },
+            JiraError::PaginationStalled(msg) => TrackerError::PaginationStalled(msg),
             JiraError::InvalidTransition {
                 requested,
                 available,

--- a/crates/jira-backend/src/models/changelog.rs
+++ b/crates/jira-backend/src/models/changelog.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+
+use super::user::JiraUser;
+
+/// One page of an issue's changelog from
+/// `GET /rest/api/3/issue/{key}/changelog`.
+///
+/// This endpoint is offset-paged (a `PageBean`), unlike the cursor-based issue
+/// search.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraChangelogPage {
+    #[serde(default)]
+    pub start_at: usize,
+    #[serde(default)]
+    pub max_results: usize,
+    #[serde(default)]
+    pub total: usize,
+    #[serde(default)]
+    pub is_last: bool,
+    #[serde(default)]
+    pub values: Vec<JiraChangelogEntry>,
+}
+
+/// A single changelog entry: one author making one or more field changes at a
+/// single point in time.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraChangelogEntry {
+    pub id: Option<String>,
+    pub author: Option<JiraUser>,
+    /// Creation timestamp (Atlassian datetime string).
+    pub created: Option<String>,
+    #[serde(default)]
+    pub items: Vec<JiraChangelogItem>,
+}
+
+/// A single field modification within a changelog entry.
+///
+/// `from_string`/`to_string` carry human-readable values (status names, user
+/// display names); `from`/`to` carry the corresponding internal IDs.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraChangelogItem {
+    #[serde(default)]
+    pub field: String,
+    pub field_id: Option<String>,
+    pub fieldtype: Option<String>,
+    pub from: Option<String>,
+    pub from_string: Option<String>,
+    pub to: Option<String>,
+    pub to_string: Option<String>,
+}

--- a/crates/jira-backend/src/models/mod.rs
+++ b/crates/jira-backend/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod changelog;
 pub mod comment;
 pub mod confluence;
 pub mod field;
@@ -6,6 +7,7 @@ pub mod project;
 pub mod transitions;
 pub mod user;
 
+pub use changelog::*;
 pub use comment::*;
 pub use confluence::*;
 pub use field::*;

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -2,14 +2,15 @@
 
 use tracker_core::{
     AttachmentUpload, Comment, CreateIssue, CreateProject, CreateTag, Issue, IssueAttachment,
-    IssueLink, IssueLinkType, IssueTag, IssueTracker, Project, ProjectCustomField, Result,
-    SearchResult, TrackerError, UpdateIssue, User,
+    IssueHistoryEvent, IssueLink, IssueLinkType, IssueTag, IssueTracker, Project,
+    ProjectCustomField, Result, SearchResult, TrackerError, UpdateIssue, User,
 };
 
 use crate::client::JiraClient;
 use crate::convert::{
-    create_issue_to_jira, get_standard_custom_fields, jira_field_to_project_custom_field,
-    jira_issue_to_core, merge_fields, parse_jira_datetime, update_issue_to_jira,
+    create_issue_to_jira, get_standard_custom_fields, jira_changelog_to_history_events,
+    jira_field_to_project_custom_field, jira_issue_to_core, merge_fields, parse_jira_datetime,
+    update_issue_to_jira,
 };
 use crate::models::{
     CreateJiraIssueLink, IssueKeyRef, IssueLinkTypeName, ParentId, UpdateJiraIssue,
@@ -436,6 +437,11 @@ impl IssueTracker for JiraClient {
             .into_iter()
             .map(Into::into)
             .collect())
+    }
+
+    fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
+        let entries = self.get_issue_changelog(issue_id)?;
+        Ok(jira_changelog_to_history_events(entries))
     }
 }
 

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.10.5"
+version = "1.11.0"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/cli.rs
+++ b/crates/track/src/cli.rs
@@ -541,6 +541,18 @@ pub enum IssueCommands {
         #[arg(long)]
         all: bool,
     },
+    /// Show an issue's change history (field transition timeline)
+    #[command(visible_alias = "hist")]
+    History {
+        /// Issue ID (e.g., PROJ-123)
+        id: String,
+        /// Only show changes to this field (canonical name, e.g. "status")
+        #[arg(long)]
+        field: Option<String>,
+        /// Only show changes within this window (e.g. 1d, 24h, 2w, 30m)
+        #[arg(long)]
+        since: Option<String>,
+    },
     /// Link two issues together
     Link {
         /// Source issue ID (e.g., PROJ-123)

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -1,11 +1,13 @@
 use crate::cache::TrackerCache;
 use crate::cli::{IssueCommands, OutputFormat};
-use crate::output::{output_json, output_list, output_page_hint, output_progress, output_result};
+use crate::output::{
+    Displayable, output_json, output_list, output_page_hint, output_progress, output_result,
+};
 use anyhow::{Context, Result, anyhow};
 use serde::Deserialize;
 use tracker_core::{
     CreateIssue, CustomFieldUpdate, Issue, IssueTracker, ProjectCustomField, UpdateIssue,
-    fetch_all_pages, get_max_results, unicode_eq_ignore_case,
+    canonical_field_name, fetch_all_pages, get_max_results, unicode_eq_ignore_case,
 };
 
 /// Shared fields for create, update, and batch-update commands.
@@ -173,6 +175,9 @@ pub fn handle_issue(
         }
         IssueCommands::Comments { id, limit, all } => {
             handle_comments(client, id, *limit, *all, format)
+        }
+        IssueCommands::History { id, field, since } => {
+            handle_history(client, id, field.as_deref(), since.as_deref(), format)
         }
         IssueCommands::Link {
             source,
@@ -1102,6 +1107,85 @@ fn handle_comments(
     Ok(())
 }
 
+fn handle_history(
+    client: &dyn IssueTracker,
+    id: &str,
+    field: Option<&str>,
+    since: Option<&str>,
+    format: OutputFormat,
+) -> Result<()> {
+    let mut events = client
+        .get_issue_history(id)
+        .with_context(|| format!("Failed to get history for issue '{}'", id))?;
+
+    if let Some(field) = field {
+        let wanted = canonical_field_name(field);
+        events.retain(|e| unicode_eq_ignore_case(&canonical_field_name(&e.field), &wanted));
+    }
+
+    if let Some(since) = since {
+        let window = parse_since(since)?;
+        let cutoff = chrono::Utc::now() - window;
+        events.retain(|e| e.at >= cutoff);
+    }
+
+    match format {
+        OutputFormat::Json => {
+            let payload = serde_json::json!({
+                "issue": id,
+                "changes": events,
+            });
+            output_json(&payload)?;
+        }
+        OutputFormat::Text => {
+            use colored::Colorize;
+            if events.is_empty() {
+                println!("No change history for {}", id.cyan().bold());
+            } else {
+                println!("History for {} ({}):", id.cyan().bold(), events.len());
+                for event in &events {
+                    println!("  {}", event.display());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parse a relative duration like `1d`, `24h`, `2w`, `30m`, or `45s` into a
+/// [`chrono::Duration`]. Accepts a single integer followed by one unit suffix
+/// (`s`, `m`, `h`, `d`, `w`).
+fn parse_since(input: &str) -> Result<chrono::Duration> {
+    let s = input.trim();
+    let split = s
+        .find(|c: char| !c.is_ascii_digit())
+        .ok_or_else(|| anyhow!("--since '{}' must include a unit (s, m, h, d, or w)", input))?;
+    let (num, unit) = s.split_at(split);
+    let value: i64 = num
+        .parse()
+        .map_err(|_| anyhow!("--since '{}' must start with a whole number", input))?;
+    if value < 0 {
+        return Err(anyhow!("--since '{}' must not be negative", input));
+    }
+    // Use the checked constructors: the panicking `Duration::weeks` etc. would
+    // abort the CLI on an out-of-range value like `9999999999999w`.
+    let duration = match unit.trim() {
+        "s" => chrono::Duration::try_seconds(value),
+        "m" => chrono::Duration::try_minutes(value),
+        "h" => chrono::Duration::try_hours(value),
+        "d" => chrono::Duration::try_days(value),
+        "w" => chrono::Duration::try_weeks(value),
+        other => {
+            return Err(anyhow!(
+                "--since '{}' has an unknown unit '{}'; use s, m, h, d, or w",
+                input,
+                other
+            ));
+        }
+    };
+    duration.ok_or_else(|| anyhow!("--since '{}' is out of range", input))
+}
+
 fn handle_link(
     client: &dyn IssueTracker,
     source: &str,
@@ -1778,6 +1862,35 @@ mod tests {
     #[test]
     fn rejects_field_value_with_empty_value() {
         assert!(parse_field_value("Name=").is_err());
+    }
+
+    #[test]
+    fn parse_since_supports_all_units() {
+        assert_eq!(parse_since("45s").unwrap(), chrono::Duration::seconds(45));
+        assert_eq!(parse_since("30m").unwrap(), chrono::Duration::minutes(30));
+        assert_eq!(parse_since("24h").unwrap(), chrono::Duration::hours(24));
+        assert_eq!(parse_since("7d").unwrap(), chrono::Duration::days(7));
+        assert_eq!(parse_since("2w").unwrap(), chrono::Duration::weeks(2));
+        // Surrounding whitespace is tolerated.
+        assert_eq!(parse_since(" 1d ").unwrap(), chrono::Duration::days(1));
+    }
+
+    #[test]
+    fn parse_since_rejects_bad_input() {
+        assert!(parse_since("10").is_err()); // missing unit
+        assert!(parse_since("d").is_err()); // missing number
+        assert!(parse_since("5y").is_err()); // unknown unit
+        assert!(parse_since("-1d").is_err()); // negative / non-digit lead
+        assert!(parse_since("").is_err()); // empty
+    }
+
+    #[test]
+    fn parse_since_rejects_overflow_without_panicking() {
+        // i64::MAX weeks overflows chrono's internal seconds; must error, not panic.
+        let huge = format!("{}w", i64::MAX);
+        assert!(parse_since(&huge).is_err());
+        // A value too large to fit in i64 at all is also a graceful error.
+        assert!(parse_since("99999999999999999999999d").is_err());
     }
 
     #[test]

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::io::IsTerminal;
 use tracker_core::{
     Article, ArticleAttachment, BundleDefinition, Comment, CustomField, CustomFieldDefinition,
-    Issue, IssueAttachment, IssueTag, Project, ProjectCustomField, case_key,
+    Issue, IssueAttachment, IssueHistoryEvent, IssueTag, Project, ProjectCustomField, case_key,
     unicode_eq_ignore_case,
 };
 
@@ -630,6 +630,29 @@ impl Displayable for Comment {
             .unwrap_or_else(|| "Unknown date".to_string());
 
         format!("[{}] {} - {}", date.dimmed(), author.cyan(), self.text)
+    }
+}
+
+impl Displayable for IssueHistoryEvent {
+    fn display(&self) -> String {
+        let author = self
+            .author
+            .as_ref()
+            .map(|a| a.name.as_deref().unwrap_or(&a.login))
+            .unwrap_or("Unknown");
+
+        let date = self.at.format("%Y-%m-%d %H:%M").to_string();
+        let from = self.from.as_deref().unwrap_or("∅");
+        let to = self.to.as_deref().unwrap_or("∅");
+
+        format!(
+            "[{}] {} {}: {} → {}",
+            date.dimmed(),
+            author.cyan(),
+            self.field.yellow(),
+            from,
+            to
+        )
     }
 }
 

--- a/crates/track/tests/jira_integration_tests.rs
+++ b/crates/track/tests/jira_integration_tests.rs
@@ -2486,3 +2486,116 @@ fn test_jira_search_skip_shifts_window() {
         "--skip 2 must shift the window past the first page"
     );
 }
+
+/// A single-page Jira changelog body shared by the history tests below.
+fn mock_changelog_body() -> String {
+    serde_json::json!({
+        "startAt": 0,
+        "maxResults": 100,
+        "total": 2,
+        "isLast": true,
+        "values": [
+            {
+                "id": "1",
+                "author": { "accountId": "acc-1", "displayName": "Alice" },
+                "created": "2024-01-10T09:00:00.000+0000",
+                "items": [
+                    { "field": "status", "fromString": "To Do", "toString": "In Progress" }
+                ]
+            },
+            {
+                "id": "2",
+                "author": { "accountId": "acc-2", "displayName": "Bob" },
+                "created": "2024-01-15T14:00:00.000+0000",
+                "items": [
+                    { "field": "assignee", "fromString": null, "toString": "Alice" },
+                    { "field": "status", "fromString": "In Progress", "toString": "Done" }
+                ]
+            }
+        ]
+    })
+    .to_string()
+}
+
+#[test]
+fn test_jira_issue_history_json_envelope_orders_newest_first() {
+    let (_server, port) = start_jira_mock_server(mock_changelog_body());
+    thread::sleep(Duration::from_millis(50));
+
+    let cfg = write_jira_mock_config(port);
+    let output = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "-o", "json", "--config"])
+        .arg(&cfg)
+        .args(["issue", "history", "TEST-1"])
+        .timeout(Duration::from_secs(5))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v: Value = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
+    assert_eq!(v["issue"], "TEST-1", "envelope carries the issue id");
+    let changes = v["changes"].as_array().unwrap();
+    // Two entries, one with two items => three events.
+    assert_eq!(changes.len(), 3);
+
+    // Newest entry (2024-01-15) sorts first; its two items keep their order.
+    assert_eq!(changes[0]["field"], "assignee");
+    assert!(changes[0]["from"].is_null(), "null fromString -> JSON null");
+    assert_eq!(changes[0]["to"], "Alice");
+    assert_eq!(changes[0]["author"]["login"], "acc-2");
+    assert_eq!(changes[0]["author"]["name"], "Bob");
+    assert_eq!(changes[1]["field"], "status");
+    assert_eq!(changes[1]["to"], "Done");
+
+    // Oldest entry sorts last.
+    assert_eq!(changes[2]["field"], "status");
+    assert_eq!(changes[2]["to"], "In Progress");
+}
+
+#[test]
+fn test_jira_issue_history_field_filter() {
+    let (_server, port) = start_jira_mock_server(mock_changelog_body());
+    thread::sleep(Duration::from_millis(50));
+
+    let cfg = write_jira_mock_config(port);
+    let output = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "-o", "json", "--config"])
+        .arg(&cfg)
+        .args(["issue", "history", "TEST-1", "--field", "status"])
+        .timeout(Duration::from_secs(5))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v: Value = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
+    let changes = v["changes"].as_array().unwrap();
+    // Only the two status transitions survive the filter.
+    assert_eq!(changes.len(), 2);
+    assert!(changes.iter().all(|c| c["field"] == "status"));
+}
+
+#[test]
+fn test_jira_issue_history_since_filter_excludes_old() {
+    let (_server, port) = start_jira_mock_server(mock_changelog_body());
+    thread::sleep(Duration::from_millis(50));
+
+    let cfg = write_jira_mock_config(port);
+    let output = cargo_bin_cmd!("track")
+        .args(["-b", "jira", "-o", "json", "--config"])
+        .arg(&cfg)
+        // The fixture's changes are from 2024; a 1-day window excludes them all.
+        .args(["issue", "history", "TEST-1", "--since", "1d"])
+        .timeout(Duration::from_secs(5))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v: Value = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
+    assert_eq!(v["changes"].as_array().unwrap().len(), 0);
+}

--- a/crates/tracker-core/src/models.rs
+++ b/crates/tracker-core/src/models.rs
@@ -206,6 +206,45 @@ pub struct CommentAuthor {
     pub name: Option<String>,
 }
 
+/// A single field change in an issue's history (changelog / activity timeline).
+///
+/// Backends model history differently — Jira and YouTrack expose field diffs
+/// directly, while GitHub/GitLab expose typed events that must be coerced into
+/// this shape. The lowest-common-denominator representation is one field
+/// transition: who changed `field` from `from` to `to`, and when.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueHistoryEvent {
+    /// When the change was recorded.
+    pub at: DateTime<Utc>,
+    /// Who made the change, if known.
+    pub author: Option<CommentAuthor>,
+    /// Canonical field name that changed (e.g. "status"). See
+    /// [`canonical_field_name`].
+    pub field: String,
+    /// Previous human-readable value, if any.
+    pub from: Option<String>,
+    /// New human-readable value, if any.
+    pub to: Option<String>,
+}
+
+/// Canonical name for the workflow status/state field, normalized across
+/// backends so a `--field status` filter works regardless of the backend's
+/// native terminology (Jira "status", YouTrack "State", GitHub/GitLab close
+/// events).
+pub const FIELD_STATUS: &str = "status";
+
+/// Normalize a backend's raw history field name to a canonical token.
+///
+/// Folds known synonyms for the workflow status field onto [`FIELD_STATUS`] so
+/// callers can filter portably. All other field names are returned trimmed but
+/// otherwise unchanged, preserving their display casing.
+pub fn canonical_field_name(raw: &str) -> String {
+    match raw.trim().to_lowercase().as_str() {
+        "status" | "state" => FIELD_STATUS.to_string(),
+        _ => raw.trim().to_string(),
+    }
+}
+
 /// Upload request shared by issue and article attachment commands.
 #[derive(Debug, Clone)]
 pub struct AttachmentUpload {

--- a/crates/tracker-core/src/traits.rs
+++ b/crates/tracker-core/src/traits.rs
@@ -256,6 +256,20 @@ pub trait IssueTracker: Send + Sync {
             .take(limit)
             .collect())
     }
+
+    // ========== History Operations ==========
+
+    /// Get an issue's change history (the field-transition timeline).
+    ///
+    /// Returns field changes — status transitions, assignee changes, etc. —
+    /// ordered newest-first. Optional: backends without a changelog/activity
+    /// API return an error by default.
+    fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
+        let _ = issue_id;
+        Err(crate::error::TrackerError::InvalidInput(
+            "Issue history is not supported by this backend".to_string(),
+        ))
+    }
 }
 
 /// Trait for knowledge base / wiki operations

--- a/crates/tracker-mock/src/client.rs
+++ b/crates/tracker-mock/src/client.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use tracker_core::{
     Article, ArticleAttachment, Comment, CreateArticle, CreateIssue, CreateProject, Issue,
-    IssueLink, IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project, ProjectCustomField,
-    Result, SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
+    IssueHistoryEvent, IssueLink, IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project,
+    ProjectCustomField, Result, SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
 };
 
 /// A mock client that reads responses from fixture files
@@ -407,6 +407,13 @@ impl IssueTracker for MockClient {
             .into_iter()
             .collect();
         self.get_response("get_comments", args, None)
+    }
+
+    fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
+        let args = [("issue_id".to_string(), issue_id.to_string())]
+            .into_iter()
+            .collect();
+        self.get_response("get_issue_history", args, None)
     }
 }
 

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -231,6 +231,7 @@ track config get default_project
 | Comment | `track i cmt PROJ-123 -m "Text"` | `track -b j i cmt PROJ-123 -m "Text"` | `track -b gh i cmt PROJ-42 -m "Text"` | `track -b gl i cmt PROJ-42 -m "Text"` |
 | Link | `track i link PROJ-1 PROJ-2` | `track -b j i link PROJ-1 PROJ-2` | Subtask/parent only | `track -b gl i link PROJ-1 PROJ-2` |
 | Unlink | `track i ul PROJ-1 <link-id>` | `track -b j i ul PROJ-1 <link-id>` | Not supported | `track -b gl i ul #42 <link-id>` |
+| History | Not supported | `track -b j i history PROJ-123 --field status --since 7d` | Not supported | Not supported |
 
 **GitHub/GitLab notes**:
 - GitHub and GitLab use numeric issue IDs (e.g., `42`), not project-prefixed keys
@@ -303,6 +304,7 @@ track bundle create "Bug Status" -t state -v "Open,Fixed,Closed" --resolved "Fix
 | `track issue delete` | `track i rm`, `track i del` |
 | `track issue comment` | `track i cmt` |
 | `track issue comments` | `track i comments` |
+| `track issue history` | `track i history`, `track i hist` |
 | `track issue complete` | `track i done`, `track i resolve` |
 | `track issue start` | `track i start` |
 | `track issue link` | `track i link` |
@@ -655,6 +657,22 @@ track -b j i comments PROJ-123
 track -b gh i comments PROJ-42
 track -b gl i comments PROJ-42
 ```
+
+### Issue History (Jira only)
+
+Retrieve the field-transition timeline (status/assignee/etc. changes) with
+timestamps and authors — useful for flow metrics, cycle/lead time, and
+per-issue lifecycle reporting. Other backends report "not supported".
+
+```bash
+track -b j i history PROJ-123                 # Full timeline, newest first
+track -b j i history PROJ-123 --field status  # Only status transitions (canonical field)
+track -b j i history PROJ-123 --since 24h      # Window: s/m/h/d/w
+track -b j -o json i history PROJ-123          # {"issue": id, "changes": [{at, author, field, from, to}]}
+```
+
+There is no batch form (one call per issue): for board-level metrics, search
+for the candidate issues first, then call `i history` per issue.
 
 ### Link Issues
 

--- a/fixtures/scenarios/issue-history/manifest.toml
+++ b/fixtures/scenarios/issue-history/manifest.toml
@@ -1,0 +1,61 @@
+# Request-to-Response Mapping for issue-history scenario
+
+# =============================================================================
+# Project Operations
+# =============================================================================
+
+[[responses]]
+method = "list_projects"
+file = "list_projects.json"
+
+[[responses]]
+method = "get_project"
+file = "get_project_DEMO.json"
+[responses.args]
+id = "DEMO"
+
+[[responses]]
+method = "get_project_custom_fields"
+file = "project_custom_fields.json"
+[responses.args]
+project_id = "*"
+
+# =============================================================================
+# Issue Operations
+# =============================================================================
+
+[[responses]]
+method = "get_issue"
+file = "get_issue_DEMO-1.json"
+[responses.args]
+id = "DEMO-1"
+
+[[responses]]
+method = "get_issue"
+file = "get_issue_DEMO-2.json"
+[responses.args]
+id = "DEMO-2"
+
+# =============================================================================
+# History Operations
+# =============================================================================
+
+[[responses]]
+method = "get_issue_history"
+file = "get_issue_history_DEMO-1.json"
+[responses.args]
+issue_id = "DEMO-1"
+
+[[responses]]
+method = "get_issue_history"
+file = "get_issue_history_DEMO-2.json"
+[responses.args]
+issue_id = "DEMO-2"
+
+# =============================================================================
+# Supporting Operations
+# =============================================================================
+
+[[responses]]
+method = "list_tags"
+file = "list_tags.json"

--- a/fixtures/scenarios/issue-history/responses/get_issue_DEMO-1.json
+++ b/fixtures/scenarios/issue-history/responses/get_issue_DEMO-1.json
@@ -1,0 +1,22 @@
+{
+  "id": "2-1",
+  "id_readable": "DEMO-1",
+  "summary": "Implement user authentication",
+  "project": {
+    "id": "0-1",
+    "short_name": "DEMO"
+  },
+  "custom_fields": [
+    {
+      "State": {
+        "name": "State",
+        "value": "Done",
+        "is_resolved": true
+      }
+    }
+  ],
+  "created": "2026-04-18T08:00:00Z",
+  "tags": [],
+  "updated": "2026-05-01T12:03:44Z",
+  "description": null
+}

--- a/fixtures/scenarios/issue-history/responses/get_issue_DEMO-2.json
+++ b/fixtures/scenarios/issue-history/responses/get_issue_DEMO-2.json
@@ -1,0 +1,22 @@
+{
+  "id": "2-2",
+  "id_readable": "DEMO-2",
+  "summary": "Fix login redirect loop",
+  "project": {
+    "id": "0-1",
+    "short_name": "DEMO"
+  },
+  "custom_fields": [
+    {
+      "State": {
+        "name": "State",
+        "value": "Open",
+        "is_resolved": false
+      }
+    }
+  ],
+  "created": "2026-04-30T09:00:00Z",
+  "tags": [],
+  "updated": "2026-05-10T10:00:00Z",
+  "description": null
+}

--- a/fixtures/scenarios/issue-history/responses/get_issue_history_DEMO-1.json
+++ b/fixtures/scenarios/issue-history/responses/get_issue_history_DEMO-1.json
@@ -1,0 +1,30 @@
+[
+  {
+    "at": "2026-05-01T12:03:44Z",
+    "author": { "login": "712020:1a2b", "name": "Jane Doe" },
+    "field": "status",
+    "from": "In Progress",
+    "to": "Done"
+  },
+  {
+    "at": "2026-04-28T09:11:02Z",
+    "author": { "login": "712020:3c4d", "name": "John Roe" },
+    "field": "assignee",
+    "from": null,
+    "to": "Jane Doe"
+  },
+  {
+    "at": "2026-04-20T15:30:00Z",
+    "author": { "login": "712020:1a2b", "name": "Jane Doe" },
+    "field": "priority",
+    "from": "Medium",
+    "to": "High"
+  },
+  {
+    "at": "2026-04-18T08:00:00Z",
+    "author": { "login": "712020:1a2b", "name": "Jane Doe" },
+    "field": "status",
+    "from": "To Do",
+    "to": "In Progress"
+  }
+]

--- a/fixtures/scenarios/issue-history/responses/get_issue_history_DEMO-2.json
+++ b/fixtures/scenarios/issue-history/responses/get_issue_history_DEMO-2.json
@@ -1,0 +1,16 @@
+[
+  {
+    "at": "2026-05-10T10:00:00Z",
+    "author": { "login": "712020:1a2b", "name": "Jane Doe" },
+    "field": "status",
+    "from": "Open",
+    "to": "Closed"
+  },
+  {
+    "at": "2026-05-02T14:20:00Z",
+    "author": { "login": "712020:3c4d", "name": "John Roe" },
+    "field": "status",
+    "from": "Reopened",
+    "to": "Open"
+  }
+]

--- a/fixtures/scenarios/issue-history/responses/get_project_DEMO.json
+++ b/fixtures/scenarios/issue-history/responses/get_project_DEMO.json
@@ -1,0 +1,6 @@
+{
+  "id": "0-1",
+  "name": "Demo Project",
+  "short_name": "DEMO",
+  "description": "A demo project for testing"
+}

--- a/fixtures/scenarios/issue-history/responses/list_projects.json
+++ b/fixtures/scenarios/issue-history/responses/list_projects.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "0-1",
+    "name": "Demo Project",
+    "short_name": "DEMO",
+    "description": "A demo project for testing"
+  },
+  {
+    "id": "0-2",
+    "name": "Another Project",
+    "short_name": "OTHER",
+    "description": "Another project"
+  }
+]

--- a/fixtures/scenarios/issue-history/responses/list_tags.json
+++ b/fixtures/scenarios/issue-history/responses/list_tags.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "tag-1",
+    "name": "backend",
+    "color": {
+      "id": "color-1",
+      "background": "#4CAF50",
+      "foreground": "#FFFFFF"
+    },
+    "issues_count": 5
+  },
+  {
+    "id": "tag-2",
+    "name": "frontend",
+    "color": {
+      "id": "color-2",
+      "background": "#2196F3",
+      "foreground": "#FFFFFF"
+    },
+    "issues_count": 8
+  }
+]

--- a/fixtures/scenarios/issue-history/responses/project_custom_fields.json
+++ b/fixtures/scenarios/issue-history/responses/project_custom_fields.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "field-1",
+    "name": "State",
+    "field_type": "state",
+    "required": true,
+    "values": ["Open", "In Progress", "Done"],
+    "state_values": [
+      { "name": "Open", "is_resolved": false, "ordinal": 0 },
+      { "name": "In Progress", "is_resolved": false, "ordinal": 1 },
+      { "name": "Done", "is_resolved": true, "ordinal": 2 }
+    ]
+  },
+  {
+    "id": "field-2",
+    "name": "Priority",
+    "field_type": "enum",
+    "required": true,
+    "values": ["Low", "Normal", "High", "Critical"]
+  },
+  {
+    "id": "field-3",
+    "name": "Type",
+    "field_type": "enum",
+    "required": true,
+    "values": ["Bug", "Task", "Feature", "Improvement"]
+  },
+  {
+    "id": "field-4",
+    "name": "Assignee",
+    "field_type": "user",
+    "required": false,
+    "values": []
+  }
+]

--- a/fixtures/scenarios/issue-history/scenario.toml
+++ b/fixtures/scenarios/issue-history/scenario.toml
@@ -1,0 +1,47 @@
+# Issue History Scenario
+# Tests: retrieving an issue's change history (field transition timeline)
+
+[scenario]
+name = "issue-history"
+description = "Test issue change-history retrieval and filtering (Jira only)"
+backend = "jira"
+difficulty = "easy"
+tags = ["history", "reporting", "flow-metrics"]
+
+[setup]
+prompt = """
+You have access to a Jira instance with project DEMO.
+
+Task:
+1. Get the full change history (transition timeline) of issue DEMO-1
+2. Show only the status transitions of DEMO-1
+3. Get the change history of DEMO-2
+
+Use the track issue history command.
+"""
+default_project = "DEMO"
+cache_available = true
+context = """
+DEMO-1 has moved through several states and changed assignee/priority.
+DEMO-2 was reopened once.
+History is read-only and Jira-only; other backends report "not supported".
+"""
+
+[expected_outcomes]
+history_listed = { method_called = "get_issue_history", issue = "DEMO-1" }
+history_filtered = { method_called = "get_issue_history", issue = "DEMO-1" }
+history_demo2 = { method_called = "get_issue_history", issue = "DEMO-2" }
+
+[scoring]
+min_commands = 3
+max_commands = 5
+optimal_commands = 3
+base_score = 100
+
+[scoring.penalties]
+extra_command = -5
+redundant_fetch = -10
+command_error = -15
+
+[scoring.bonuses]
+under_optimal = 5


### PR DESCRIPTION
Closes #260.

## Summary

Adds `track issue history <id>` — a read-only command returning an issue's **change history**: the time-ordered list of field transitions (status, assignee, priority, …) with timestamps and authors. This closes the gap where JQL `CHANGED FROM … AFTER` predicates could only answer point-in-time set membership, but couldn't reconstruct a timeline, count reopens, or compute time-in-status — the data needed for flow metrics, cycle/lead time, and per-issue lifecycle reporting.

```console
$ track -b j issue history NEK-1234 -o json
{
  "issue": "NEK-1234",
  "changes": [
    { "at": "2026-05-01T12:03:44Z", "author": {"login": "712020:…", "name": "Jane Doe"},
      "field": "status", "from": "In Progress", "to": "Done" }
  ]
}
```

## Scope

**Jira-only first cut.** The new `get_issue_history` is an *optional* `IssueTracker` trait method defaulting to "not supported by this backend", so YouTrack, GitHub, GitLab, and Linear are untouched and return a clear error until implemented. Filters `--field` (canonical `status`, normalized across backends) and `--since` (`s`/`m`/`h`/`d`/`w`) are included.

## Changes

- **core** — `IssueHistoryEvent` model; `canonical_field_name()` + `FIELD_STATUS` so `--field status` is portable; optional `get_issue_history` trait method.
- **jira** — `JiraChangelog*` serde models; offset-paged `get_issue_changelog` (bounded backstop → `PaginationStalled` rather than an unbounded loop; does **not** stop on a short page since Jira may cap `maxResults`); `jira_changelog_to_history_events` (newest-first, null-safe, canonical field names).
- **cli** — `track issue history <id>` (alias `hist`); `--field`/`--since`; `--since` parsed with checked `try_*` constructors so an out-of-range value errors instead of panicking; `{"issue": id, "changes": […]}` JSON envelope; text `Displayable`.
- **tests** — `convert.rs` unit tests; wiremock client pagination/sort test; 3 binary-level integration tests; `MockClient::get_issue_history` + a `fixtures/scenarios/issue-history` eval scenario.
- **docs** — `agent-skills/SKILL.md`, `README.md`, `docs/agent_guide.md`.
- **version** — bump `track` 1.10.5 → 1.11.0.

## Notes / decisions

- **Author shape:** reuses the existing `CommentAuthor` (`{login, name}`) for consistency across `track`'s JSON output, rather than the `{display_name, login}` spelling in the issue's illustrative example.
- **N+1 by design:** there is no batch changelog endpoint in Jira — board-level metrics search for the candidate set, then call `i history` per issue. Documented as such.
- Folding history into `issue get --full` was deliberately avoided to keep that common path at one round trip.

## Verification

`cargo build`, `cargo clippy --all-targets`, `cargo fmt --check`, and `cargo test --workspace` all pass with zero failures. Verified end-to-end via the mock client (text, JSON envelope, `--field`, `--since`).
