### PR TITLE
feat(history): extend `issue history` to YouTrack, GitHub, GitLab, and Linear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -304,15 +304,21 @@ track issue comments PROJ-123 --limit 10
 ### History
 
 Show an issue's change history — the time-ordered timeline of field transitions
-(status changes, assignee changes, etc.) with timestamps and authors.
-**Jira only** for now; other backends report "not supported".
+(status changes, assignee changes, etc.) with timestamps and authors. Supported
+on all backends.
 
 ```bash
-track -b j issue history PROJ-123                 # Full timeline, newest first
-track -b j i hist PROJ-123 --field status         # Only status transitions
-track -b j i history PROJ-123 --since 7d           # Last 7 days (s/m/h/d/w)
-track -b j -o json i history PROJ-123              # {"issue": id, "changes": [...]}
+track issue history PROJ-123                       # Full timeline, newest first
+track i hist PROJ-123 --field status               # Only status transitions
+track i history PROJ-123 --since 7d                 # Last 7 days (s/m/h/d/w)
+track -o json i history PROJ-123                    # {"issue": id, "changes": [...]}
+track -b gh i history 42                            # GitHub (numeric id)
 ```
+
+`from`/`to` coverage varies by backend: Jira, YouTrack, and Linear carry the
+prior value for every field; the event-based backends (GitHub, GitLab) populate
+`from` only for `status` and report `from: null` for other fields. (Linear
+label-change history is not yet included.)
 
 
 ### Links

--- a/agent-skills/SKILL.md
+++ b/agent-skills/SKILL.md
@@ -176,7 +176,7 @@ track config clear [-g]        # Delete a config file
 | Unlink | `track i ul PROJ-1 <link-id>` | `track -b j i ul PROJ-1 <link-id>` | Not supported | `track -b gl i ul 42 <link-id>` |
 | Start | `track i start PROJ-123` | `track -b j i start PROJ-123 --field Status --state "In Progress"` | `track -b gh i start 42` | `track -b gl i start 42` |
 | Complete | `track i done PROJ-123` | `track -b j i done PROJ-123 --field Status --state Done` | `track -b gh i done 42` (closes) | `track -b gl i done 42` (closes) |
-| History | Not supported | `track -b j i history PROJ-123 --field status --since 7d` | Not supported | Not supported |
+| History | `track i history PROJ-123` | `track -b j i history PROJ-123 --field status --since 7d` | `track -b gh i history 42` | `track -b gl i history 42` |
 
 **Bare-ID shortcut**: `track PROJ-123` = `track issue get PROJ-123`, but it only fires for IDs shaped `ALPHANUM-DIGITS` with **exactly one dash** (`PROJ-123`, `my2proj-99`). Purely numeric IDs must use `track i g 42`. Global flags (`-b`, `-o`, ...) must come **before** the ID; the only flag recognized after the ID is `--full`.
 
@@ -385,7 +385,7 @@ track completions zsh      # Shell completions (bash|zsh|fish|powershell|elvish)
 - **`i s -o json`** returns a bare array — no total or pagination metadata (hints go to stderr in text mode only).
 - **`i del -o json`** returns `{"success": true, "message": "..."}`.
 
