### PR TITLE
⚡ Optimize `TrackerCache::ensure_projects` concurrent read

### DIFF
--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -466,13 +466,15 @@ impl TrackerCache {
         if self.loaded_shards.projects {
             return Ok(());
         }
-        self.loaded_shards.projects = true;
 
         let root = Self::cache_dir_path(self.cache_dir.clone())?;
         let projects_dir = root.join("projects");
         if projects_dir.exists() {
-            let entries: Vec<_> = fs::read_dir(projects_dir)?.filter_map(|e| e.ok()).collect();
-            if entries.is_empty() {
+            let project_dirs: Vec<PathBuf> = fs::read_dir(&projects_dir)?
+                .map(|entry| entry.map(|e| e.path()))
+                .collect::<std::io::Result<_>>()?;
+            if project_dirs.is_empty() {
+                self.loaded_shards.projects = true;
                 return Ok(());
             }
 
@@ -480,15 +482,15 @@ impl TrackerCache {
             let num_threads = std::thread::available_parallelism()
                 .map(|n| n.get())
                 .unwrap_or(4);
-            let chunk_size = entries.len().div_ceil(num_threads);
+            let chunk_size = project_dirs.len().div_ceil(num_threads);
 
+            let mut worker_error = None;
             std::thread::scope(|s| {
                 let mut handles = Vec::with_capacity(num_threads);
-                for chunk in entries.chunks(chunk_size) {
+                for chunk in project_dirs.chunks(chunk_size) {
                     handles.push(s.spawn(move || {
                         let mut chunk_projects = Vec::with_capacity(chunk.len());
-                        for entry in chunk {
-                            let project_dir = entry.path();
+                        for project_dir in chunk {
                             if project_dir.is_dir()
                                 && let Ok(content) =
                                     fs::read_to_string(project_dir.join("meta.json"))
@@ -506,14 +508,22 @@ impl TrackerCache {
                     }));
                 }
                 for handle in handles {
-                    if let Ok(mut res) = handle.join() {
-                        self.projects.append(&mut res);
+                    match handle.join() {
+                        Ok(mut res) => self.projects.append(&mut res),
+                        Err(_) => worker_error = Some(anyhow!("project metadata worker panicked")),
                     }
                 }
             });
+
+            if let Some(err) = worker_error {
+                return Err(err);
+            }
         }
+        self.loaded_shards.projects = true;
         Ok(())
     }
+
+    /// Ensure backend shards are loaded (tags, templates, link types)
     pub fn ensure_backend_shards(&mut self) -> Result<()> {
         if self.loaded_shards.backend {
             return Ok(());

--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -471,26 +471,49 @@ impl TrackerCache {
         let root = Self::cache_dir_path(self.cache_dir.clone())?;
         let projects_dir = root.join("projects");
         if projects_dir.exists() {
-            for entry in fs::read_dir(projects_dir)? {
-                let entry = entry?;
-                let project_dir = entry.path();
-                if project_dir.is_dir()
-                    && let Ok(content) = fs::read_to_string(project_dir.join("meta.json"))
-                    && let Ok(meta) = serde_json::from_str::<ProjectShardMeta>(&content)
-                {
-                    self.projects.push(CachedProject {
-                        id: meta.id.clone(),
-                        short_name: meta.short_name.clone(),
-                        name: meta.name.clone(),
-                        description: meta.description.clone(),
-                    });
-                }
+            let entries: Vec<_> = fs::read_dir(projects_dir)?.filter_map(|e| e.ok()).collect();
+            if entries.is_empty() {
+                return Ok(());
             }
+
+            // Read and parse project metadata concurrently to improve startup performance
+            let num_threads = std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(4);
+            let chunk_size = entries.len().div_ceil(num_threads);
+
+            std::thread::scope(|s| {
+                let mut handles = Vec::with_capacity(num_threads);
+                for chunk in entries.chunks(chunk_size) {
+                    handles.push(s.spawn(move || {
+                        let mut chunk_projects = Vec::with_capacity(chunk.len());
+                        for entry in chunk {
+                            let project_dir = entry.path();
+                            if project_dir.is_dir()
+                                && let Ok(content) =
+                                    fs::read_to_string(project_dir.join("meta.json"))
+                                && let Ok(meta) = serde_json::from_str::<ProjectShardMeta>(&content)
+                            {
+                                chunk_projects.push(CachedProject {
+                                    id: meta.id,
+                                    short_name: meta.short_name,
+                                    name: meta.name,
+                                    description: meta.description,
+                                });
+                            }
+                        }
+                        chunk_projects
+                    }));
+                }
+                for handle in handles {
+                    if let Ok(mut res) = handle.join() {
+                        self.projects.append(&mut res);
+                    }
+                }
+            });
         }
         Ok(())
     }
-
-    /// Ensure backend shards are loaded (tags, templates, link types)
     pub fn ensure_backend_shards(&mut self) -> Result<()> {
         if self.loaded_shards.backend {
             return Ok(());

--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -2,9 +2,11 @@ use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::thread;
 
 #[cfg(unix)]
 use std::os::unix::fs::DirBuilderExt;
@@ -30,6 +32,35 @@ fn create_dir_all_secure(path: &Path) -> Result<()> {
 const CACHE_DIR_NAME: &str = ".tracker-cache";
 const CACHE_VERSION: u32 = 2;
 const MAX_RECENT_ISSUES: usize = 50;
+const DEFAULT_CACHE_REFRESH_CONCURRENCY: usize = 4;
+const MIN_CACHE_REFRESH_CONCURRENCY: usize = 1;
+const MAX_CACHE_REFRESH_CONCURRENCY: usize = 16;
+const MIN_PARALLEL_PROJECT_META_SHARDS: usize = 64;
+
+fn cache_refresh_concurrency() -> usize {
+    let configured = env::var("TRACK_CACHE_REFRESH_CONCURRENCY")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok());
+    clamp_cache_refresh_concurrency(configured)
+}
+
+fn clamp_cache_refresh_concurrency(configured: Option<usize>) -> usize {
+    configured
+        .unwrap_or(DEFAULT_CACHE_REFRESH_CONCURRENCY)
+        .clamp(MIN_CACHE_REFRESH_CONCURRENCY, MAX_CACHE_REFRESH_CONCURRENCY)
+}
+
+fn project_metadata_worker_count(project_count: usize, configured: Option<usize>) -> usize {
+    if project_count < MIN_PARALLEL_PROJECT_META_SHARDS {
+        return 1;
+    }
+
+    clamp_cache_refresh_concurrency(configured).min(project_count)
+}
+
+fn configured_project_metadata_worker_count(project_count: usize) -> usize {
+    project_metadata_worker_count(project_count, Some(cache_refresh_concurrency()))
+}
 
 /// Cached tracker context for AI assistants
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -268,6 +299,61 @@ pub struct StateTransition {
 }
 
 impl TrackerCache {
+    fn load_project_metadata_shard(project_dir: &Path) -> Option<CachedProject> {
+        if !project_dir.is_dir() {
+            return None;
+        }
+
+        let content = fs::read_to_string(project_dir.join("meta.json")).ok()?;
+        let meta = serde_json::from_str::<ProjectShardMeta>(&content).ok()?;
+        Some(CachedProject {
+            id: meta.id,
+            short_name: meta.short_name,
+            name: meta.name,
+            description: meta.description,
+        })
+    }
+
+    fn load_project_metadata_shards(
+        project_dirs: &[PathBuf],
+        worker_count: usize,
+    ) -> Result<Vec<CachedProject>> {
+        if project_dirs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let worker_count = worker_count.max(1).min(project_dirs.len());
+        if worker_count == 1 {
+            return Ok(project_dirs
+                .iter()
+                .filter_map(|project_dir| Self::load_project_metadata_shard(project_dir))
+                .collect());
+        }
+
+        thread::scope(|scope| -> Result<Vec<CachedProject>> {
+            let chunk_size = project_dirs.len().div_ceil(worker_count);
+            let mut handles = Vec::with_capacity(worker_count);
+            for chunk in project_dirs.chunks(chunk_size) {
+                handles.push(scope.spawn(move || {
+                    chunk
+                        .iter()
+                        .filter_map(|project_dir| Self::load_project_metadata_shard(project_dir))
+                        .collect::<Vec<_>>()
+                }));
+            }
+
+            let mut projects = Vec::new();
+            for handle in handles {
+                let mut loaded = handle
+                    .join()
+                    .map_err(|_| anyhow!("project metadata worker panicked"))?;
+                projects.append(&mut loaded);
+            }
+
+            Ok(projects)
+        })
+    }
+
     /// Load cache from the sharded directory layout
     pub fn load(cache_dir: Option<PathBuf>) -> Result<Self> {
         let root = Self::cache_dir_path(cache_dir.clone())?;
@@ -478,46 +564,8 @@ impl TrackerCache {
                 return Ok(());
             }
 
-            // Read and parse project metadata concurrently to improve startup performance
-            let num_threads = std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(4);
-            let chunk_size = project_dirs.len().div_ceil(num_threads);
-
-            let mut worker_error = None;
-            std::thread::scope(|s| {
-                let mut handles = Vec::with_capacity(num_threads);
-                for chunk in project_dirs.chunks(chunk_size) {
-                    handles.push(s.spawn(move || {
-                        let mut chunk_projects = Vec::with_capacity(chunk.len());
-                        for project_dir in chunk {
-                            if project_dir.is_dir()
-                                && let Ok(content) =
-                                    fs::read_to_string(project_dir.join("meta.json"))
-                                && let Ok(meta) = serde_json::from_str::<ProjectShardMeta>(&content)
-                            {
-                                chunk_projects.push(CachedProject {
-                                    id: meta.id,
-                                    short_name: meta.short_name,
-                                    name: meta.name,
-                                    description: meta.description,
-                                });
-                            }
-                        }
-                        chunk_projects
-                    }));
-                }
-                for handle in handles {
-                    match handle.join() {
-                        Ok(mut res) => self.projects.append(&mut res),
-                        Err(_) => worker_error = Some(anyhow!("project metadata worker panicked")),
-                    }
-                }
-            });
-
-            if let Some(err) = worker_error {
-                return Err(err);
-            }
+            let worker_count = configured_project_metadata_worker_count(project_dirs.len());
+            self.projects = Self::load_project_metadata_shards(&project_dirs, worker_count)?;
         }
         self.loaded_shards.projects = true;
         Ok(())
@@ -1539,6 +1587,57 @@ mod tests {
     fn get_issue_count_returns_none_for_unknown() {
         let cache = TrackerCache::default();
         assert_eq!(cache.get_issue_count("PROJ", "unresolved"), None);
+    }
+
+    #[test]
+    fn cache_refresh_concurrency_clamps_to_conservative_range() {
+        assert_eq!(
+            clamp_cache_refresh_concurrency(None),
+            DEFAULT_CACHE_REFRESH_CONCURRENCY
+        );
+        assert_eq!(clamp_cache_refresh_concurrency(Some(0)), 1);
+        assert_eq!(clamp_cache_refresh_concurrency(Some(2)), 2);
+        assert_eq!(
+            clamp_cache_refresh_concurrency(Some(MAX_CACHE_REFRESH_CONCURRENCY + 1)),
+            MAX_CACHE_REFRESH_CONCURRENCY
+        );
+    }
+
+    #[test]
+    fn project_metadata_worker_count_stays_sequential_below_threshold() {
+        for project_count in [0, 1, 10, 50, MIN_PARALLEL_PROJECT_META_SHARDS - 1] {
+            assert_eq!(
+                project_metadata_worker_count(project_count, Some(MAX_CACHE_REFRESH_CONCURRENCY)),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn project_metadata_worker_count_uses_bounded_concurrency_at_threshold() {
+        assert_eq!(
+            project_metadata_worker_count(MIN_PARALLEL_PROJECT_META_SHARDS, None),
+            DEFAULT_CACHE_REFRESH_CONCURRENCY
+        );
+        assert_eq!(
+            project_metadata_worker_count(MIN_PARALLEL_PROJECT_META_SHARDS, Some(8)),
+            8
+        );
+    }
+
+    #[test]
+    fn project_metadata_worker_count_clamps_configured_concurrency() {
+        assert_eq!(
+            project_metadata_worker_count(MIN_PARALLEL_PROJECT_META_SHARDS, Some(0)),
+            MIN_CACHE_REFRESH_CONCURRENCY
+        );
+        assert_eq!(
+            project_metadata_worker_count(
+                MIN_PARALLEL_PROJECT_META_SHARDS,
+                Some(MAX_CACHE_REFRESH_CONCURRENCY + 1)
+            ),
+            MAX_CACHE_REFRESH_CONCURRENCY
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`TrackerCache::ensure_projects` now keeps the project metadata loading optimization, but avoids worker setup for normal-sized caches.

- Preserves the existing correctness hardening: `read_dir` iteration errors are returned, worker panics become errors, and `loaded_shards.projects` is set only after a successful load.
- Keeps missing or invalid `projects/*/meta.json` behavior unchanged: that project is skipped.
- Adds `MIN_PARALLEL_PROJECT_META_SHARDS = 64`.
- Uses the sequential path below 64 project shards.
- Uses bounded scoped-thread loading at 64+ shards with the same conservative cache concurrency clamp used by cache refresh: default `4`, min `1`, max `16`, and capped by project count.

## Why

Large project-context caches spend measurable time discovering project metadata by reading many `.tracker-cache/projects/*/meta.json` shard files. This optimizes that project metadata discovery path. It is not claiming a global startup speedup for every CLI command.

## Benchmark

Release binaries were built for current `origin/main` (`2c9fa3b`) and this PR branch (`cbcfe7a`). Fixtures were synthetic project-context caches under `/tmp` containing `.track.toml`, `.tracker-cache/index.json`, and valid `projects/Pxxxx/meta.json` shards.

Command:

```bash
TRACK_MOCK_DIR=/Users/david/Workspaces/OrekGames/youtrack-cli/fixtures/scenarios/cache-operations \
  <binary> --url https://mock.test --token mock-token -o json cache status
```

Warmups: 5. Measured iterations: 30. Speedup is `origin/main median / PR median`.

| shards | origin/main median ms | PR #268 median ms | speedup | origin/main mean ms | PR #268 mean ms | origin/main p95 ms | PR #268 p95 ms |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 5.978 | 5.793 | 1.03x | 6.668 | 6.300 | 8.215 | 7.494 |
| 10 | 5.599 | 5.652 | 0.99x | 5.655 | 5.693 | 6.363 | 6.206 |
| 50 | 5.832 | 5.834 | 1.00x | 5.911 | 5.925 | 6.601 | 6.454 |
| 100 | 6.404 | 6.025 | 1.06x | 6.487 | 6.158 | 7.239 | 7.029 |
| 1000 | 16.248 | 10.828 | 1.50x | 16.316 | 10.892 | 17.189 | 11.657 |
| 10000 | 132.265 | 65.667 | 2.01x | 132.407 | 67.650 | 135.023 | 76.229 |

## Limits

This benchmark validates the command path affected by this PR: `cache status` loading project metadata shards. It does not measure every cache-consuming command or full CLI startup globally.

## Test Plan

- `cargo fmt --all --check`
- `cargo test -p track cache_refresh_concurrency_clamps_to_conservative_range`
- `cargo test -p track project_metadata_worker_count`
- `cargo test -p track test_cache_v2_roundtrip`
- `cargo test -p track test_cache_v2_robustness`
