### PR TITLE
feat(jira): surface standard Components field in issue get/search output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -575,6 +575,8 @@ track --format json p ls    # JSON
 - **Rich Text**: Uses Atlassian Document Format (ADF) for descriptions
 - **Project Creation**: Requires admin permissions (use web interface)
 - **Subtasks**: Create as subtask with `--parent`, or link existing issues with `issue link -t subtask`
+- **Labels**: Map to tags
+- **Components**: Jira's standard Components field is surfaced as a `Components` multi-value custom field on `issue get`/`issue search` (read-only for now; filter server-side with JQL such as `component = "Rendering"`)
 
 ### GitHub
 - **Scope**: Repository-scoped (requires owner and repo configuration)

--- a/agent-skills/SKILL.md
+++ b/agent-skills/SKILL.md
@@ -371,7 +371,7 @@ track completions zsh      # Shell completions (bash|zsh|fish|powershell|elvish)
     {"SingleEnum": {"name": "Priority", "value": "Major"}},
     {"SingleUser": {"name": "Assignee", "login": "...", "display_name": "..."}},
     {"Text":       {"name": "...", "value": "..."}},
-    {"MultiEnum":  {"name": "...", "values": ["..."]}}
+    {"MultiEnum":  {"name": "Components", "values": ["Rendering", "Audio"]}}
   ],
   "tags": [{"id": "...", "name": "..."}],
   "created": "2024-01-15T10:00:00Z", "updated": "...",
@@ -380,6 +380,7 @@ track completions zsh      # Shell completions (bash|zsh|fish|powershell|elvish)
 ```
 
 - `custom_fields` entries are **externally tagged** — the variant name (`State`, `SingleEnum`, ...) is the JSON key.
+- **Jira `Components`** (the standard subsystem/area field) is surfaced as a `MultiEnum` custom field named `Components`. To find issues by area, read `custom_fields` for that entry (or filter server-side with JQL, e.g. `component = "Rendering"`). Setting components on create/update is not yet supported.
 - `resolved` is the **resolution timestamp**, not a closed flag: it can be `null` even for Done issues (e.g. a Jira workflow that never sets Resolution). Test closedness via the State field's `is_resolved`.
 - **`--full`** wraps the issue in an envelope: `{"issue": {...}, "links": [{"id", "direction", "link_type", "issues": [...]}], "comments": [{"id", "text", "author", "created"}]}`. Attachments are NOT included — use `track i attachments`.
 - **`i s -o json`** returns a bare array — no total or pagination metadata (hints go to stderr in text mode only).

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -112,6 +112,19 @@ mod tests {
                     "active": true
                 },
                 "labels": ["bug", "urgent"],
+                "components": [
+                    {
+                        "self": "https://test.atlassian.net/rest/api/3/component/10001",
+                        "id": "10001",
+                        "name": "Rendering",
+                        "description": "Rendering subsystem"
+                    },
+                    {
+                        "self": "https://test.atlassian.net/rest/api/3/component/10002",
+                        "id": "10002",
+                        "name": "Audio"
+                    }
+                ],
                 "created": "2024-01-15T10:30:00.000+0000",
                 "updated": "2024-01-15T12:00:00.000+0000",
                 "subtasks": [],
@@ -213,6 +226,17 @@ mod tests {
         assert_eq!(issue.fields.summary, "Test issue");
         assert_eq!(issue.fields.status.name, "Open");
         assert_eq!(issue.fields.labels, vec!["bug", "urgent"]);
+
+        // Components must be deserialized into the named field (pulled out of
+        // the flattened `extra` catch-all), not silently dropped.
+        let component_names: Vec<&str> = issue
+            .fields
+            .components
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(component_names, vec!["Rendering", "Audio"]);
+        assert!(!issue.fields.extra.contains_key("components"));
     }
 
     #[tokio::test]

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -74,6 +74,15 @@ pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
         value: Some(j.fields.issuetype.name.clone()),
     });
 
+    // Map components (Jira's standard subsystem/area field) as a multi-value
+    // custom field, mirroring how the other standard fields above are surfaced.
+    if !j.fields.components.is_empty() {
+        custom_fields.push(CustomField::MultiEnum {
+            name: "Components".to_string(),
+            values: j.fields.components.iter().map(|c| c.name.clone()).collect(),
+        });
+    }
+
     // Map extra custom fields from the flattened HashMap
     let id_to_name: HashMap<&str, &str> = jira_fields
         .iter()
@@ -1368,6 +1377,7 @@ mod tests {
                 assignee: None,
                 reporter: None,
                 labels: vec![],
+                components: vec![],
                 created: Some("2024-01-15T10:00:00.000+0000".to_string()),
                 updated: Some("2024-01-15T12:00:00.000+0000".to_string()),
                 resolution_date: None,
@@ -1421,6 +1431,46 @@ mod tests {
             Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap()
         );
         assert_eq!(core.resolved, None);
+    }
+
+    #[test]
+    fn jira_issue_to_core_maps_components() {
+        let mut issue = mock_jira_issue_for_conversion(Default::default());
+        issue.fields.components = vec![
+            JiraComponent {
+                id: Some("10001".to_string()),
+                name: "Rendering".to_string(),
+            },
+            JiraComponent {
+                id: Some("10002".to_string()),
+                name: "Audio".to_string(),
+            },
+        ];
+
+        let core = jira_issue_to_core(issue, &[]);
+
+        let components = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "Components"))
+            .expect("Components custom field should be present");
+        assert!(
+            matches!(components, CustomField::MultiEnum { values, .. } if values == &["Rendering".to_string(), "Audio".to_string()])
+        );
+    }
+
+    #[test]
+    fn jira_issue_to_core_omits_components_when_empty() {
+        let issue = mock_jira_issue_for_conversion(Default::default());
+        let core = jira_issue_to_core(issue, &[]);
+
+        // No empty Components entry should be emitted when the issue has none.
+        assert!(
+            !core
+                .custom_fields
+                .iter()
+                .any(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "Components"))
+        );
     }
 
     #[test]

--- a/crates/jira-backend/src/models/issue.rs
+++ b/crates/jira-backend/src/models/issue.rs
@@ -44,6 +44,9 @@ pub struct JiraIssueFields {
     /// Labels (equivalent to tags)
     #[serde(default)]
     pub labels: Vec<String>,
+    /// Components (Jira's standard subsystem/area categorization field)
+    #[serde(default)]
+    pub components: Vec<JiraComponent>,
     /// Creation timestamp
     pub created: Option<String>,
     /// Last update timestamp
@@ -151,6 +154,16 @@ pub struct JiraPriority {
     /// Priority ID
     pub id: Option<String>,
     /// Priority name
+    pub name: String,
+}
+
+/// Component (Jira's standard Components field is an array of these)
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraComponent {
+    /// Component ID
+    pub id: Option<String>,
+    /// Component name
     pub name: String,
 }
 

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -779,6 +779,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn issue_display_renders_components_multi_enum() {
+        // Jira's Components field is surfaced as a MultiEnum custom field named
+        // "Components"; the text output should list the component names.
+        let issue = issue_with_custom_fields(vec![CustomField::MultiEnum {
+            name: "Components".into(),
+            values: vec!["Rendering".into(), "Audio".into()],
+        }]);
+        let rendered = issue.display();
+        assert!(
+            rendered.contains("Components"),
+            "expected Components label in output, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("Rendering, Audio"),
+            "expected joined component names in output, got:\n{rendered}"
+        );
+    }
+
     fn state_update(name: &str) -> tracker_core::CustomFieldUpdate {
         tracker_core::CustomFieldUpdate::State {
             name: name.into(),

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -487,6 +487,7 @@ track -b lin i s "project: ORE priority: High"
 | Priority | `Priority: Major` | `priority = Major` | `label:priority-major` | `labels=priority::major` |
 | Text search | `summary:~'keyword'` | `summary ~ "keyword"` | `keyword` (in query) | `search=keyword` |
 | By label | `tag: {bug}` | `labels = bug` | `label:bug` | `labels=bug` |
+| By component | — | `component = "Rendering"` | — | — |
 | AND | implicit or `AND` | `AND` | space-separated | `&`-separated params |
 | OR | `OR` | `OR` | N/A | N/A |
 


### PR DESCRIPTION
Closes #263.

## Problem
On the Jira backend, the standard **Components** field was silently dropped from `issue get` and `issue search` (JSON and text). The data was already fetched (`fields=*all`), but `JiraIssueFields` had no `components` field, so it fell into the flattened `extra` catch-all and was skipped by the `customfield_*` filter — track was filtering on a field (`component IS NOT EMPTY` via JQL) it would never return.

## Approach
Surface components as a **`Components` multi-value custom field**, consistent with how every other categorization axis is modeled across backends (Jira Priority/Status/Type, YouTrack Subsystem, GitHub milestone, Linear Project all flow through `custom_fields`). This keeps the label/component distinction intact (labels stay in `tags`) with **no core-model, output-layer, or cross-backend changes** — components ride the existing custom-field rails and render consistently in text and JSON.

We considered a dedicated top-level `components` array (the issue's Option A), but that would be the first single-backend top-level `Issue` field; routing through `custom_fields` fits the platform's design better.

## Changes
- **`jira-backend/models/issue.rs`**: add `JiraComponent { id, name }` and `#[serde(default)] components: Vec<JiraComponent>` on `JiraIssueFields` (first-class deserialization, pulled out of `extra`).
- **`jira-backend/convert.rs`**: map non-empty components → `CustomField::MultiEnum { name: "Components", values }` in `jira_issue_to_core`.
- **Docs**: `SKILL.md` (output schema + mapping note), `README.md` (Jira backend section), `docs/agent_guide.md` (JQL `component = …` query row).
- **Version**: 1.12.0 → 1.13.0.