-**History** (`i history`, **Jira only** — other backends error with "not supported"):
+**History** (`i history`, all backends):
 ```json
 {
   "issue": "PROJ-123",
@@ -404,6 +404,7 @@ track completions zsh      # Shell completions (bash|zsh|fish|powershell|elvish)
 - Ordered **newest-first**. `author` reuses the comment-author shape (`{login, name}`).
 - Filter at the source: `--field status` (canonical name) and `--since 7d` (`s`/`m`/`h`/`d`/`w`).
 - No batch form — one call per issue. For flow metrics across a board, search for the candidate set first, then call `i history` per issue.
+- **`from` coverage varies by backend.** Jira/YouTrack/Linear carry the prior value for every field. GitHub/GitLab are event-based, so `from` is populated only for `status` (derived from the event sequence); other fields report `from: null` with the new value in `to`. Linear label-change history is not yet included.
 
 ---
 

--- a/crates/github-backend/src/client.rs
+++ b/crates/github-backend/src/client.rs
@@ -447,4 +447,71 @@ impl GitHubClient {
         let comments: Vec<GitHubComment> = response.body_mut().read_json()?;
         Ok(comments)
     }
+
+    // ==================== Timeline / History Operations ====================
+
+    /// Fetch a single page of an issue's timeline events.
+    ///
+    /// Mirrors [`get_comments_page`](Self::get_comments_page): offset paging via
+    /// `per_page` (capped at 100) and `page` (1-based). GitHub returns the
+    /// timeline oldest-first. Unrecognized event types deserialize to
+    /// [`GitHubTimelineEvent::Other`] rather than failing the whole page.
+    pub fn get_timeline_page(
+        &self,
+        number: u64,
+        per_page: usize,
+        page: usize,
+    ) -> Result<Vec<GitHubTimelineEvent>> {
+        let url = format!(
+            "{}?per_page={}&page={}",
+            self.repo_url(&format!("/issues/{}/timeline", number)),
+            per_page.min(100),
+            page.max(1)
+        );
+
+        let response = self
+            .agent
+            .get(&url)
+            .header("Authorization", &self.auth_header())
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .call()
+            .map_err(GitHubError::Http)?;
+
+        let mut response = self.check_response(response)?;
+        let raw: Vec<serde_json::Value> = response.body_mut().read_json()?;
+        raw.into_iter()
+            .map(GitHubTimelineEvent::from_value)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(GitHubError::Parse)
+    }
+
+    /// Fetch an issue's complete timeline, paging through every event.
+    ///
+    /// GitHub honors `per_page`, so a short page (fewer than `PER_PAGE` events)
+    /// is a reliable end-of-data signal. A `MAX_PAGES` backstop guards against a
+    /// server that ignores paging and never shrinks a page — failing loudly via
+    /// [`GitHubError::PaginationStalled`] instead of looping forever.
+    ///
+    /// Events are returned oldest-first, matching the GitHub API ordering.
+    pub fn get_issue_timeline(&self, number: u64) -> Result<Vec<GitHubTimelineEvent>> {
+        const PER_PAGE: usize = 100;
+        const MAX_PAGES: usize = 10_000;
+
+        let mut events = Vec::new();
+        let mut page = 1;
+        for _ in 0..MAX_PAGES {
+            let batch = self.get_timeline_page(number, PER_PAGE, page)?;
+            let fetched = batch.len();
+            events.extend(batch);
+            if fetched < PER_PAGE {
+                return Ok(events);
+            }
+            page += 1;
+        }
+        Err(GitHubError::PaginationStalled(format!(
+            "issue '{}' timeline did not terminate after {} pages",
+            number, MAX_PAGES
+        )))
+    }
 }

--- a/crates/github-backend/src/client_tests.rs
+++ b/crates/github-backend/src/client_tests.rs
@@ -507,6 +507,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_issue_history_paginates_and_derives_status() {
+        let mock_server = MockServer::start().await;
+
+        // Page 1: a full page of 100 events (oldest-first). A full page forces
+        // the loop to request a second page. These are all `labeled` events so
+        // they don't disturb the running status; timestamps ascend.
+        let page1: Vec<serde_json::Value> = (0..100)
+            .map(|i| {
+                // Keep hours/minutes in valid RFC3339 ranges (<24 / <60).
+                let created_at = format!("2024-01-01T{:02}:{:02}:00Z", i / 60, i % 60);
+                serde_json::json!({
+                    "event": "labeled",
+                    "created_at": created_at,
+                    "actor": { "login": "alice", "id": 1 },
+                    "label": { "id": i, "name": format!("label-{i}"), "color": "ffffff", "description": null }
+                })
+            })
+            .collect();
+
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/issues/42/timeline"))
+            .and(query_param("per_page", "100"))
+            .and(query_param("page", "1"))
+            .and(header("Authorization", "Bearer test-token"))
+            .and(header("X-GitHub-Api-Version", "2022-11-28"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(page1)))
+            .mount(&mock_server)
+            .await;
+
+        // Page 2: a short page (< per_page) signaling end-of-data. A
+        // closed->reopened->closed sequence exercises the running-status
+        // derivation, plus an unknown event that must be ignored.
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/issues/42/timeline"))
+            .and(query_param("per_page", "100"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "event": "closed",
+                    "created_at": "2024-02-01T10:00:00Z",
+                    "actor": { "login": "bob", "id": 2 }
+                },
+                {
+                    "event": "reopened",
+                    "created_at": "2024-02-02T10:00:00Z",
+                    "actor": { "login": "carol", "id": 3 }
+                },
+                {
+                    "event": "commented",
+                    "created_at": "2024-02-03T10:00:00Z",
+                    "actor": { "login": "dave", "id": 4 }
+                },
+                {
+                    "event": "closed",
+                    "created_at": "2024-02-04T10:00:00Z",
+                    "actor": { "login": "erin", "id": 5 }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = GitHubClient::with_base_url(&mock_server.uri(), "owner", "repo", "test-token");
+        let events = client.get_issue_history("42").unwrap();
+
+        // 100 labels (page 1) + 3 status events (page 2, comment dropped).
+        assert_eq!(events.len(), 103);
+
+        // Newest-first: the page-2 status events sort to the front in reverse
+        // chronological order. Verify the from-walk: open->closed,
+        // closed->open, open->closed; reversed for display.
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].from.as_deref(), Some("open"));
+        assert_eq!(events[0].to.as_deref(), Some("closed"));
+        assert_eq!(events[0].author.as_ref().unwrap().login, "erin");
+
+        assert_eq!(events[1].field, "status");
+        assert_eq!(events[1].from.as_deref(), Some("closed"));
+        assert_eq!(events[1].to.as_deref(), Some("open"));
+        assert_eq!(events[1].author.as_ref().unwrap().login, "carol");
+
+        assert_eq!(events[2].field, "status");
+        assert_eq!(events[2].from.as_deref(), Some("open"));
+        assert_eq!(events[2].to.as_deref(), Some("closed"));
+        assert_eq!(events[2].author.as_ref().unwrap().login, "bob");
+
+        // The remaining 100 are the labels.
+        assert!(events[3..].iter().all(|e| e.field == "labels"));
+    }
+
+    #[tokio::test]
     async fn test_rate_limit_detection() {
         let mock_server = MockServer::start().await;
 

--- a/crates/github-backend/src/convert.rs
+++ b/crates/github-backend/src/convert.rs
@@ -2,8 +2,9 @@
 
 use chrono::{DateTime, Utc};
 use tracker_core::{
-    Comment, CommentAuthor, CreateIssue, CustomField, CustomFieldUpdate, Issue, IssueTag, Project,
-    ProjectCustomField, ProjectRef, StateValueInfo, Tag, TagColor, UpdateIssue,
+    Comment, CommentAuthor, CreateIssue, CustomField, CustomFieldUpdate, Issue, IssueHistoryEvent,
+    IssueTag, Project, ProjectCustomField, ProjectRef, StateValueInfo, Tag, TagColor, UpdateIssue,
+    canonical_field_name,
 };
 
 use crate::models::*;
@@ -291,4 +292,192 @@ fn parse_github_datetime(dt: &str) -> Option<DateTime<Utc>> {
     chrono::DateTime::parse_from_rfc3339(dt)
         .ok()
         .map(|d| d.with_timezone(&Utc))
+}
+
+/// Map a GitHub timeline actor onto a [`CommentAuthor`].
+///
+/// Mirrors the comment author mapping (`login` → `login`, `name` →
+/// `Some(login)`) so history and comment authors render identically. A system
+/// event with no actor produces `None`.
+fn timeline_actor_to_author(actor: Option<GitHubUser>) -> Option<CommentAuthor> {
+    actor.map(|u| CommentAuthor {
+        login: u.login.clone(),
+        name: Some(u.login),
+    })
+}
+
+/// Convert a GitHub issue timeline (oldest-first) into history events
+/// (newest-first).
+///
+/// GitHub is an event-stream backend: each event records *what happened*, not a
+/// before/after diff. For the workflow status field there is no `from` in the
+/// payload, so we reconstruct it by walking the events in chronological order
+/// while threading a single running `status` string (seeded to `"open"`). Each
+/// close/reopen reads the current status as its `from`, then advances it. All
+/// other fields follow a status-only-from policy: their `from` stays `None`
+/// unless the event itself carries a prior value (only `renamed` does).
+///
+/// Events whose `created_at` cannot be parsed are skipped rather than
+/// fabricated. After the chronological walk the result is sorted newest-first
+/// (stable) to match the reporting order used by the other backends.
+pub fn github_timeline_to_events(events: Vec<GitHubTimelineEvent>) -> Vec<IssueHistoryEvent> {
+    // The seed/initial workflow state. GitHub issues are born `open`.
+    let mut status = "open".to_string();
+    let mut out = Vec::new();
+
+    for event in events {
+        match event {
+            GitHubTimelineEvent::Closed { created_at, actor } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: canonical_field_name("status"),
+                    from: Some(status.clone()),
+                    to: Some("closed".to_string()),
+                });
+                status = "closed".to_string();
+            }
+            GitHubTimelineEvent::Reopened { created_at, actor } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: canonical_field_name("status"),
+                    from: Some(status.clone()),
+                    to: Some("open".to_string()),
+                });
+                status = "open".to_string();
+            }
+            GitHubTimelineEvent::Assigned {
+                created_at,
+                actor,
+                assignee,
+            } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: "assignee".to_string(),
+                    from: None,
+                    to: assignee.map(|u| u.login),
+                });
+            }
+            GitHubTimelineEvent::Unassigned {
+                created_at,
+                actor,
+                assignee,
+            } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: "assignee".to_string(),
+                    from: assignee.map(|u| u.login),
+                    to: None,
+                });
+            }
+            GitHubTimelineEvent::Labeled {
+                created_at,
+                actor,
+                label,
+            } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: "labels".to_string(),
+                    from: None,
+                    to: label.map(|l| l.name),
+                });
+            }
+            GitHubTimelineEvent::Unlabeled {
+                created_at,
+                actor,
+                label,
+            } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: "labels".to_string(),
+                    from: label.map(|l| l.name),
+                    to: None,
+                });
+            }
+            GitHubTimelineEvent::Renamed {
+                created_at,
+                actor,
+                rename,
+            } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                // The `renamed` event is the one event that carries a prior
+                // value, so use its from/to directly.
+                let (from, to) = match rename {
+                    Some(r) => (r.from, r.to),
+                    None => (None, None),
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: "title".to_string(),
+                    from,
+                    to,
+                });
+            }
+            GitHubTimelineEvent::Milestoned {
+                created_at,
+                actor,
+                milestone,
+            } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: "milestone".to_string(),
+                    from: None,
+                    to: milestone.map(|m| m.title),
+                });
+            }
+            GitHubTimelineEvent::Demilestoned {
+                created_at,
+                actor,
+                milestone,
+            } => {
+                let Some(at) = created_at.as_deref().and_then(parse_github_datetime) else {
+                    continue;
+                };
+                out.push(IssueHistoryEvent {
+                    at,
+                    author: timeline_actor_to_author(actor),
+                    field: "milestone".to_string(),
+                    from: milestone.map(|m| m.title),
+                    to: None,
+                });
+            }
+            GitHubTimelineEvent::Other => {}
+        }
+    }
+
+    // GitHub returns the timeline oldest-first; expose newest-first to match
+    // the reporting order used by the other backends. `sort_by` is stable, so
+    // events sharing a timestamp keep their chronological order.
+    out.sort_by(|a, b| b.at.cmp(&a.at));
+    out
 }

--- a/crates/github-backend/src/convert_tests.rs
+++ b/crates/github-backend/src/convert_tests.rs
@@ -1,6 +1,159 @@
 #[cfg(test)]
 mod tests {
-    use crate::convert::convert_query_to_github;
+    use crate::convert::{convert_query_to_github, github_timeline_to_events};
+    use crate::models::GitHubTimelineEvent;
+
+    /// Build a typed timeline event from raw JSON, mirroring how the client
+    /// deserializes each element of the timeline array.
+    fn event_from_json(value: serde_json::Value) -> GitHubTimelineEvent {
+        GitHubTimelineEvent::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn github_timeline_derives_status_from_running_state() {
+        // A close/reopen/close sequence (oldest-first). Because GitHub never
+        // sends a `from` for status, we reconstruct it by threading a running
+        // status seeded to "open".
+        let events = vec![
+            event_from_json(serde_json::json!({
+                "event": "closed",
+                "created_at": "2024-01-01T10:00:00Z",
+                "actor": { "login": "alice", "id": 1 }
+            })),
+            event_from_json(serde_json::json!({
+                "event": "reopened",
+                "created_at": "2024-01-02T10:00:00Z",
+                "actor": { "login": "bob", "id": 2 }
+            })),
+            event_from_json(serde_json::json!({
+                "event": "closed",
+                "created_at": "2024-01-03T10:00:00Z",
+                "actor": { "login": "carol", "id": 3 }
+            })),
+        ];
+
+        let out = github_timeline_to_events(events);
+
+        assert_eq!(out.len(), 3);
+        // All three are status transitions, folded onto the canonical name.
+        assert!(out.iter().all(|e| e.field == "status"));
+
+        // Output is newest-first, so display order reverses the chronological
+        // from-derivation walk:
+        //   chronological: open->closed, closed->open, open->closed
+        //   newest-first:  open->closed (3rd), closed->open (2nd), open->closed (1st)
+        assert_eq!(out[0].from.as_deref(), Some("open"));
+        assert_eq!(out[0].to.as_deref(), Some("closed"));
+        assert_eq!(out[0].author.as_ref().unwrap().login, "carol");
+
+        assert_eq!(out[1].from.as_deref(), Some("closed"));
+        assert_eq!(out[1].to.as_deref(), Some("open"));
+        assert_eq!(out[1].author.as_ref().unwrap().login, "bob");
+
+        assert_eq!(out[2].from.as_deref(), Some("open"));
+        assert_eq!(out[2].to.as_deref(), Some("closed"));
+        assert_eq!(out[2].author.as_ref().unwrap().login, "alice");
+    }
+
+    #[test]
+    fn github_timeline_mixed_assign_label_rename() {
+        // Non-status fields follow the status-only-from policy: assignee/label
+        // carry `from: None` (assigned) / `to: None` (only on un* events), while
+        // `renamed` is the one event that carries a real from/to.
+        let events = vec![
+            event_from_json(serde_json::json!({
+                "event": "assigned",
+                "created_at": "2024-01-01T10:00:00Z",
+                "actor": { "login": "alice", "id": 1 },
+                "assignee": { "login": "dave", "id": 4 }
+            })),
+            event_from_json(serde_json::json!({
+                "event": "labeled",
+                "created_at": "2024-01-02T10:00:00Z",
+                "actor": { "login": "alice", "id": 1 },
+                "label": { "id": 9, "name": "bug", "color": "fc2929", "description": null }
+            })),
+            event_from_json(serde_json::json!({
+                "event": "renamed",
+                "created_at": "2024-01-03T10:00:00Z",
+                "actor": { "login": "alice", "id": 1 },
+                "rename": { "from": "Old title", "to": "New title" }
+            })),
+        ];
+
+        let out = github_timeline_to_events(events);
+        assert_eq!(out.len(), 3);
+
+        // Newest-first: renamed, labeled, assigned.
+        let renamed = &out[0];
+        assert_eq!(renamed.field, "title");
+        assert_eq!(renamed.from.as_deref(), Some("Old title"));
+        assert_eq!(renamed.to.as_deref(), Some("New title"));
+
+        let labeled = &out[1];
+        assert_eq!(labeled.field, "labels");
+        assert_eq!(labeled.from, None);
+        assert_eq!(labeled.to.as_deref(), Some("bug"));
+
+        let assigned = &out[2];
+        assert_eq!(assigned.field, "assignee");
+        assert_eq!(assigned.from, None);
+        assert_eq!(assigned.to.as_deref(), Some("dave"));
+    }
+
+    #[test]
+    fn github_timeline_handles_null_actor() {
+        // A system close (no actor) yields a status event with author None.
+        let events = vec![event_from_json(serde_json::json!({
+            "event": "closed",
+            "created_at": "2024-01-01T10:00:00Z",
+            "actor": null
+        }))];
+
+        let out = github_timeline_to_events(events);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].field, "status");
+        assert_eq!(out[0].from.as_deref(), Some("open"));
+        assert_eq!(out[0].to.as_deref(), Some("closed"));
+        assert!(out[0].author.is_none());
+    }
+
+    #[test]
+    fn github_timeline_ignores_unknown_events() {
+        // commented/referenced/etc. map to `Other` and are dropped; surrounding
+        // status events still derive correctly and unparseable dates are skipped.
+        let events = vec![
+            event_from_json(serde_json::json!({
+                "event": "commented",
+                "created_at": "2024-01-01T10:00:00Z",
+                "actor": { "login": "alice", "id": 1 }
+            })),
+            event_from_json(serde_json::json!({
+                "event": "referenced",
+                "commit_id": "abc123"
+            })),
+            event_from_json(serde_json::json!({
+                "event": "closed",
+                "created_at": "not-a-date",
+                "actor": { "login": "bob", "id": 2 }
+            })),
+            event_from_json(serde_json::json!({
+                "event": "closed",
+                "created_at": "2024-01-02T10:00:00Z",
+                "actor": { "login": "carol", "id": 3 }
+            })),
+        ];
+
+        let out = github_timeline_to_events(events);
+        // Only the one parseable close survives.
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].field, "status");
+        // The unparseable-date close did NOT advance the running status, so the
+        // surviving close still reads from "open".
+        assert_eq!(out[0].from.as_deref(), Some("open"));
+        assert_eq!(out[0].to.as_deref(), Some("closed"));
+        assert_eq!(out[0].author.as_ref().unwrap().login, "carol");
+    }
 
     #[test]
     fn test_convert_query_to_github() {

--- a/crates/github-backend/src/error.rs
+++ b/crates/github-backend/src/error.rs
@@ -29,6 +29,9 @@ pub enum GitHubError {
 
     #[error("Wiki error: {0}")]
     Wiki(String),
+
+    #[error("Pagination stalled: {0}")]
+    PaginationStalled(String),
 }
 
 pub type Result<T> = std::result::Result<T, GitHubError>;
@@ -51,6 +54,7 @@ impl From<GitHubError> for TrackerError {
                 status: 500,
                 message: format!("Wiki error: {}", msg),
             },
+            GitHubError::PaginationStalled(msg) => TrackerError::PaginationStalled(msg),
         }
     }
 }

--- a/crates/github-backend/src/models/mod.rs
+++ b/crates/github-backend/src/models/mod.rs
@@ -2,8 +2,10 @@ pub mod comment;
 pub mod issue;
 pub mod label;
 pub mod project;
+pub mod timeline;
 
 pub use comment::*;
 pub use issue::*;
 pub use label::*;
 pub use project::*;
+pub use timeline::*;

--- a/crates/github-backend/src/models/timeline.rs
+++ b/crates/github-backend/src/models/timeline.rs
@@ -1,0 +1,145 @@
+use serde::{Deserialize, Serialize};
+
+use super::issue::{GitHubMilestone, GitHubUser};
+use super::label::GitHubLabel;
+
+/// A single GitHub issue timeline event.
+///
+/// The GitHub "List timeline events" API returns a heterogeneous stream of
+/// events discriminated by an `event` string field. We model only the
+/// transition events that map cleanly onto an [`tracker_core::IssueHistoryEvent`]
+/// and route everything else (commented, referenced, cross-referenced, etc.)
+/// to [`GitHubTimelineEvent::Other`].
+///
+/// `#[serde(other)]` is **not** supported on internally tagged enums
+/// (`#[serde(tag = ...)]`), so the discriminator is matched manually in
+/// [`from_value`] rather than relying on serde's tagged dispatch.
+#[derive(Debug, Clone)]
+pub enum GitHubTimelineEvent {
+    Closed {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+    },
+    Reopened {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+    },
+    Assigned {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+        assignee: Option<GitHubUser>,
+    },
+    Unassigned {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+        assignee: Option<GitHubUser>,
+    },
+    Labeled {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+        label: Option<GitHubLabel>,
+    },
+    Unlabeled {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+        label: Option<GitHubLabel>,
+    },
+    Renamed {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+        rename: Option<GitHubRename>,
+    },
+    Milestoned {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+        milestone: Option<GitHubMilestone>,
+    },
+    Demilestoned {
+        created_at: Option<String>,
+        actor: Option<GitHubUser>,
+        milestone: Option<GitHubMilestone>,
+    },
+    /// Any event type we don't translate (commented, referenced, ...).
+    Other,
+}
+
+/// The `rename` payload on a `renamed` timeline event.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitHubRename {
+    pub from: Option<String>,
+    pub to: Option<String>,
+}
+
+/// Flattened representation of the raw timeline event JSON, used as a
+/// deserialization target before we dispatch on the `event` discriminator.
+///
+/// All fields are optional because each concrete event type only populates a
+/// subset; unknown event types simply leave them all `None`.
+#[derive(Debug, Clone, Deserialize)]
+struct RawTimelineEvent {
+    event: Option<String>,
+    created_at: Option<String>,
+    actor: Option<GitHubUser>,
+    assignee: Option<GitHubUser>,
+    label: Option<GitHubLabel>,
+    rename: Option<GitHubRename>,
+    milestone: Option<GitHubMilestone>,
+}
+
+impl GitHubTimelineEvent {
+    /// Map a raw timeline JSON value onto a typed event, routing unrecognized
+    /// `event` discriminators to [`GitHubTimelineEvent::Other`].
+    pub fn from_value(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        let raw: RawTimelineEvent = serde_json::from_value(value)?;
+        let RawTimelineEvent {
+            event,
+            created_at,
+            actor,
+            assignee,
+            label,
+            rename,
+            milestone,
+        } = raw;
+
+        Ok(match event.as_deref() {
+            Some("closed") => GitHubTimelineEvent::Closed { created_at, actor },
+            Some("reopened") => GitHubTimelineEvent::Reopened { created_at, actor },
+            Some("assigned") => GitHubTimelineEvent::Assigned {
+                created_at,
+                actor,
+                assignee,
+            },
+            Some("unassigned") => GitHubTimelineEvent::Unassigned {
+                created_at,
+                actor,
+                assignee,
+            },
+            Some("labeled") => GitHubTimelineEvent::Labeled {
+                created_at,
+                actor,
+                label,
+            },
+            Some("unlabeled") => GitHubTimelineEvent::Unlabeled {
+                created_at,
+                actor,
+                label,
+            },
+            Some("renamed") => GitHubTimelineEvent::Renamed {
+                created_at,
+                actor,
+                rename,
+            },
+            Some("milestoned") => GitHubTimelineEvent::Milestoned {
+                created_at,
+                actor,
+                milestone,
+            },
+            Some("demilestoned") => GitHubTimelineEvent::Demilestoned {
+                created_at,
+                actor,
+                milestone,
+            },
+            _ => GitHubTimelineEvent::Other,
+        })
+    }
+}

