### PR TITLE
[codex] perf(track): stream JSON output

### DIFF
--- a/crates/track/src/commands/article.rs
+++ b/crates/track/src/commands/article.rs
@@ -1,5 +1,5 @@
 use crate::cli::{ArticleCommands, OutputFormat};
-use crate::output::{output_list, output_page_hint, output_progress, output_result};
+use crate::output::{output_json, output_list, output_page_hint, output_progress, output_result};
 use anyhow::{Context, Result, anyhow};
 use tracker_core::{CreateArticle, IssueTracker, KnowledgeBase, UpdateArticle, fetch_all_pages};
 
@@ -294,7 +294,7 @@ fn handle_tree(client: &dyn KnowledgeBase, id: &str, format: OutputFormat) -> Re
                 article: parent,
                 children,
             };
-            println!("{}", serde_json::to_string_pretty(&tree).unwrap());
+            output_json(&tree)?;
         }
         OutputFormat::Text => {
             use colored::Colorize;

--- a/crates/track/src/commands/bundle.rs
+++ b/crates/track/src/commands/bundle.rs
@@ -1,7 +1,7 @@
 //! Bundle admin command handlers
 
 use crate::cli::{BundleCommands, OutputFormat};
-use crate::output::output_result;
+use crate::output::{output_json, output_result};
 use anyhow::{Context, Result, anyhow};
 use tracker_core::{BundleType, CreateBundle, CreateBundleValue, IssueTracker};
 
@@ -39,8 +39,7 @@ fn handle_list(client: &dyn IssueTracker, bundle_type: &str, format: OutputForma
 
     match format {
         OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(&bundles)?;
-            println!("{}", json);
+            output_json(&bundles)?;
         }
         OutputFormat::Text => {
             if bundles.is_empty() {
@@ -138,8 +137,7 @@ fn handle_add_value(
 
     match format {
         OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(&created)?;
-            println!("{}", json);
+            output_json(&created)?;
         }
         OutputFormat::Text => {
             use colored::Colorize;

--- a/crates/track/src/commands/config.rs
+++ b/crates/track/src/commands/config.rs
@@ -261,7 +261,7 @@ pub fn handle_config_local(action: &cli::ConfigCommands, format: cli::OutputForm
                             })
                         })
                         .collect();
-                    println!("{}", serde_json::to_string_pretty(&keys)?);
+                    output_json(&keys)?;
                 }
                 cli::OutputFormat::Text => {
                     use colored::Colorize;

--- a/crates/track/src/commands/context.rs
+++ b/crates/track/src/commands/context.rs
@@ -4,6 +4,7 @@ use crate::cache::{
     TrackerCache,
 };
 use crate::cli::OutputFormat;
+use crate::output::output_json;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::Serialize;
@@ -204,8 +205,7 @@ pub fn handle_context(
     // Output
     match format {
         OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(&context)?;
-            println!("{}", json);
+            output_json(&context)?;
         }
         OutputFormat::Text => {
             println!("{}:", "AI Context".white().bold());

--- a/crates/track/src/commands/field.rs
+++ b/crates/track/src/commands/field.rs
@@ -1,7 +1,7 @@
 //! Custom field admin command handlers
 
 use crate::cli::{FieldCommands, OutputFormat};
-use crate::output::output_result;
+use crate::output::{output_json, output_result};
 use anyhow::{Context, Result, anyhow};
 use tracker_core::{
     AttachFieldToProject, BundleType, CreateBundle, CreateBundleValue, CreateCustomField,
@@ -38,8 +38,7 @@ fn handle_list(client: &dyn IssueTracker, format: OutputFormat) -> Result<()> {
 
     match format {
         OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(&fields)?;
-            println!("{}", json);
+            output_json(&fields)?;
         }
         OutputFormat::Text => {
             if fields.is_empty() {
@@ -184,8 +183,7 @@ fn handle_new(
 
     match format {
         OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(&result)?;
-            println!("{}", json);
+            output_json(&result)?;
         }
         OutputFormat::Text => {
             use colored::Colorize;

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -2,7 +2,7 @@ use crate::cli::OutputFormat;
 use colored::Colorize;
 use serde::Serialize;
 use std::collections::HashSet;
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use tracker_core::{
     Article, ArticleAttachment, BundleDefinition, Comment, CustomField, CustomFieldDefinition,
     Issue, IssueAttachment, IssueHistoryEvent, IssueTag, Project, ProjectCustomField, case_key,
@@ -10,8 +10,10 @@ use tracker_core::{
 };
 
 pub fn output_json<T: Serialize + ?Sized>(value: &T) -> anyhow::Result<()> {
-    let json = serde_json::to_string_pretty(value)?;
-    println!("{}", json);
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    serde_json::to_writer_pretty(&mut handle, value)?;
+    writeln!(handle)?;
     Ok(())
 }
 

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -2,7 +2,7 @@ use crate::cli::OutputFormat;
 use colored::Colorize;
 use serde::Serialize;
 use std::collections::HashSet;
-use std::io::{IsTerminal, Write};
+use std::io::{BufWriter, IsTerminal, Write};
 use tracker_core::{
     Article, ArticleAttachment, BundleDefinition, Comment, CustomField, CustomFieldDefinition,
     Issue, IssueAttachment, IssueHistoryEvent, IssueTag, Project, ProjectCustomField, case_key,
@@ -11,9 +11,11 @@ use tracker_core::{
 
 pub fn output_json<T: Serialize + ?Sized>(value: &T) -> anyhow::Result<()> {
     let stdout = std::io::stdout();
-    let mut handle = stdout.lock();
-    serde_json::to_writer_pretty(&mut handle, value)?;
-    writeln!(handle)?;
+    let handle = stdout.lock();
+    let mut writer = BufWriter::new(handle);
+    serde_json::to_writer_pretty(&mut writer, value)?;
+    writeln!(writer)?;
+    writer.flush()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Why

Large JSON commands such as `cache show -o json`, `context -o json`, `issue search --all -o json`, and article/comment list outputs previously built a complete pretty-printed JSON `String` before writing to stdout. For large outputs that duplicates the serialized JSON in memory on top of the already-loaded Rust data structure.

The goal of this PR is to reduce peak memory for large JSON output while preserving the existing pretty JSON stdout contract. This is a memory-pressure improvement, not a backend/API optimization.

The first implementation streamed directly to `StdoutLock`, which reduced peak memory but caused many small writes and regressed wall time badly. The branch now streams through `BufWriter<StdoutLock>`, keeping the memory benefit without the syscall-heavy regression.

## Summary

- centralize more JSON output paths through `output_json`
- stream pretty JSON directly to stdout instead of allocating the full output `String`
- buffer streamed stdout writes with `BufWriter` to avoid small-write overhead
- preserve the trailing newline and byte-identical pretty JSON output

## Benchmark

Benchmarked `cache show -o json` with synthetic large project-local cache data. Output was redirected to `/dev/null`; each version loaded and serialized the same cache. Compared `main`, the original unbuffered #270 implementation, and the updated buffered implementation.

| Output Size | main median | unbuffered #270 median | buffered #270 median |
| --- | ---: | ---: | ---: |
| 378 KB | 6.44 ms | 9.55 ms | 6.52 ms |
| 3.7 MB | 11.60 ms | 41.87 ms | 11.91 ms |
| 18.8 MB | 31.96 ms | 183.73 ms | 32.92 ms |

Peak RSS on the 18.8 MB output case:

| Version | Max RSS |
| --- | ---: |
| main | 69.7 MB |
| unbuffered #270 | 49.9 MB |
| buffered #270 | 50.0 MB |

Interpretation:

- the original unbuffered streaming design was not acceptable because it traded memory for a large wall-time regression
- the buffered design keeps the peak-memory reduction, about 20 MB lower RSS in the 18.8 MB case
- buffered streaming keeps runtime effectively flat versus main for these samples
- the PR should be understood as reducing peak memory for large JSON output, not speeding up backend calls or normal small outputs

## Decision Notes

Streaming JSON can emit partial stdout if serialization or IO fails after writing begins. The old `to_string_pretty` path completed serialization before printing, so serialization failure produced no partial stdout. That is the tradeoff for avoiding the full output allocation. For successful output, the byte-equivalence check confirmed main and buffered #270 produced identical 18.8 MB JSON.

## Validation

- `cargo fmt --package track`
- `cargo test --package track`
- `cargo build --release --package track`
- output equivalence check: main and buffered #270 produced byte-identical 18.8 MB JSON output for the benchmark fixture
- prior live JSON validation against configured YouTrack and GitHub backends passed

Latest implementation commit: `3f8b389 perf(track): buffer streamed JSON output`.