## Output
```
Custom Fields:
    ...
    Components: Rendering, Audio
```
```json
{"MultiEnum": {"name": "Components", "values": ["Rendering", "Audio"]}}
```

## Tests
- `jira_issue_to_core_maps_components` — mapping.
- `jira_issue_to_core_omits_components_when_empty` — no empty entry emitted.
- `test_get_issue` (extended) — deserializes a realistic Jira `components` array and asserts it lands in the named field, **not** in `extra` (guards the `flatten` + explicit-field interaction).
- `issue_display_renders_components_multi_enum` — text rendering.

Verified end-to-end against the mock backend (text + JSON). `fmt`/`clippy` clean; full workspace suite passes.

## Out of scope (natural follow-up)
Setting components on create/update, and registering `Components` in `get_standard_custom_fields()` (the project-field registry) — deferred together so we don't advertise a field that isn't yet writable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only display change in the Jira backend with no core API or write-path changes; covered by unit tests.
> 
> **Overview**
> Jira **Components** no longer disappear on `issue get` / `issue search`: the backend now deserializes them explicitly and exposes them as a **`Components` `MultiEnum` custom field** (same JSON/text path as Status, Priority, etc.). Labels stay in `tags`; setting components on create/update is still out of scope.
> 
> Implementation is **Jira-backend only** — `JiraComponent` + `components` on issue fields, mapping in `jira_issue_to_core` when non-empty (no empty placeholder). Docs (`README`, agent skill, agent guide JQL row) and version **1.13.0** updated; tests cover deserialization, conversion, and text display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35513157eca879885e1f2f0a7d75f7d34c1aa54f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->