--- a/crates/github-backend/src/trait_impl.rs
+++ b/crates/github-backend/src/trait_impl.rs
@@ -2,15 +2,16 @@
 
 use tracker_core::{
     Article, ArticleAttachment, ArticleRef, AttachmentUpload, Comment, CommentAuthor,
-    CreateArticle, CreateIssue, CreateProject, CreateTag, Issue, IssueAttachment, IssueLink,
-    IssueTag, IssueTracker, KnowledgeBase, Project, ProjectCustomField, ProjectRef, Result,
-    SearchResult, Tag, TrackerError, UpdateArticle, UpdateIssue,
+    CreateArticle, CreateIssue, CreateProject, CreateTag, Issue, IssueAttachment,
+    IssueHistoryEvent, IssueLink, IssueTag, IssueTracker, KnowledgeBase, Project,
+    ProjectCustomField, ProjectRef, Result, SearchResult, Tag, TrackerError, UpdateArticle,
+    UpdateIssue,
 };
 
 use crate::client::GitHubClient;
 use crate::convert::{
     convert_query_to_github, create_issue_from_core, get_standard_custom_fields,
-    github_issue_to_core, update_issue_from_core,
+    github_issue_to_core, github_timeline_to_events, update_issue_from_core,
 };
 use crate::wiki::WikiPage;
 
@@ -337,6 +338,12 @@ impl IssueTracker for GitHubClient {
         }
 
         Ok(comments)
+    }
+
+    fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
+        let number = parse_issue_number(issue_id)?;
+        let timeline = self.get_issue_timeline(number)?;
+        Ok(github_timeline_to_events(timeline))
     }
 }
 

--- a/crates/gitlab-backend/src/client.rs
+++ b/crates/gitlab-backend/src/client.rs
@@ -489,6 +489,120 @@ impl GitLabClient {
         Ok(notes)
     }
 
+    // ==================== Resource Event (History) Operations ====================
+
+    /// Fetch a single page of a resource-event subresource for an issue.
+    ///
+    /// `subpath` is the trailing segment (e.g. `resource_state_events`). Mirrors
+    /// [`get_notes_page_raw`](Self::get_notes_page_raw): offset paging via
+    /// `per_page` (capped at 100) and `page` (1-based), `PRIVATE-TOKEN` auth,
+    /// and GitLab returns these events oldest-first.
+    fn get_resource_events_page<T: serde::de::DeserializeOwned>(
+        &self,
+        iid: u64,
+        subpath: &str,
+        per_page: usize,
+        page: usize,
+    ) -> Result<Vec<T>> {
+        let url = self.project_url(&format!(
+            "/issues/{}/{}?per_page={}&page={}",
+            iid,
+            subpath,
+            per_page.min(100),
+            page.max(1)
+        ))?;
+
+        let response = self
+            .agent
+            .get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("Accept", "application/json")
+            .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let events: Vec<T> = response.body_mut().read_json()?;
+        Ok(events)
+    }
+
+    /// Page through every event of a resource-event subresource to completion.
+    ///
+    /// GitLab honors `per_page`, so a short page (fewer than `PER_PAGE` events)
+    /// is a reliable end-of-data signal. A `MAX_PAGES` backstop guards against a
+    /// server that ignores paging and never shrinks a page — failing loudly via
+    /// [`GitLabError::PaginationStalled`] instead of looping forever.
+    ///
+    /// Events are returned oldest-first, matching the GitLab API ordering.
+    fn get_all_resource_events<T: serde::de::DeserializeOwned>(
+        &self,
+        iid: u64,
+        subpath: &str,
+    ) -> Result<Vec<T>> {
+        const PER_PAGE: usize = 100;
+        const MAX_PAGES: usize = 10_000;
+
+        let mut events = Vec::new();
+        let mut page = 1;
+        for _ in 0..MAX_PAGES {
+            let batch = self.get_resource_events_page::<T>(iid, subpath, PER_PAGE, page)?;
+            let fetched = batch.len();
+            events.extend(batch);
+            if fetched < PER_PAGE {
+                return Ok(events);
+            }
+            page += 1;
+        }
+        Err(GitLabError::PaginationStalled(format!(
+            "issue '{}' {} did not terminate after {} pages",
+            iid, subpath, MAX_PAGES
+        )))
+    }
+
+    /// Fetch a single page of an issue's resource state events.
+    pub fn get_state_events_page(
+        &self,
+        iid: u64,
+        per_page: usize,
+        page: usize,
+    ) -> Result<Vec<GitLabStateEvent>> {
+        self.get_resource_events_page(iid, "resource_state_events", per_page, page)
+    }
+
+    /// Fetch all of an issue's resource state events (oldest-first).
+    pub fn get_state_events(&self, iid: u64) -> Result<Vec<GitLabStateEvent>> {
+        self.get_all_resource_events(iid, "resource_state_events")
+    }
+
+    /// Fetch a single page of an issue's resource label events.
+    pub fn get_label_events_page(
+        &self,
+        iid: u64,
+        per_page: usize,
+        page: usize,
+    ) -> Result<Vec<GitLabLabelEvent>> {
+        self.get_resource_events_page(iid, "resource_label_events", per_page, page)
+    }
+
+    /// Fetch all of an issue's resource label events (oldest-first).
+    pub fn get_label_events(&self, iid: u64) -> Result<Vec<GitLabLabelEvent>> {
+        self.get_all_resource_events(iid, "resource_label_events")
+    }
+
+    /// Fetch a single page of an issue's resource milestone events.
+    pub fn get_milestone_events_page(
+        &self,
+        iid: u64,
+        per_page: usize,
+        page: usize,
+    ) -> Result<Vec<GitLabMilestoneEvent>> {
+        self.get_resource_events_page(iid, "resource_milestone_events", per_page, page)
+    }
+
+    /// Fetch all of an issue's resource milestone events (oldest-first).
+    pub fn get_milestone_events(&self, iid: u64) -> Result<Vec<GitLabMilestoneEvent>> {
+        self.get_all_resource_events(iid, "resource_milestone_events")
+    }
+
     // ==================== Link Operations ====================
 
     /// Get issue links for an issue

--- a/crates/gitlab-backend/src/client_tests.rs
+++ b/crates/gitlab-backend/src/client_tests.rs
@@ -856,4 +856,99 @@ mod tests {
 
         assert_eq!(client.resolve_link_type("nonexistent"), "nonexistent");
     }
+
+    // ==================== Issue History (3-endpoint merge) Tests ====================
+
+    #[tokio::test]
+    async fn test_get_issue_history_merges_three_endpoints() {
+        let mock_server = MockServer::start().await;
+
+        // resource_state_events: opened -> closed (out of order to exercise the
+        // chronological sort + from-derivation).
+        Mock::given(method("GET"))
+            .and(path("/projects/123/issues/42/resource_state_events"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("per_page", "100"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": 200,
+                    "user": { "id": 2, "username": "bob", "name": "Bob" },
+                    "created_at": "2024-01-05T00:00:00.000Z",
+                    "state": "closed"
+                },
+                {
+                    "id": 100,
+                    "user": { "id": 1, "username": "alice", "name": "Alice" },
+                    "created_at": "2024-01-01T00:00:00.000Z",
+                    "state": "opened"
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        // resource_label_events: add bug.
+        Mock::given(method("GET"))
+            .and(path("/projects/123/issues/42/resource_label_events"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("per_page", "100"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": 300,
+                    "user": { "id": 3, "username": "carol", "name": "Carol" },
+                    "created_at": "2024-01-03T00:00:00.000Z",
+                    "action": "add",
+                    "label": { "id": 9, "name": "bug" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        // resource_milestone_events: add v1.0.
+        Mock::given(method("GET"))
+            .and(path("/projects/123/issues/42/resource_milestone_events"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("per_page", "100"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": 400,
+                    "user": { "id": 4, "username": "dave", "name": "Dave" },
+                    "created_at": "2024-01-04T00:00:00.000Z",
+                    "action": "add",
+                    "milestone": { "id": 1, "iid": 1, "title": "v1.0" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let events = <GitLabClient as IssueTracker>::get_issue_history(&client, "42").unwrap();
+
+        // 2 state + 1 label + 1 milestone, merged and sorted newest-first.
+        assert_eq!(events.len(), 4);
+
+        // 01-05 closed (status, from-derived as "opened" -> "closed").
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].from.as_deref(), Some("opened"));
+        assert_eq!(events[0].to.as_deref(), Some("closed"));
+        assert_eq!(events[0].author.as_ref().unwrap().login, "bob");
+
+        // 01-04 milestone add.
+        assert_eq!(events[1].field, "milestone");
+        assert_eq!(events[1].from, None);
+        assert_eq!(events[1].to.as_deref(), Some("v1.0"));
+
+        // 01-03 label add.
+        assert_eq!(events[2].field, "labels");
+        assert_eq!(events[2].from, None);
+        assert_eq!(events[2].to.as_deref(), Some("bug"));
+
+        // 01-01 opened (seed transition).
+        assert_eq!(events[3].field, "status");
+        assert_eq!(events[3].from.as_deref(), Some("opened"));
+        assert_eq!(events[3].to.as_deref(), Some("opened"));
+        assert_eq!(events[3].author.as_ref().unwrap().login, "alice");
+    }
 }

--- a/crates/gitlab-backend/src/convert.rs
+++ b/crates/gitlab-backend/src/convert.rs
@@ -2,8 +2,9 @@
 
 use chrono::{DateTime, Utc};
 use tracker_core::{
-    Comment, CommentAuthor, CustomField, IssueLink, IssueLinkType, IssueTag, LinkedIssue, Project,
-    ProjectCustomField, ProjectRef, StateValueInfo, Tag, TagColor, User,
+    Comment, CommentAuthor, CustomField, IssueHistoryEvent, IssueLink, IssueLinkType, IssueTag,
+    LinkedIssue, Project, ProjectCustomField, ProjectRef, StateValueInfo, Tag, TagColor, User,
+    canonical_field_name,
 };
 
 use crate::models::*;
@@ -251,6 +252,119 @@ fn parse_gitlab_datetime(dt: &Option<String>) -> Option<DateTime<Utc>> {
             .ok()
             .map(|d| d.with_timezone(&Utc))
     })
+}
+
+/// Map a GitLab resource-event user onto a [`CommentAuthor`].
+///
+/// Mirrors the note/comment author mapping (`username` → `login`, `name` →
+/// `Some(name)`) so history and comment authors render identically. A
+/// system-generated event with no user produces `None`.
+fn event_user_to_author(user: Option<GitLabUser>) -> Option<CommentAuthor> {
+    user.map(|u| CommentAuthor {
+        login: u.username,
+        name: Some(u.name),
+    })
+}
+
+/// Merge GitLab's three resource-event streams into a unified history.
+///
+/// GitLab is an event-stream backend: state/label/milestone changes live on
+/// three separate endpoints, each recording *what happened* rather than a
+/// before/after diff.
+///
+/// For the workflow status field there is no `from` in the payload, so we
+/// reconstruct it by walking the state events in chronological order
+/// (oldest-first) while threading a single running `status` string (seeded to
+/// `"opened"`, the state a GitLab issue is born in). Each state event reads the
+/// current status as its `from`, then advances it. Events whose `created_at`
+/// cannot be parsed are skipped *without* advancing the running status, so a
+/// dropped event never corrupts later `from` values.
+///
+/// Label and milestone events carry their own value directly: an `add` emits a
+/// `to` with no `from`, a `remove` emits a `from` with no `to`. Their `field`
+/// stays fixed (`labels` / `milestone`).
+///
+/// After merging all three streams the result is sorted newest-first (stable)
+/// to match the reporting order used by the other backends.
+pub fn gitlab_events_to_history_events(
+    mut state: Vec<GitLabStateEvent>,
+    label: Vec<GitLabLabelEvent>,
+    milestone: Vec<GitLabMilestoneEvent>,
+) -> Vec<IssueHistoryEvent> {
+    let mut out = Vec::new();
+
+    // --- State events: derive `from` by walking chronologically. ---
+    // Sort oldest-first so the running-status thread is meaningful; `sort_by`
+    // is stable, preserving the API's ordering for events sharing a timestamp.
+    state.sort_by(|a, b| {
+        let a_at = parse_gitlab_datetime(&a.created_at);
+        let b_at = parse_gitlab_datetime(&b.created_at);
+        a_at.cmp(&b_at)
+    });
+
+    // GitLab issues are born `opened`.
+    let mut status = "opened".to_string();
+    for event in state {
+        let Some(at) = parse_gitlab_datetime(&event.created_at) else {
+            // Skip unparseable timestamps without advancing the running status.
+            continue;
+        };
+        let Some(to) = event.state else {
+            continue;
+        };
+        out.push(IssueHistoryEvent {
+            at,
+            author: event_user_to_author(event.user),
+            field: canonical_field_name("state"),
+            from: Some(status.clone()),
+            to: Some(to.clone()),
+        });
+        status = to;
+    }
+
+    // --- Label events: `add` -> to, `remove` -> from. ---
+    for event in label {
+        let Some(at) = parse_gitlab_datetime(&event.created_at) else {
+            continue;
+        };
+        let label_name = event.label.map(|l| l.name);
+        let (from, to) = match event.action.as_deref() {
+            Some("remove") => (label_name, None),
+            _ => (None, label_name), // "add" (and any other action) treated as add
+        };
+        out.push(IssueHistoryEvent {
+            at,
+            author: event_user_to_author(event.user),
+            field: "labels".to_string(),
+            from,
+            to,
+        });
+    }
+
+    // --- Milestone events: `add` -> to, `remove` -> from. ---
+    for event in milestone {
+        let Some(at) = parse_gitlab_datetime(&event.created_at) else {
+            continue;
+        };
+        let title = event.milestone.map(|m| m.title);
+        let (from, to) = match event.action.as_deref() {
+            Some("remove") => (title, None),
+            _ => (None, title),
+        };
+        out.push(IssueHistoryEvent {
+            at,
+            author: event_user_to_author(event.user),
+            field: "milestone".to_string(),
+            from,
+            to,
+        });
+    }
+
+    // Expose newest-first to match the reporting order used by the other
+    // backends. `sort_by` is stable, so events sharing a timestamp keep their
+    // insertion order.
+    out.sort_by(|a, b| b.at.cmp(&a.at));
+    out
 }
 
 /// Convert a simple tracker-core query to GitLab search params.
@@ -531,5 +645,218 @@ mod tests {
             core_link.issues[0].summary,
             Some("Unknown Link Type Issue".to_string())
         );
+    }
+
+    // ==================== gitlab_events_to_history_events tests ====================
+
+    use crate::models::{
+        GitLabEventLabel, GitLabEventMilestone, GitLabLabelEvent, GitLabMilestoneEvent,
+        GitLabStateEvent, GitLabUser,
+    };
+
+    fn user(username: &str) -> GitLabUser {
+        GitLabUser {
+            id: 1,
+            username: username.to_string(),
+            name: format!("{} Name", username),
+        }
+    }
+
+    fn state_event(id: u64, at: &str, state: &str, username: Option<&str>) -> GitLabStateEvent {
+        GitLabStateEvent {
+            id,
+            user: username.map(user),
+            created_at: Some(at.to_string()),
+            state: Some(state.to_string()),
+        }
+    }
+
+    #[test]
+    fn state_events_derive_from_chronologically() {
+        // opened -> closed -> reopened, given out of order to exercise the sort.
+        let state = vec![
+            state_event(3, "2024-03-03T00:00:00Z", "reopened", Some("carol")),
+            state_event(1, "2024-01-01T00:00:00Z", "opened", Some("alice")),
+            state_event(2, "2024-02-02T00:00:00Z", "closed", Some("bob")),
+        ];
+
+        let events = gitlab_events_to_history_events(state, vec![], vec![]);
+
+        assert_eq!(events.len(), 3);
+        // Newest-first ordering.
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].from.as_deref(), Some("closed"));
+        assert_eq!(events[0].to.as_deref(), Some("reopened"));
+        assert_eq!(events[0].author.as_ref().unwrap().login, "carol");
+
+        assert_eq!(events[1].field, "status");
+        assert_eq!(events[1].from.as_deref(), Some("opened"));
+        assert_eq!(events[1].to.as_deref(), Some("closed"));
+        assert_eq!(events[1].author.as_ref().unwrap().login, "bob");
+
+        // The first transition's `from` is seeded to "opened".
+        assert_eq!(events[2].field, "status");
+        assert_eq!(events[2].from.as_deref(), Some("opened"));
+        assert_eq!(events[2].to.as_deref(), Some("opened"));
+        assert_eq!(events[2].author.as_ref().unwrap().login, "alice");
+    }
+
+    #[test]
+    fn unparseable_state_timestamp_is_skipped_without_advancing_status() {
+        // The middle event has a bad timestamp; it must be dropped and must NOT
+        // advance the running status, so the final transition's `from` is still
+        // "opened" (the seed) rather than "closed".
+        let state = vec![
+            GitLabStateEvent {
+                id: 1,
+                user: Some(user("alice")),
+                created_at: Some("not-a-date".to_string()),
+                state: Some("closed".to_string()),
+            },
+            state_event(2, "2024-02-02T00:00:00Z", "reopened", Some("bob")),
+        ];
+
+        let events = gitlab_events_to_history_events(state, vec![], vec![]);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].from.as_deref(), Some("opened"));
+        assert_eq!(events[0].to.as_deref(), Some("reopened"));
+    }
+
+    #[test]
+    fn label_add_and_remove_produce_correct_from_to() {
+        let label = vec![
+            GitLabLabelEvent {
+                id: 1,
+                user: Some(user("alice")),
+                created_at: Some("2024-01-01T00:00:00Z".to_string()),
+                action: Some("add".to_string()),
+                label: Some(GitLabEventLabel {
+                    name: "bug".to_string(),
+                }),
+            },
+            GitLabLabelEvent {
+                id: 2,
+                user: Some(user("bob")),
+                created_at: Some("2024-01-02T00:00:00Z".to_string()),
+                action: Some("remove".to_string()),
+                label: Some(GitLabEventLabel {
+                    name: "bug".to_string(),
+                }),
+            },
+        ];
+
+        let events = gitlab_events_to_history_events(vec![], label, vec![]);
+
+        assert_eq!(events.len(), 2);
+        // Newest-first: the remove sorts ahead of the add.
+        assert_eq!(events[0].field, "labels");
+        assert_eq!(events[0].from.as_deref(), Some("bug"));
+        assert_eq!(events[0].to, None);
+
+        assert_eq!(events[1].field, "labels");
+        assert_eq!(events[1].from, None);
+        assert_eq!(events[1].to.as_deref(), Some("bug"));
+    }
+
+    #[test]
+    fn milestone_add_and_remove_produce_correct_from_to() {
+        let milestone = vec![
+            GitLabMilestoneEvent {
+                id: 1,
+                user: Some(user("alice")),
+                created_at: Some("2024-01-01T00:00:00Z".to_string()),
+                action: Some("add".to_string()),
+                milestone: Some(GitLabEventMilestone {
+                    title: "v1.0".to_string(),
+                }),
+            },
+            GitLabMilestoneEvent {
+                id: 2,
+                user: Some(user("bob")),
+                created_at: Some("2024-01-02T00:00:00Z".to_string()),
+                action: Some("remove".to_string()),
+                milestone: Some(GitLabEventMilestone {
+                    title: "v1.0".to_string(),
+                }),
+            },
+        ];
+
+        let events = gitlab_events_to_history_events(vec![], vec![], milestone);
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].field, "milestone");
+        assert_eq!(events[0].from.as_deref(), Some("v1.0"));
+        assert_eq!(events[0].to, None);
+
+        assert_eq!(events[1].field, "milestone");
+        assert_eq!(events[1].from, None);
+        assert_eq!(events[1].to.as_deref(), Some("v1.0"));
+    }
+
+    #[test]
+    fn mixed_events_merge_and_sort_newest_first() {
+        let state = vec![
+            state_event(1, "2024-01-01T00:00:00Z", "opened", Some("alice")),
+            state_event(2, "2024-01-05T00:00:00Z", "closed", Some("alice")),
+        ];
+        let label = vec![GitLabLabelEvent {
+            id: 1,
+            user: Some(user("bob")),
+            created_at: Some("2024-01-03T00:00:00Z".to_string()),
+            action: Some("add".to_string()),
+            label: Some(GitLabEventLabel {
+                name: "bug".to_string(),
+            }),
+        }];
+        let milestone = vec![GitLabMilestoneEvent {
+            id: 1,
+            user: Some(user("carol")),
+            created_at: Some("2024-01-04T00:00:00Z".to_string()),
+            action: Some("add".to_string()),
+            milestone: Some(GitLabEventMilestone {
+                title: "v1.0".to_string(),
+            }),
+        }];
+
+        let events = gitlab_events_to_history_events(state, label, milestone);
+
+        // All four events present, sorted newest-first across all three streams.
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].field, "status"); // 01-05 closed
+        assert_eq!(events[0].to.as_deref(), Some("closed"));
+        assert_eq!(events[1].field, "milestone"); // 01-04
+        assert_eq!(events[2].field, "labels"); // 01-03
+        assert_eq!(events[3].field, "status"); // 01-01 opened
+        assert_eq!(events[3].to.as_deref(), Some("opened"));
+    }
+
+    #[test]
+    fn null_user_yields_no_author() {
+        let state = vec![state_event(1, "2024-01-01T00:00:00Z", "closed", None)];
+
+        let events = gitlab_events_to_history_events(state, vec![], vec![]);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].author.is_none());
+    }
+
+    #[test]
+    fn null_label_is_tolerated() {
+        let label = vec![GitLabLabelEvent {
+            id: 1,
+            user: Some(user("alice")),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            action: Some("add".to_string()),
+            label: None,
+        }];
+
+        let events = gitlab_events_to_history_events(vec![], label, vec![]);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].field, "labels");
+        assert_eq!(events[0].from, None);
+        assert_eq!(events[0].to, None);
     }
 }

--- a/crates/gitlab-backend/src/error.rs
+++ b/crates/gitlab-backend/src/error.rs
@@ -23,6 +23,9 @@ pub enum GitLabError {
 
     #[error("API error ({status}): {message}")]
     Api { status: u16, message: String },
+
+    #[error("Pagination stalled: {0}")]
+    PaginationStalled(String),
 }
 
 pub type Result<T> = std::result::Result<T, GitLabError>;
@@ -37,6 +40,7 @@ impl From<GitLabError> for TrackerError {
             GitLabError::ProjectNotFound(id) => TrackerError::ProjectNotFound(id),
             GitLabError::Unauthorized => TrackerError::Unauthorized,
             GitLabError::Api { status, message } => TrackerError::Api { status, message },
+            GitLabError::PaginationStalled(msg) => TrackerError::PaginationStalled(msg),
         }
     }
 }

--- a/crates/gitlab-backend/src/models/events.rs
+++ b/crates/gitlab-backend/src/models/events.rs
@@ -1,0 +1,62 @@
+use serde::{Deserialize, Serialize};
+
+use super::issue::GitLabUser;
+
+/// GitLab resource state event
+/// (`GET /projects/:id/issues/:iid/resource_state_events`).
+///
+/// `state` is one of `opened`/`closed`/`reopened`/... The `user` is absent for
+/// some system-generated events.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabStateEvent {
+    pub id: u64,
+    pub user: Option<GitLabUser>,
+    pub created_at: Option<String>,
+    pub state: Option<String>,
+}
+
+/// Label reference embedded in a [`GitLabLabelEvent`].
+///
+/// Only the name is needed for history rendering.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabEventLabel {
+    #[serde(default)]
+    pub name: String,
+}
+
+/// GitLab resource label event
+/// (`GET /projects/:id/issues/:iid/resource_label_events`).
+///
+/// `action` is `"add"` or `"remove"`. `label` may be `null` if the referenced
+/// label has since been deleted.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabLabelEvent {
+    pub id: u64,
+    pub user: Option<GitLabUser>,
+    pub created_at: Option<String>,
+    pub action: Option<String>,
+    pub label: Option<GitLabEventLabel>,
+}
+
+/// Milestone reference embedded in a [`GitLabMilestoneEvent`].
+///
+/// Only the title is needed for history rendering.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabEventMilestone {
+    #[serde(default)]
+    pub title: String,
+}
+
+/// GitLab resource milestone event
+/// (`GET /projects/:id/issues/:iid/resource_milestone_events`).
+///
+/// `action` is `"add"` or `"remove"`. `milestone` may be `null` for system or
+/// removed milestones.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitLabMilestoneEvent {
+    pub id: u64,
+    pub user: Option<GitLabUser>,
+    pub created_at: Option<String>,
+    pub action: Option<String>,
+    pub milestone: Option<GitLabEventMilestone>,
+}

--- a/crates/gitlab-backend/src/models/mod.rs
+++ b/crates/gitlab-backend/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod comment;
+pub mod events;
 pub mod issue;
 pub mod label;
 pub mod project;
@@ -6,6 +7,7 @@ pub mod upload;
 pub mod wiki;
 
 pub use comment::*;
+pub use events::*;
 pub use issue::*;
 pub use label::*;
 pub use project::*;

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -2,15 +2,15 @@
 
 use tracker_core::{
     Article, ArticleAttachment, ArticleRef, AttachmentUpload, Comment, CreateArticle, CreateIssue,
-    CreateProject, CreateTag, Issue, IssueAttachment, IssueLink, IssueLinkType, IssueTag,
-    IssueTracker, KnowledgeBase, Project, ProjectCustomField, ProjectRef, Result, SearchResult,
-    TrackerError, UpdateArticle, UpdateIssue, User,
+    CreateProject, CreateTag, Issue, IssueAttachment, IssueHistoryEvent, IssueLink, IssueLinkType,
+    IssueTag, IssueTracker, KnowledgeBase, Project, ProjectCustomField, ProjectRef, Result,
+    SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
 };
 
 use crate::client::GitLabClient;
 use crate::convert::{
     convert_query_to_gitlab_params, get_gitlab_link_types, get_standard_custom_fields,
-    gitlab_issue_to_core, gitlab_link_to_core,
+    gitlab_events_to_history_events, gitlab_issue_to_core, gitlab_link_to_core,
 };
 use crate::models::{
     CreateGitLabIssue, CreateGitLabIssueLink, CreateGitLabLabel, CreateGitLabWikiPage,
@@ -433,6 +433,18 @@ impl IssueTracker for GitLabClient {
         }
 
         Ok(comments)
+    }
+
+    fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
+        let iid = parse_issue_iid(issue_id)?;
+
+        // History is spread across three independent endpoints; fetch each to
+        // completion, then merge into a single chronological timeline.
+        let state = self.get_state_events(iid)?;
+        let label = self.get_label_events(iid)?;
+        let milestone = self.get_milestone_events(iid)?;
+
+        Ok(gitlab_events_to_history_events(state, label, milestone))
     }
 }
 

--- a/crates/linear-backend/src/client.rs
+++ b/crates/linear-backend/src/client.rs
@@ -673,6 +673,66 @@ impl LinearClient {
         Ok((issue.comments.nodes, issue.comments.page_info))
     }
 
+    /// Fetch one page of an issue's change history (`Issue.history`).
+    ///
+    /// Mirrors [`get_comments_page`](Self::get_comments_page): cursor-paged via
+    /// `first`/`after`, returning the nodes plus the page info so the caller can
+    /// walk to completion. `issue_id` must be Linear's internal id (callers
+    /// resolve a readable identifier through [`get_issue`](Self::get_issue)
+    /// first, exactly as the comments path does). History is returned
+    /// newest-first by Linear; the converter re-sorts to be safe.
+    pub fn get_issue_history_page(
+        &self,
+        issue_id: &str,
+        first: usize,
+        after: Option<String>,
+    ) -> Result<(Vec<LinearIssueHistory>, LinearPageInfo)> {
+        #[derive(serde::Deserialize)]
+        struct IssueHistory {
+            history: LinearConnection<LinearIssueHistory>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct Data {
+            issue: Option<IssueHistory>,
+        }
+
+        let query = r#"
+            query IssueHistory($id: String!, $first: Int!, $after: String) {
+              issue(id: $id) {
+                history(first: $first, after: $after) {
+                  nodes {
+                    createdAt
+                    actor { id name displayName email }
+                    fromState { name }
+                    toState { name }
+                    fromAssignee { id displayName name email }
+                    toAssignee { id displayName name email }
+                    fromPriority
+                    toPriority
+                    fromTitle
+                    toTitle
+                  }
+                  pageInfo { hasNextPage endCursor }
+                }
+              }
+            }
+        "#;
+
+        let data: Data = self.graphql(
+            query,
+            json!({
+                "id": issue_id,
+                "first": first.clamp(1, 100),
+                "after": after,
+            }),
+        )?;
+        let issue = data
+            .issue
+            .ok_or_else(|| LinearError::IssueNotFound(issue_id.to_string()))?;
+        Ok((issue.history.nodes, issue.history.page_info))
+    }
+
     pub fn create_label(&self, input: &LinearIssueLabelCreateInput) -> Result<LinearIssueLabel> {
         #[derive(serde::Deserialize)]
         struct Data {

--- a/crates/linear-backend/src/client_tests.rs
+++ b/crates/linear-backend/src/client_tests.rs
@@ -372,4 +372,87 @@ mod tests {
         assert_eq!(events[1].to.as_deref(), Some("In Progress"));
         assert_eq!(events[1].from.as_deref(), Some("Todo"));
     }
+
+    #[tokio::test]
+    async fn test_get_issue_history_skips_empty_page_with_next_cursor() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("query Issue"))
+            .and(body_string_contains("ORE-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "issue": mock_linear_issue("ORE-123", "History issue") }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Page 3: real data, last page.
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueHistory"))
+            .and(body_string_contains("cursor-2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "history": {
+                            "nodes": [
+                                {
+                                    "createdAt": "2024-01-15T14:30:00Z",
+                                    "fromState": { "name": "In Progress" },
+                                    "toState": { "name": "Done" }
+                                }
+                            ],
+                            "pageInfo": { "hasNextPage": false, "endCursor": null }
+                        }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Page 2: empty but hasNextPage — must not truncate.
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueHistory"))
+            .and(body_string_contains("cursor-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "history": {
+                            "nodes": [],
+                            "pageInfo": { "hasNextPage": true, "endCursor": "cursor-2" }
+                        }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Page 1: oldest node with a next cursor.
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueHistory"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "history": {
+                            "nodes": [
+                                {
+                                    "createdAt": "2024-01-10T09:00:00Z",
+                                    "fromState": { "name": "Todo" },
+                                    "toState": { "name": "In Progress" }
+                                }
+                            ],
+                            "pageInfo": { "hasNextPage": true, "endCursor": "cursor-1" }
+                        }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = LinearClient::with_base_url(&mock_server.uri(), "test-token");
+        let events = <LinearClient as IssueTracker>::get_issue_history(&client, "ORE-123").unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].to.as_deref(), Some("Done"));
+        assert_eq!(events[1].to.as_deref(), Some("In Progress"));
+    }
 }

--- a/crates/linear-backend/src/client_tests.rs
+++ b/crates/linear-backend/src/client_tests.rs
@@ -289,4 +289,87 @@ mod tests {
         assert!(fields.iter().any(|field| field.name == "Labels"));
         assert!(fields.iter().any(|field| field.name == "Project"));
     }
+
+    #[tokio::test]
+    async fn test_get_issue_history_paginates_and_sorts() {
+        let mock_server = MockServer::start().await;
+
+        // 1. `get_issue` resolves the readable id to the internal id; the
+        //    history query then keys on that internal id.
+        Mock::given(method("POST"))
+            .and(body_string_contains("query Issue"))
+            .and(body_string_contains("ORE-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "issue": mock_linear_issue("ORE-123", "History issue") }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // 2. History page 2 (matched first, since it is more specific): it is
+        //    requested with the cursor from page 1 and reports the newest node.
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueHistory"))
+            .and(body_string_contains("cursor-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "history": {
+                            "nodes": [
+                                {
+                                    "createdAt": "2024-01-15T14:30:00Z",
+                                    "actor": { "id": "u-bob", "name": "bob", "displayName": "Bob", "email": "bob@example.com" },
+                                    "fromState": { "name": "In Progress" },
+                                    "toState": { "name": "Done" }
+                                }
+                            ],
+                            "pageInfo": { "hasNextPage": false, "endCursor": null }
+                        }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // 3. History page 1 (no cursor): an older node, with `hasNextPage` true
+        //    so the loop must fetch page 2.
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueHistory"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "history": {
+                            "nodes": [
+                                {
+                                    "createdAt": "2024-01-10T09:00:00Z",
+                                    "actor": { "id": "u-alice", "name": "alice", "displayName": "Alice", "email": "alice@example.com" },
+                                    "fromState": { "name": "Todo" },
+                                    "toState": { "name": "In Progress" }
+                                }
+                            ],
+                            "pageInfo": { "hasNextPage": true, "endCursor": "cursor-1" }
+                        }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = LinearClient::with_base_url(&mock_server.uri(), "test-token");
+        let events = <LinearClient as IssueTracker>::get_issue_history(&client, "ORE-123").unwrap();
+
+        // One event per page, both state transitions canonicalized to "status".
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|e| e.field == "status"));
+
+        // Newest-first: the page-2 (Done) node sorts to the front.
+        assert_eq!(events[0].to.as_deref(), Some("Done"));
+        assert_eq!(events[0].from.as_deref(), Some("In Progress"));
+        assert_eq!(
+            events[0].author.as_ref().and_then(|a| a.name.as_deref()),
+            Some("Bob")
+        );
+        // Oldest sorts last.
+        assert_eq!(events[1].to.as_deref(), Some("In Progress"));
+        assert_eq!(events[1].from.as_deref(), Some("Todo"));
+    }
 }

--- a/crates/linear-backend/src/convert.rs
+++ b/crates/linear-backend/src/convert.rs
@@ -2,8 +2,9 @@
 
 use serde_json::{Value, json};
 use tracker_core::{
-    Comment, CommentAuthor, CustomField, Issue, IssueLink, IssueLinkType, IssueTag, LinkedIssue,
-    Project, ProjectCustomField, ProjectRef, StateValueInfo, Tag, TagColor, User,
+    Comment, CommentAuthor, CustomField, Issue, IssueHistoryEvent, IssueLink, IssueLinkType,
+    IssueTag, LinkedIssue, Project, ProjectCustomField, ProjectRef, StateValueInfo, Tag, TagColor,
+    User, canonical_field_name,
 };
 
 use crate::client::{LinearIssueRelations, add_filter_condition, filter_with_team};
@@ -138,6 +139,89 @@ impl From<LinearComment> for Comment {
             created: Some(comment.created_at),
         }
     }
+}
+
+/// Convert Linear issue-history nodes into core history events, newest-first.
+///
+/// Linear models history as nodes that may each carry several independent
+/// transitions (state, assignee, priority, title), so every populated
+/// transition is **decomposed** into its own [`IssueHistoryEvent`], all sharing
+/// the node's `createdAt` and `actor`. Nodes whose timestamp is missing are
+/// skipped rather than fabricated. The state field is canonicalized so Linear's
+/// workflow "state" folds onto the portable "status" token. `from`/`to` are
+/// `None` when the corresponding source field is null.
+///
+/// Label history (`addedLabelIds`/`removedLabelIds`) is intentionally not
+/// emitted here — see the TODO below.
+pub fn linear_history_to_events(nodes: Vec<LinearIssueHistory>) -> Vec<IssueHistoryEvent> {
+    let mut events = Vec::new();
+    for node in nodes {
+        // A node without a timestamp can't be placed on the timeline; skip it
+        // rather than stamping a fabricated `at`.
+        let Some(at) = node.created_at else {
+            continue;
+        };
+        let author = node.actor.as_ref().map(|user| CommentAuthor {
+            login: linear_user_login(user),
+            name: Some(linear_user_display_name(user)),
+        });
+
+        // State transition -> canonical "status".
+        if let Some(to_state) = &node.to_state {
+            events.push(IssueHistoryEvent {
+                at,
+                author: author.clone(),
+                field: canonical_field_name("state"),
+                from: node.from_state.as_ref().map(|s| s.name.clone()),
+                to: Some(to_state.name.clone()),
+            });
+        }
+
+        // Assignee transition (only when something actually changed).
+        let from_assignee = node.from_assignee.as_ref().map(linear_user_display_name);
+        let to_assignee = node.to_assignee.as_ref().map(linear_user_display_name);
+        if (from_assignee.is_some() || to_assignee.is_some()) && from_assignee != to_assignee {
+            events.push(IssueHistoryEvent {
+                at,
+                author: author.clone(),
+                field: "assignee".to_string(),
+                from: from_assignee,
+                to: to_assignee,
+            });
+        }
+
+        // Priority transition (only when the value actually changed).
+        if node.to_priority.is_some() && node.to_priority != node.from_priority {
+            events.push(IssueHistoryEvent {
+                at,
+                author: author.clone(),
+                field: "priority".to_string(),
+                from: node.from_priority.map(|p| priority_label(p).to_string()),
+                to: node.to_priority.map(|p| priority_label(p).to_string()),
+            });
+        }
+
+        // Title transition.
+        if node.to_title.is_some() {
+            events.push(IssueHistoryEvent {
+                at,
+                author: author.clone(),
+                field: "title".to_string(),
+                from: node.from_title.clone(),
+                to: node.to_title.clone(),
+            });
+        }
+
+        // TODO: label history (addedLabelIds/removedLabelIds) is deferred —
+        // those carry only label *ids*, which require a separate name lookup to
+        // render portably. Documented follow-up.
+    }
+
+    // Linear returns history newest-first; re-sort defensively. `sort_by` is a
+    // stable sort, so the per-node transition order (state, assignee, priority,
+    // title) is preserved among events sharing a timestamp.
+    events.sort_by(|a, b| b.at.cmp(&a.at));
+    events
 }
 
 pub fn team_details_custom_fields(
@@ -607,6 +691,146 @@ fn tokenize_query(query: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn history_from_json(value: serde_json::Value) -> Vec<LinearIssueHistory> {
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn linear_history_decomposes_multi_change_node() {
+        // One node carrying state + assignee + priority transitions must yield
+        // three events, all sharing the node's timestamp and actor, in
+        // per-node order (state, assignee, priority).
+        let nodes = history_from_json(serde_json::json!([
+            {
+                "createdAt": "2024-01-15T10:00:00Z",
+                "actor": { "id": "u-alice", "name": "alice", "displayName": "Alice", "email": "alice@example.com" },
+                "fromState": { "name": "Todo" },
+                "toState": { "name": "In Progress" },
+                "fromAssignee": null,
+                "toAssignee": { "id": "u-bob", "name": "bob", "displayName": "Bob", "email": "bob@example.com" },
+                "fromPriority": 3,
+                "toPriority": 1,
+                "fromTitle": null,
+                "toTitle": null
+            }
+        ]));
+
+        let events = linear_history_to_events(nodes);
+        assert_eq!(events.len(), 3);
+
+        // State -> canonical "status".
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].from.as_deref(), Some("Todo"));
+        assert_eq!(events[0].to.as_deref(), Some("In Progress"));
+
+        // Assignee uses display name; a null `from` side maps to None.
+        assert_eq!(events[1].field, "assignee");
+        assert_eq!(events[1].from, None);
+        assert_eq!(events[1].to.as_deref(), Some("Bob"));
+
+        // Priority maps numeric codes through priority_label.
+        assert_eq!(events[2].field, "priority");
+        assert_eq!(events[2].from.as_deref(), Some("Medium"));
+        assert_eq!(events[2].to.as_deref(), Some("Urgent"));
+
+        // Author is shared across all three events.
+        for event in &events {
+            assert_eq!(
+                event.author.as_ref().map(|a| a.login.as_str()),
+                Some("alice@example.com")
+            );
+            assert_eq!(
+                event.author.as_ref().and_then(|a| a.name.as_deref()),
+                Some("Alice")
+            );
+        }
+    }
+
+    #[test]
+    fn linear_history_null_actor_yields_no_author() {
+        // A system change carries no actor; the event's author must be None.
+        let nodes = history_from_json(serde_json::json!([
+            {
+                "createdAt": "2024-01-15T10:00:00Z",
+                "actor": null,
+                "fromState": { "name": "Backlog" },
+                "toState": { "name": "Todo" }
+            }
+        ]));
+
+        let events = linear_history_to_events(nodes);
+        assert_eq!(events.len(), 1);
+        assert!(events[0].author.is_none());
+        assert_eq!(events[0].field, "status");
+    }
+
+    #[test]
+    fn linear_history_title_only_node() {
+        // A node with only a title transition produces exactly one title event,
+        // and no spurious state/assignee/priority events.
+        let nodes = history_from_json(serde_json::json!([
+            {
+                "createdAt": "2024-01-15T10:00:00Z",
+                "actor": { "id": "u-carol", "name": "carol", "displayName": "Carol" },
+                "fromTitle": "Old title",
+                "toTitle": "New title"
+            }
+        ]));
+
+        let events = linear_history_to_events(nodes);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].field, "title");
+        assert_eq!(events[0].from.as_deref(), Some("Old title"));
+        assert_eq!(events[0].to.as_deref(), Some("New title"));
+    }
+
+    #[test]
+    fn linear_history_sorts_newest_first() {
+        // Two nodes arrive oldest-first; output must be newest-first.
+        let nodes = history_from_json(serde_json::json!([
+            {
+                "createdAt": "2024-01-10T09:00:00Z",
+                "fromState": { "name": "Todo" },
+                "toState": { "name": "In Progress" }
+            },
+            {
+                "createdAt": "2024-01-15T14:30:00Z",
+                "fromState": { "name": "In Progress" },
+                "toState": { "name": "Done" }
+            }
+        ]));
+
+        let events = linear_history_to_events(nodes);
+        assert_eq!(events.len(), 2);
+        // Newest (Done) first.
+        assert_eq!(events[0].to.as_deref(), Some("Done"));
+        assert_eq!(events[1].to.as_deref(), Some("In Progress"));
+    }
+
+    #[test]
+    fn linear_history_skips_missing_timestamp_and_unchanged_fields() {
+        let nodes = history_from_json(serde_json::json!([
+            {
+                // No createdAt -> skipped rather than fabricated.
+                "toState": { "name": "Done" }
+            },
+            {
+                "createdAt": "2024-02-01T00:00:00Z",
+                // Priority present but unchanged -> no priority event.
+                "fromPriority": 2,
+                "toPriority": 2,
+                // Assignee present but unchanged -> no assignee event.
+                "fromAssignee": { "id": "u-dan", "name": "dan", "displayName": "Dan" },
+                "toAssignee": { "id": "u-dan", "name": "dan", "displayName": "Dan" }
+            }
+        ]));
+
+        let events = linear_history_to_events(nodes);
+        // The timestamp-less node is dropped, and the second node has nothing
+        // that actually changed.
+        assert!(events.is_empty());
+    }
 
     #[test]
     fn parses_linear_query_tokens() {

--- a/crates/linear-backend/src/convert.rs
+++ b/crates/linear-backend/src/convert.rs
@@ -193,24 +193,28 @@ pub fn linear_history_to_events(nodes: Vec<LinearIssueHistory>) -> Vec<IssueHist
         }
 
         // Priority transition (only when the value actually changed).
-        if node.to_priority.is_some() && node.to_priority != node.from_priority {
+        let from_priority = node.from_priority;
+        let to_priority = node.to_priority;
+        if (from_priority.is_some() || to_priority.is_some()) && from_priority != to_priority {
             events.push(IssueHistoryEvent {
                 at,
                 author: author.clone(),
                 field: "priority".to_string(),
-                from: node.from_priority.map(|p| priority_label(p).to_string()),
-                to: node.to_priority.map(|p| priority_label(p).to_string()),
+                from: from_priority.map(|p| priority_label(p).to_string()),
+                to: to_priority.map(|p| priority_label(p).to_string()),
             });
         }
 
         // Title transition (only when the value actually changed).
-        if node.to_title.is_some() && node.to_title != node.from_title {
+        let from_title = node.from_title.clone();
+        let to_title = node.to_title.clone();
+        if (from_title.is_some() || to_title.is_some()) && from_title != to_title {
             events.push(IssueHistoryEvent {
                 at,
                 author: author.clone(),
                 field: "title".to_string(),
-                from: node.from_title.clone(),
-                to: node.to_title.clone(),
+                from: from_title,
+                to: to_title,
             });
         }
 
@@ -838,6 +842,30 @@ mod tests {
         // The timestamp-less node is dropped, and the second node has nothing
         // that actually changed (priority, assignee, state, and title all equal).
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn linear_history_emits_cleared_priority_and_title() {
+        let nodes = history_from_json(serde_json::json!([
+            {
+                "createdAt": "2024-01-15T10:00:00Z",
+                "fromPriority": 2,
+                "toPriority": null,
+                "fromTitle": "Old title",
+                "toTitle": null
+            }
+        ]));
+
+        let events = linear_history_to_events(nodes);
+        assert_eq!(events.len(), 2);
+
+        assert_eq!(events[0].field, "priority");
+        assert_eq!(events[0].from.as_deref(), Some("High"));
+        assert_eq!(events[0].to, None);
+
+        assert_eq!(events[1].field, "title");
+        assert_eq!(events[1].from.as_deref(), Some("Old title"));
+        assert_eq!(events[1].to, None);
     }
 
     #[test]

--- a/crates/linear-backend/src/convert.rs
+++ b/crates/linear-backend/src/convert.rs
@@ -166,14 +166,16 @@ pub fn linear_history_to_events(nodes: Vec<LinearIssueHistory>) -> Vec<IssueHist
             name: Some(linear_user_display_name(user)),
         });
 
-        // State transition -> canonical "status".
-        if let Some(to_state) = &node.to_state {
+        // State transition -> canonical "status" (only when the value changed).
+        let from_state = node.from_state.as_ref().map(|s| s.name.clone());
+        let to_state = node.to_state.as_ref().map(|s| s.name.clone());
+        if to_state.is_some() && to_state != from_state {
             events.push(IssueHistoryEvent {
                 at,
                 author: author.clone(),
                 field: canonical_field_name("state"),
-                from: node.from_state.as_ref().map(|s| s.name.clone()),
-                to: Some(to_state.name.clone()),
+                from: from_state,
+                to: to_state,
             });
         }
 
@@ -201,8 +203,8 @@ pub fn linear_history_to_events(nodes: Vec<LinearIssueHistory>) -> Vec<IssueHist
             });
         }
 
-        // Title transition.
-        if node.to_title.is_some() {
+        // Title transition (only when the value actually changed).
+        if node.to_title.is_some() && node.to_title != node.from_title {
             events.push(IssueHistoryEvent {
                 at,
                 author: author.clone(),
@@ -822,13 +824,19 @@ mod tests {
                 "toPriority": 2,
                 // Assignee present but unchanged -> no assignee event.
                 "fromAssignee": { "id": "u-dan", "name": "dan", "displayName": "Dan" },
-                "toAssignee": { "id": "u-dan", "name": "dan", "displayName": "Dan" }
+                "toAssignee": { "id": "u-dan", "name": "dan", "displayName": "Dan" },
+                // State present but unchanged -> no status event.
+                "fromState": { "name": "In Progress" },
+                "toState": { "name": "In Progress" },
+                // Title present but unchanged -> no title event.
+                "fromTitle": "Fix login",
+                "toTitle": "Fix login"
             }
         ]));
 
         let events = linear_history_to_events(nodes);
         // The timestamp-less node is dropped, and the second node has nothing
-        // that actually changed.
+        // that actually changed (priority, assignee, state, and title all equal).
         assert!(events.is_empty());
     }
 

--- a/crates/linear-backend/src/error.rs
+++ b/crates/linear-backend/src/error.rs
@@ -26,6 +26,9 @@ pub enum LinearError {
 
     #[error("API error ({status}): {message}")]
     Api { status: u16, message: String },
+
+    #[error("Pagination stalled: {0}")]
+    PaginationStalled(String),
 }
 
 pub type Result<T> = std::result::Result<T, LinearError>;
@@ -44,6 +47,7 @@ impl From<LinearError> for TrackerError {
                 message: "Linear API rate limit exceeded".to_string(),
             },
             LinearError::Api { status, message } => TrackerError::Api { status, message },
+            LinearError::PaginationStalled(msg) => TrackerError::PaginationStalled(msg),
         }
     }
 }

--- a/crates/linear-backend/src/models.rs
+++ b/crates/linear-backend/src/models.rs
@@ -127,6 +127,38 @@ pub struct LinearComment {
     pub user: Option<LinearUser>,
 }
 
+/// A workflow state reference as it appears in an issue-history transition.
+///
+/// History nodes only need the state's display `name`; the full
+/// [`LinearWorkflowState`] is overkill (and its `type`/`position` fields are not
+/// requested on the history query).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LinearHistoryState {
+    pub name: String,
+}
+
+/// One entry in an issue's change history (`Issue.history` connection).
+///
+/// A single node may carry several independent transitions (state, assignee,
+/// priority, title, ...); each populated transition is decomposed into its own
+/// [`tracker_core::IssueHistoryEvent`] by the converter, all sharing this
+/// node's `created_at` and `actor`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearIssueHistory {
+    #[serde(default)]
+    pub created_at: Option<DateTime<Utc>>,
+    pub actor: Option<LinearUser>,
+    pub from_state: Option<LinearHistoryState>,
+    pub to_state: Option<LinearHistoryState>,
+    pub from_assignee: Option<LinearUser>,
+    pub to_assignee: Option<LinearUser>,
+    pub from_priority: Option<i64>,
+    pub to_priority: Option<i64>,
+    pub from_title: Option<String>,
+    pub to_title: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LinearIssueRelation {

--- a/crates/linear-backend/src/trait_impl.rs
+++ b/crates/linear-backend/src/trait_impl.rs
@@ -2,15 +2,15 @@
 
 use tracker_core::{
     Article, ArticleAttachment, AttachmentUpload, Comment, CreateArticle, CreateIssue,
-    CreateProject, CreateTag, CustomFieldUpdate, Issue, IssueLink, IssueLinkType, IssueTag,
-    IssueTracker, KnowledgeBase, Project, ProjectCustomField, Result, SearchResult, TrackerError,
-    UpdateArticle, UpdateIssue, User,
+    CreateProject, CreateTag, CustomFieldUpdate, Issue, IssueHistoryEvent, IssueLink,
+    IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project, ProjectCustomField, Result,
+    SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
 };
 
 use crate::client::LinearClient;
 use crate::convert::{
-    build_filter_from_parsed, linear_issue_to_core, linear_link_types, linear_relations_to_core,
-    parse_linear_query, priority_from_label, team_details_custom_fields,
+    build_filter_from_parsed, linear_history_to_events, linear_issue_to_core, linear_link_types,
+    linear_relations_to_core, parse_linear_query, priority_from_label, team_details_custom_fields,
 };
 use crate::models::{
     LinearIssueCreateInput, LinearIssueLabelCreateInput, LinearIssueLabelUpdateInput,
@@ -311,6 +311,35 @@ impl IssueTracker for LinearClient {
         }
 
         Ok(comments)
+    }
+
+    fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
+        // Generous backstop against a server that keeps reporting `hasNextPage`
+        // without advancing the cursor; large enough never to truncate a real
+        // history (100 nodes/page).
+        const MAX_PAGES: usize = 10_000;
+
+        // Resolve the readable identifier to Linear's internal id, exactly as
+        // the comments path does, since `Issue.history` keys on the id.
+        let issue = self.get_issue(issue_id)?;
+        let mut nodes = Vec::new();
+        let mut after = None;
+
+        for _ in 0..MAX_PAGES {
+            let (page, page_info) = self.get_issue_history_page(&issue.id, 100, after)?;
+            let page_len = page.len();
+            nodes.extend(page);
+
+            if !page_info.has_next_page || page_len == 0 {
+                return Ok(linear_history_to_events(nodes));
+            }
+            after = page_info.end_cursor;
+        }
+
+        Err(TrackerError::PaginationStalled(format!(
+            "issue '{}' history did not terminate after {} pages",
+            issue_id, MAX_PAGES
+        )))
     }
 }
 

--- a/crates/linear-backend/src/trait_impl.rs
+++ b/crates/linear-backend/src/trait_impl.rs
@@ -318,22 +318,45 @@ impl IssueTracker for LinearClient {
         // without advancing the cursor; large enough never to truncate a real
         // history (100 nodes/page).
         const MAX_PAGES: usize = 10_000;
+        const MAX_EMPTY_PAGES: usize = 5;
 
         // Resolve the readable identifier to Linear's internal id, exactly as
         // the comments path does, since `Issue.history` keys on the id.
         let issue = self.get_issue(issue_id)?;
         let mut nodes = Vec::new();
         let mut after = None;
+        let mut empty_pages = 0;
 
         for _ in 0..MAX_PAGES {
+            let prev_after = after.clone();
             let (page, page_info) = self.get_issue_history_page(&issue.id, 100, after)?;
             let page_len = page.len();
             nodes.extend(page);
 
-            if !page_info.has_next_page || page_len == 0 {
+            if !page_info.has_next_page {
                 return Ok(linear_history_to_events(nodes));
             }
-            after = page_info.end_cursor;
+
+            if page_len == 0 {
+                empty_pages += 1;
+                if empty_pages >= MAX_EMPTY_PAGES {
+                    return Err(TrackerError::PaginationStalled(format!(
+                        "issue '{}' history returned {} consecutive empty pages with hasNextPage=true",
+                        issue_id, MAX_EMPTY_PAGES
+                    )));
+                }
+            } else {
+                empty_pages = 0;
+            }
+
+            let next_after = page_info.end_cursor;
+            if next_after == prev_after {
+                return Err(TrackerError::PaginationStalled(format!(
+                    "issue '{}' history cursor did not advance",
+                    issue_id
+                )));
+            }
+            after = next_after;
         }
 
         Err(TrackerError::PaginationStalled(format!(

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/youtrack-backend/src/client.rs
+++ b/crates/youtrack-backend/src/client.rs
@@ -821,6 +821,70 @@ impl YouTrackClient {
     }
 
     // ========================================================================
+    // History Operations
+    // ========================================================================
+
+    /// Fetch one page of an issue's custom-field activity timeline.
+    ///
+    /// `GET /api/issues/{id}/activities` is offset-paged (`$top`/`$skip`). We
+    /// scope to `CustomFieldCategory` so only field transitions come back
+    /// (comments/work-items have their own commands). Activities are
+    /// oldest-first; the caller re-sorts.
+    pub fn get_activities_page(
+        &self,
+        issue_id: &str,
+        top: usize,
+        skip: usize,
+    ) -> Result<Vec<YouTrackActivity>> {
+        let url = format!(
+            "{}/api/issues/{}/activities?categories=CustomFieldCategory&fields=id,timestamp,author(login,name),field(name,presentation),added(name,text,login,presentation),removed(name,text,login,presentation)&$top={}&$skip={}",
+            self.base_url, issue_id, top, skip
+        );
+
+        let response = self
+            .agent
+            .get(&url)
+            .header("Authorization", &self.auth_header())
+            .header("Accept", "application/json")
+            .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let activities: Vec<YouTrackActivity> = response.body_mut().read_json()?;
+        Ok(activities)
+    }
+
+    /// Fetch an issue's complete custom-field activity timeline, paging through
+    /// every entry. Activities are returned oldest-first (the caller re-sorts).
+    ///
+    /// Unlike Jira's changelog endpoint, YouTrack honors `$top`, so a page
+    /// shorter than requested is a reliable end-of-data signal. A generous
+    /// `MAX_PAGES` backstop guards against a server that ignores `$skip` (which
+    /// would otherwise loop forever) without truncating a legitimately large
+    /// history.
+    pub fn get_issue_activities(&self, issue_id: &str) -> Result<Vec<YouTrackActivity>> {
+        const PAGE: usize = 100;
+        const MAX_PAGES: usize = 10_000;
+        let mut activities = Vec::new();
+        let mut skip = 0;
+        for _ in 0..MAX_PAGES {
+            let page = self.get_activities_page(issue_id, PAGE, skip)?;
+            let fetched = page.len();
+            activities.extend(page);
+            // YouTrack honors `$top`, so a short (or empty) page means we have
+            // reached the end of the timeline.
+            if fetched < PAGE {
+                return Ok(activities);
+            }
+            skip += fetched;
+        }
+        Err(YouTrackError::PaginationStalled(format!(
+            "issue '{}' activity timeline did not terminate after {} pages",
+            issue_id, MAX_PAGES
+        )))
+    }
+
+    // ========================================================================
     // Knowledge Base / Article Operations
     // ========================================================================
 

--- a/crates/youtrack-backend/src/client_tests.rs
+++ b/crates/youtrack-backend/src/client_tests.rs
@@ -2006,6 +2006,7 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/api/issues/PROJ-123/activities"))
+            .and(query_param("categories", "CustomFieldCategory"))
             .and(query_param("$top", "100"))
             .and(query_param("$skip", "0"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(page1)))
@@ -2016,6 +2017,7 @@ mod tests {
         // (< $top) signals end-of-data.
         Mock::given(method("GET"))
             .and(path("/api/issues/PROJ-123/activities"))
+            .and(query_param("categories", "CustomFieldCategory"))
             .and(query_param("$top", "100"))
             .and(query_param("$skip", "100"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([

--- a/crates/youtrack-backend/src/client_tests.rs
+++ b/crates/youtrack-backend/src/client_tests.rs
@@ -1979,4 +1979,74 @@ mod tests {
 
         assert_eq!(client.resolve_link_type("nonexistent"), "nonexistent");
     }
+
+    // ==================== Issue History Tests ====================
+
+    #[tokio::test]
+    async fn test_get_issue_history_paginates_and_sorts() {
+        use tracker_core::IssueTracker;
+
+        let mock_server = MockServer::start().await;
+
+        // Page 1: a full page of 100 activities (oldest-first). A full page
+        // means the loop must request a second page. Timestamps ascend so the
+        // newest of these is the last element.
+        let page1: Vec<serde_json::Value> = (0..100)
+            .map(|i| {
+                serde_json::json!({
+                    "id": format!("{i}"),
+                    "timestamp": 1_640_000_000_000i64 + i as i64 * 1000,
+                    "author": { "login": "alice", "name": "Alice" },
+                    "field": { "name": "State", "presentation": "State" },
+                    "removed": [{ "name": "Open" }],
+                    "added": [{ "name": "In Progress" }]
+                })
+            })
+            .collect();
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues/PROJ-123/activities"))
+            .and(query_param("$top", "100"))
+            .and(query_param("$skip", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(page1)))
+            .mount(&mock_server)
+            .await;
+
+        // Page 2: a single newer activity (the overall newest). A short page
+        // (< $top) signals end-of-data.
+        Mock::given(method("GET"))
+            .and(path("/api/issues/PROJ-123/activities"))
+            .and(query_param("$top", "100"))
+            .and(query_param("$skip", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "final",
+                    "timestamp": 1_640_001_000_000i64,
+                    "author": { "login": "bob", "name": "Bob" },
+                    "field": { "name": "State" },
+                    "removed": [{ "name": "In Progress" }],
+                    "added": [{ "name": "Done" }]
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let events = client.get_issue_history("PROJ-123").unwrap();
+
+        // 100 from page 1 + 1 from page 2.
+        assert_eq!(events.len(), 101);
+        // Newest-first: the page-2 activity sorts to the front.
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].to.as_deref(), Some("Done"));
+        assert_eq!(events[0].from.as_deref(), Some("In Progress"));
+        assert_eq!(
+            events[0].author.as_ref().map(|a| a.login.as_str()),
+            Some("bob")
+        );
+        // Oldest activity sorts last.
+        assert_eq!(events[100].to.as_deref(), Some("In Progress"));
+        // Field-name canonicalization applies across the whole timeline.
+        assert!(events.iter().all(|e| e.field == "status"));
+    }
 }

--- a/crates/youtrack-backend/src/convert.rs
+++ b/crates/youtrack-backend/src/convert.rs
@@ -1,7 +1,86 @@
 //! Conversion functions between YouTrack API models and tracker-core models
 
 use crate::models as yt;
+use tracker_core::canonical_field_name;
 use tracker_core::models as core;
+
+/// Render one added/removed activity value to a human-readable string.
+///
+/// Field types surface their value under different labels (enum/state under
+/// `name`, text under `text`, users under `login`, anything else under
+/// `presentation`), so the first non-empty label wins.
+fn activity_value_to_string(value: &yt::ActivityValue) -> Option<String> {
+    [
+        value.name.as_deref(),
+        value.text.as_deref(),
+        value.login.as_deref(),
+        value.presentation.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .map(str::trim)
+    .find(|s| !s.is_empty())
+    .map(str::to_string)
+}
+
+/// Join a list of added/removed values into a single presentable string,
+/// returning `None` when nothing presentable remains (so an empty side of a
+/// transition maps to `None` rather than an empty string).
+fn activity_values_to_string(values: &[yt::ActivityValue]) -> Option<String> {
+    let parts: Vec<String> = values.iter().filter_map(activity_value_to_string).collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(", "))
+    }
+}
+
+/// Convert YouTrack custom-field activities into core history events,
+/// newest-first.
+///
+/// Each activity becomes one [`core::IssueHistoryEvent`]: `from` is the joined
+/// `removed` values, `to` the joined `added` values. Activities whose timestamp
+/// cannot be interpreted, or which carry no identifiable field name, are
+/// skipped rather than fabricated. Field names are canonicalized so YouTrack's
+/// "State" folds onto the portable "status" token.
+pub fn youtrack_activities_to_history_events(
+    activities: Vec<yt::YouTrackActivity>,
+) -> Vec<core::IssueHistoryEvent> {
+    let mut events = Vec::new();
+    for activity in activities {
+        let Some(ts) = activity.timestamp else {
+            continue;
+        };
+        let Some(at) = chrono::DateTime::from_timestamp_millis(ts) else {
+            continue;
+        };
+        // A field with no resolvable name can't be reported portably; skip it.
+        let Some(raw_field) = activity.field.as_ref().and_then(|f| {
+            f.name
+                .as_deref()
+                .or(f.presentation.as_deref())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+        }) else {
+            continue;
+        };
+        let author = activity.author.map(|a| core::CommentAuthor {
+            login: a.login,
+            name: a.name,
+        });
+        events.push(core::IssueHistoryEvent {
+            at,
+            author,
+            field: canonical_field_name(raw_field),
+            from: activity_values_to_string(&activity.removed),
+            to: activity_values_to_string(&activity.added),
+        });
+    }
+    // YouTrack returns activities oldest-first; expose newest-first. `sort_by`
+    // is stable, so activities sharing a timestamp keep their original order.
+    events.sort_by(|a, b| b.at.cmp(&a.at));
+    events
+}
 
 /// Convert YouTrack Issue to tracker-core Issue
 impl From<yt::Issue> for core::Issue {
@@ -530,5 +609,146 @@ pub fn project_custom_field_response_to_core(
         required: !field.can_be_empty,
         values,
         state_values,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn activities_from_json(value: serde_json::Value) -> Vec<yt::YouTrackActivity> {
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn youtrack_activities_map_state_change_to_status() {
+        // A State change: field name "State" must fold onto canonical "status",
+        // with from/to drawn from removed/added.
+        let activities = activities_from_json(serde_json::json!([
+            {
+                "id": "1",
+                "timestamp": 1640000000000i64,
+                "author": { "login": "alice", "name": "Alice" },
+                "field": { "name": "State", "presentation": "State" },
+                "removed": [{ "name": "Open" }],
+                "added": [{ "name": "In Progress" }]
+            }
+        ]));
+
+        let events = youtrack_activities_to_history_events(activities);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].from.as_deref(), Some("Open"));
+        assert_eq!(events[0].to.as_deref(), Some("In Progress"));
+        assert_eq!(
+            events[0].author.as_ref().map(|a| a.login.as_str()),
+            Some("alice")
+        );
+        assert_eq!(
+            events[0].author.as_ref().and_then(|a| a.name.as_deref()),
+            Some("Alice")
+        );
+    }
+
+    #[test]
+    fn youtrack_activities_join_multi_value_field() {
+        // A multi-value field reports several added values; they join with ", ".
+        // `added`/`removed` may also arrive as a single object (not a list).
+        let activities = activities_from_json(serde_json::json!([
+            {
+                "timestamp": 1640000000000i64,
+                "author": { "login": "bob", "name": "Bob" },
+                "field": { "name": "Platforms" },
+                "removed": { "name": "Windows" },
+                "added": [{ "name": "macOS" }, { "name": "Linux" }]
+            }
+        ]));
+
+        let events = youtrack_activities_to_history_events(activities);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].field, "Platforms");
+        assert_eq!(events[0].from.as_deref(), Some("Windows"));
+        assert_eq!(events[0].to.as_deref(), Some("macOS, Linux"));
+    }
+
+    #[test]
+    fn youtrack_activities_handle_null_author_and_empty_sides() {
+        // A system activity may have no author; an "added only" change has an
+        // empty `removed` side, which must map to None (not an empty string).
+        let activities = activities_from_json(serde_json::json!([
+            {
+                "timestamp": 1640000000000i64,
+                "author": null,
+                "field": { "name": "Assignee" },
+                "removed": [],
+                "added": [{ "login": "carol", "name": "Carol" }]
+            }
+        ]));
+
+        let events = youtrack_activities_to_history_events(activities);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].author.is_none());
+        assert_eq!(events[0].field, "Assignee");
+        assert_eq!(events[0].from, None);
+        // A user value carries a display `name`, which wins over `login`.
+        assert_eq!(events[0].to.as_deref(), Some("Carol"));
+    }
+
+    #[test]
+    fn youtrack_activities_sort_newest_first() {
+        // Two activities arrive oldest-first; output must be newest-first.
+        let activities = activities_from_json(serde_json::json!([
+            {
+                "timestamp": 1640000000000i64,
+                "field": { "name": "State" },
+                "removed": [{ "name": "Open" }],
+                "added": [{ "name": "In Progress" }]
+            },
+            {
+                "timestamp": 1640100000000i64,
+                "field": { "name": "State" },
+                "removed": [{ "name": "In Progress" }],
+                "added": [{ "name": "Done" }]
+            }
+        ]));
+
+        let events = youtrack_activities_to_history_events(activities);
+
+        assert_eq!(events.len(), 2);
+        // Newest (Done) first.
+        assert_eq!(events[0].to.as_deref(), Some("Done"));
+        assert_eq!(events[1].to.as_deref(), Some("In Progress"));
+    }
+
+    #[test]
+    fn youtrack_activities_skip_missing_timestamp_or_field() {
+        let activities = activities_from_json(serde_json::json!([
+            {
+                // No timestamp -> skipped rather than fabricated.
+                "field": { "name": "State" },
+                "added": [{ "name": "Done" }]
+            },
+            {
+                "timestamp": 1640000000000i64,
+                // No field name or presentation -> not portably reportable.
+                "field": {},
+                "added": [{ "name": "Done" }]
+            },
+            {
+                "timestamp": 1640100000000i64,
+                "field": { "name": "State" },
+                "added": [{ "name": "Done" }]
+            }
+        ]));
+
+        let events = youtrack_activities_to_history_events(activities);
+
+        // Only the well-formed third activity survives.
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].field, "status");
+        assert_eq!(events[0].to.as_deref(), Some("Done"));
     }
 }

--- a/crates/youtrack-backend/src/error.rs
+++ b/crates/youtrack-backend/src/error.rs
@@ -23,6 +23,9 @@ pub enum YouTrackError {
 
     #[error("API error ({status}): {message}")]
     Api { status: u16, message: String },
+
+    #[error("Pagination stalled: {0}")]
+    PaginationStalled(String),
 }
 
 pub type Result<T> = std::result::Result<T, YouTrackError>;
@@ -37,6 +40,7 @@ impl From<YouTrackError> for TrackerError {
             YouTrackError::ProjectNotFound(id) => TrackerError::ProjectNotFound(id),
             YouTrackError::Unauthorized => TrackerError::Unauthorized,
             YouTrackError::Api { status, message } => TrackerError::Api { status, message },
+            YouTrackError::PaginationStalled(msg) => TrackerError::PaginationStalled(msg),
         }
     }
 }

--- a/crates/youtrack-backend/src/models/activity.rs
+++ b/crates/youtrack-backend/src/models/activity.rs
@@ -1,0 +1,78 @@
+use serde::{Deserialize, Deserializer, Serialize};
+
+use super::issue::CommentAuthor;
+
+/// One entry from `GET /api/issues/{id}/activities`.
+///
+/// We request only the `CustomFieldCategory`, so each activity describes a
+/// single field transition: who changed `field`, when (`timestamp`), and the
+/// values that were `removed` (the old value) and `added` (the new value).
+///
+/// YouTrack's `added`/`removed` payloads are deliberately polymorphic — the
+/// API returns either a single object or a list depending on field arity — so
+/// they are normalized to `Vec<ActivityValue>` here (see [`one_or_many`]).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct YouTrackActivity {
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Event time as a Unix timestamp in milliseconds (UTC).
+    #[serde(default)]
+    pub timestamp: Option<i64>,
+    #[serde(default)]
+    pub author: Option<CommentAuthor>,
+    #[serde(default)]
+    pub field: Option<ActivityField>,
+    /// New value(s) of the field after the change.
+    #[serde(default, deserialize_with = "one_or_many")]
+    pub added: Vec<ActivityValue>,
+    /// Previous value(s) of the field before the change.
+    #[serde(default, deserialize_with = "one_or_many")]
+    pub removed: Vec<ActivityValue>,
+}
+
+/// The field that changed. `name` is the underlying custom-field name; some
+/// instances populate only the human-readable `presentation`, so both are
+/// optional and the converter falls back from one to the other.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ActivityField {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub presentation: Option<String>,
+}
+
+/// One added/removed value. The concrete shape varies by field type
+/// (enum, state, user, text, ...), so every plausible label is captured
+/// defensively and the converter picks the first non-empty one.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ActivityValue {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub login: Option<String>,
+    #[serde(default)]
+    pub presentation: Option<String>,
+}
+
+/// Deserialize a field that YouTrack may emit as `null`, a single object, or a
+/// list of objects into a flat `Vec`. A `null` or absent value yields an empty
+/// vec; a lone object yields a single-element vec.
+fn one_or_many<'de, D>(deserializer: D) -> Result<Vec<ActivityValue>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        Many(Vec<ActivityValue>),
+        One(ActivityValue),
+    }
+
+    match Option::<OneOrMany>::deserialize(deserializer)? {
+        None => Ok(Vec::new()),
+        Some(OneOrMany::Many(v)) => Ok(v),
+        Some(OneOrMany::One(v)) => Ok(vec![v]),
+    }
+}

--- a/crates/youtrack-backend/src/models/mod.rs
+++ b/crates/youtrack-backend/src/models/mod.rs
@@ -1,8 +1,10 @@
+pub mod activity;
 pub mod admin;
 pub mod article;
 pub mod issue;
 pub mod project;
 
+pub use activity::*;
 pub use admin::*;
 pub use article::*;
 pub use issue::*;

--- a/crates/youtrack-backend/src/trait_impl.rs
+++ b/crates/youtrack-backend/src/trait_impl.rs
@@ -10,8 +10,9 @@ use tracker_core::{
     Article, ArticleAttachment, AttachFieldToProject, AttachmentUpload, BundleDefinition,
     BundleType, BundleValueDefinition, Comment, CreateArticle, CreateBundle, CreateBundleValue,
     CreateCustomField, CreateIssue, CreateProject, CreateTag, CustomFieldDefinition, Issue,
-    IssueAttachment, IssueLink, IssueLinkType, IssueTag, IssueTracker, KnowledgeBase, Project,
-    ProjectCustomField, Result, SearchResult, TrackerError, UpdateArticle, UpdateIssue, User,
+    IssueAttachment, IssueHistoryEvent, IssueLink, IssueLinkType, IssueTag, IssueTracker,
+    KnowledgeBase, Project, ProjectCustomField, Result, SearchResult, TrackerError, UpdateArticle,
+    UpdateIssue, User,
 };
 
 impl IssueTracker for YouTrackClient {
@@ -225,6 +226,11 @@ impl IssueTracker for YouTrackClient {
             .into_iter()
             .map(Into::into)
             .collect())
+    }
+
+    fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
+        let activities = self.get_issue_activities(issue_id)?;
+        Ok(convert::youtrack_activities_to_history_events(activities))
     }
 
     // ========== Custom Field Admin Operations ==========

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -231,7 +231,7 @@ track config get default_project
 | Comment | `track i cmt PROJ-123 -m "Text"` | `track -b j i cmt PROJ-123 -m "Text"` | `track -b gh i cmt PROJ-42 -m "Text"` | `track -b gl i cmt PROJ-42 -m "Text"` |
 | Link | `track i link PROJ-1 PROJ-2` | `track -b j i link PROJ-1 PROJ-2` | Subtask/parent only | `track -b gl i link PROJ-1 PROJ-2` |
 | Unlink | `track i ul PROJ-1 <link-id>` | `track -b j i ul PROJ-1 <link-id>` | Not supported | `track -b gl i ul #42 <link-id>` |
-| History | Not supported | `track -b j i history PROJ-123 --field status --since 7d` | Not supported | Not supported |
+| History | `track i history PROJ-123` | `track -b j i history PROJ-123 --field status --since 7d` | `track -b gh i history 42` | `track -b gl i history 42` |
 
 **GitHub/GitLab notes**:
 - GitHub and GitLab use numeric issue IDs (e.g., `42`), not project-prefixed keys
@@ -658,21 +658,28 @@ track -b gh i comments PROJ-42
 track -b gl i comments PROJ-42
 ```
 
-### Issue History (Jira only)
+### Issue History
 
 Retrieve the field-transition timeline (status/assignee/etc. changes) with
 timestamps and authors — useful for flow metrics, cycle/lead time, and
-per-issue lifecycle reporting. Other backends report "not supported".
+per-issue lifecycle reporting. Supported on all backends.
 
 ```bash
-track -b j i history PROJ-123                 # Full timeline, newest first
-track -b j i history PROJ-123 --field status  # Only status transitions (canonical field)
-track -b j i history PROJ-123 --since 24h      # Window: s/m/h/d/w
-track -b j -o json i history PROJ-123          # {"issue": id, "changes": [{at, author, field, from, to}]}
+track i history PROJ-123                       # Full timeline, newest first
+track i history PROJ-123 --field status        # Only status transitions (canonical field)
+track i history PROJ-123 --since 24h            # Window: s/m/h/d/w
+track -o json i history PROJ-123                # {"issue": id, "changes": [{at, author, field, from, to}]}
+track -b gh i history 42                        # GitHub/GitLab use numeric ids
 ```
 
 There is no batch form (one call per issue): for board-level metrics, search
 for the candidate issues first, then call `i history` per issue.
+
+`from`/`to` coverage differs by backend. Jira, YouTrack, and Linear carry the
+prior value for every field. The event-based backends (GitHub timeline, GitLab
+resource events) derive `from` only for the canonical `status` field; other
+fields report `from: null` with the new value in `to`. (Linear label-change
+history is a documented follow-up.)
 
 ### Link Issues
 


### PR DESCRIPTION
Follow-up to #261 (now merged), which added `track issue history` for Jira. This extends it to the remaining four backends.

## Summary

Implements `get_issue_history` for YouTrack, GitHub, GitLab, and Linear, so `track issue history <id>` now works on every backend. #261 added all the generic scaffolding (core `IssueHistoryEvent`, the optional trait method, the CLI command + `--field`/`--since`, the `{"issue","changes"}` envelope, `MockClient`, fixtures); this PR is purely additive per backend: response models, a paginated client method, a conversion function, and a one-line trait override, plus tests.

## Per backend

| Backend | Source | `from`/`to` |
|---|---|---|
| **YouTrack** | `/api/issues/{id}/activities` (offset-paged) | direct — `removed`=from, `added`=to |
| **Linear** | GraphQL `issue.history` (cursor-paged) | direct — state, assignee, priority, title |
| **GitHub** | REST `/issues/{n}/timeline` (offset-paged) | derived for `status` only |
| **GitLab** | `resource_state` + `resource_label` + `resource_milestone` events (3 endpoints, merged) | derived for `status` only |

## Design

- **`from` policy for event-stream backends (GitHub, GitLab):** the timeline/resource events carry no prior value, so `from` is derived **only for the canonical `status` field** via a low-risk single-field chronological walk (running state seeded `open`/`opened`). Other event-derived fields report `from: null` with the new value in `to`, except GitHub's `renamed` event which carries an explicit from/to. This deliberately avoids a fragile multi-field state machine.
- **Diff backends (YouTrack, Linear)** carry the prior value, so `from`/`to` are populated directly for every field.
- Consistent across all four: newest-first stable sort, `canonical_field_name` (status/state → `status`), `CommentAuthor{login,name}`, null-author/system events → `author: null`, skip unparseable timestamps, and a bounded pagination loop with a `PaginationStalled` backstop (no infinite loops, no silent truncation).
- **No changes** to `tracker-core`, the CLI, `MockClient`, or fixtures — the command is backend-agnostic.

## Tests

Each backend adds conversion unit tests (multi-field/multi-event, null cases, ordering, and the GitHub/GitLab status `from`-walk) plus a client mock test mirroring #261's pattern. GitLab's exercises the 3-endpoint merge; GitHub's exercises status derivation across pages.

## Review

Ran an adversarial review workflow (5 dimensions × independent verification) over the diff. The riskiest parts — GitHub/GitLab `from`-derivation and the GitLab merge — held up clean. Three confirmed findings were fixed: Linear emitted spurious no-op `status`/`title` events when `from == to` (now guarded, matching assignee/priority), and the YouTrack mock test now asserts the `categories` filter is sent.

## Out of scope (documented follow-ups)

- Multi-field `from` derivation for GitHub/GitLab (assignee/labels/milestone) — currently `from: null`.
- Linear **label-change** history (needs label ID→name resolution).

## Verification

`cargo build`, `cargo clippy --all-targets`, `cargo fmt --check`, and `cargo test --workspace` all pass (zero failures; remaining clippy warnings are pre-existing in unrelated tests). Bumps `track` 1.11.0 → 1.12.0.
