### PR TITLE
[codex] perf(youtrack): avoid counts during paged scans

### DIFF
--- a/crates/track/tests/youtrack_integration_tests.rs
+++ b/crates/track/tests/youtrack_integration_tests.rs
@@ -180,10 +180,8 @@ fn test_issue_get_with_text_output() {
 
 #[test]
 fn test_issue_search_with_results() {
-    // First request: count endpoint response
-    let count_response = serde_json::json!({ "count": 2 }).to_string();
-
-    // Second request: search endpoint response
+    // Search returns fewer items than the requested limit, so the optimized
+    // YouTrack path should not issue a count request.
     let search_response = serde_json::json!([
         {
             "id": "2-1",
@@ -208,7 +206,7 @@ fn test_issue_search_with_results() {
     ])
     .to_string();
 
-    let (_server, port) = start_mock_server_multi(vec![count_response, search_response]);
+    let (_server, port) = start_mock_server_multi(vec![search_response]);
     thread::sleep(Duration::from_millis(50));
 
     let output = cargo_bin_cmd!("track")
@@ -750,7 +748,8 @@ fn test_completions_no_config_required() {
 
 #[test]
 fn test_pagination_hint_on_full_page() {
-    // YouTrack search: first request = count, second request = search results
+    // YouTrack search: first request = search results, second request = count
+    // because the full page needs a best-effort total for the hint.
     let count_response = serde_json::json!({ "count": 10 }).to_string();
     let search_response = serde_json::json!([
         {
@@ -768,7 +767,7 @@ fn test_pagination_hint_on_full_page() {
     ])
     .to_string();
 
-    let (_server, port) = start_mock_server_multi(vec![count_response, search_response]);
+    let (_server, port) = start_mock_server_multi(vec![search_response, count_response]);
     thread::sleep(Duration::from_millis(50));
 
     let output = cargo_bin_cmd!("track")
@@ -798,8 +797,7 @@ fn test_pagination_hint_on_full_page() {
 
 #[test]
 fn test_no_pagination_hint_on_partial_page() {
-    // Return fewer items than limit — no hint expected
-    let count_response = serde_json::json!({ "count": 2 }).to_string();
+    // Return fewer items than limit -- no hint expected and no count request needed.
     let search_response = serde_json::json!([
         {
             "id": "2-1", "idReadable": "PROJ-1", "summary": "Issue 1",
@@ -816,7 +814,7 @@ fn test_no_pagination_hint_on_partial_page() {
     ])
     .to_string();
 
-    let (_server, port) = start_mock_server_multi(vec![count_response, search_response]);
+    let (_server, port) = start_mock_server_multi(vec![search_response]);
     thread::sleep(Duration::from_millis(50));
 
     let output = cargo_bin_cmd!("track")
@@ -858,7 +856,7 @@ fn test_no_pagination_hint_in_json_mode() {
     ])
     .to_string();
 
-    let (_server, port) = start_mock_server_multi(vec![count_response, search_response]);
+    let (_server, port) = start_mock_server_multi(vec![search_response, count_response]);
     thread::sleep(Duration::from_millis(50));
 
     let output = cargo_bin_cmd!("track")
@@ -908,7 +906,7 @@ fn test_pagination_hint_shows_total() {
     ])
     .to_string();
 
-    let (_server, port) = start_mock_server_multi(vec![count_response, search_response]);
+    let (_server, port) = start_mock_server_multi(vec![search_response, count_response]);
     thread::sleep(Duration::from_millis(50));
 
     let output = cargo_bin_cmd!("track")

--- a/crates/youtrack-backend/src/client.rs
+++ b/crates/youtrack-backend/src/client.rs
@@ -163,10 +163,19 @@ impl YouTrackClient {
         const MAX_RETRIES: u32 = 4;
         const RETRY_DELAY_MS: u64 = 400;
 
+        self.count_issues_with_retry(query, MAX_RETRIES, Duration::from_millis(RETRY_DELAY_MS))
+    }
+
+    pub(crate) fn count_issues_with_retry(
+        &self,
+        query: &str,
+        max_attempts: u32,
+        retry_delay: Duration,
+    ) -> Result<Option<u64>> {
         let url = format!("{}/api/issuesGetter/count?fields=count", self.base_url);
         let body = serde_json::json!({ "query": query });
 
-        for attempt in 0..MAX_RETRIES {
+        for attempt in 0..max_attempts {
             let response = self
                 .agent
                 .post(&url)
@@ -184,8 +193,8 @@ impl YouTrackClient {
             }
 
             // -1 means still counting; wait and retry (except on last attempt)
-            if attempt < MAX_RETRIES - 1 {
-                std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
+            if attempt < max_attempts - 1 {
+                std::thread::sleep(retry_delay);
             }
         }
 

--- a/crates/youtrack-backend/src/client_tests.rs
+++ b/crates/youtrack-backend/src/client_tests.rs
@@ -4,9 +4,24 @@ mod tests {
     use crate::models::*;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
-    use tracker_core::{AttachmentUpload, AttachmentUploadFile};
+    use tracker_core::{AttachmentUpload, AttachmentUploadFile, IssueTracker};
     use wiremock::matchers::{body_json, body_string_contains, header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn mock_issue(id: &str, id_readable: &str, summary: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "idReadable": id_readable,
+            "summary": summary,
+            "project": {
+                "id": "0-1",
+                "shortName": "PROJ"
+            },
+            "customFields": [],
+            "created": 1640000000000i64,
+            "updated": 1640000000000i64,
+        })
+    }
 
     fn temp_upload_file(name: &str, contents: &[u8]) -> PathBuf {
         let nanos = SystemTime::now()
@@ -94,6 +109,186 @@ mod tests {
         assert_eq!(issues.len(), 2);
         assert_eq!(issues[0].id_readable, "PROJ-123");
         assert_eq!(issues[1].id_readable, "PROJ-124");
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_all_issues_pages_without_counting() {
+        let mock_server = MockServer::start().await;
+        let first_page: Vec<_> = (1..=100)
+            .map(|n| {
+                mock_issue(
+                    &format!("2-{n}"),
+                    &format!("PROJ-{n}"),
+                    &format!("Issue {n}"),
+                )
+            })
+            .collect();
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .and(query_param("query", "project: PROJ"))
+            .and(query_param("$top", "100"))
+            .and(query_param("$skip", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(first_page))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .and(query_param("query", "project: PROJ"))
+            .and(query_param("$top", "100"))
+            .and(query_param("$skip", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                mock_issue("2-101", "PROJ-101", "Last issue")
+            ])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/issuesGetter/count"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "count": 3
+            })))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let issues = IssueTracker::search_all_issues(&client, "project: PROJ", 1000).unwrap();
+
+        assert_eq!(issues.len(), 101);
+        assert_eq!(issues[0].id_readable, "PROJ-1");
+        assert_eq!(issues[100].id_readable, "PROJ-101");
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_short_page_infers_total_without_counting() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .and(query_param("query", "project: PROJ"))
+            .and(query_param("$top", "3"))
+            .and(query_param("$skip", "5"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                mock_issue("2-6", "PROJ-6", "Sixth issue"),
+                mock_issue("2-7", "PROJ-7", "Seventh issue")
+            ])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/issuesGetter/count"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "count": 7
+            })))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let result = IssueTracker::search_issues(&client, "project: PROJ", 3, 5).unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.total, Some(7));
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_zero_limit_makes_no_requests() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/issuesGetter/count"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "count": 10
+            })))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let result = IssueTracker::search_issues(&client, "project: PROJ", 0, 0).unwrap();
+
+        assert!(result.items.is_empty());
+        assert_eq!(result.total, None);
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_full_page_counts_once() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .and(query_param("query", "project: PROJ"))
+            .and(query_param("$top", "2"))
+            .and(query_param("$skip", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                mock_issue("2-1", "PROJ-1", "First issue"),
+                mock_issue("2-2", "PROJ-2", "Second issue")
+            ])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/issuesGetter/count"))
+            .and(query_param("fields", "count"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "count": 42
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let result = IssueTracker::search_issues(&client, "project: PROJ", 2, 0).unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.total, Some(42));
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_minus_one_count_does_not_retry() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .and(query_param("query", "project: PROJ"))
+            .and(query_param("$top", "2"))
+            .and(query_param("$skip", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                mock_issue("2-1", "PROJ-1", "First issue"),
+                mock_issue("2-2", "PROJ-2", "Second issue")
+            ])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/issuesGetter/count"))
+            .and(query_param("fields", "count"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "count": -1
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let result = IssueTracker::search_issues(&client, "project: PROJ", 2, 0).unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.total, None);
     }
 
     #[tokio::test]

--- a/crates/youtrack-backend/src/trait_impl.rs
+++ b/crates/youtrack-backend/src/trait_impl.rs
@@ -21,16 +21,42 @@ impl IssueTracker for YouTrackClient {
     }
 
     fn search_issues(&self, query: &str, limit: usize, skip: usize) -> Result<SearchResult<Issue>> {
-        // Best-effort count — don't fail the search if counting fails
-        let total = self.count_issues(query).ok().flatten();
+        if limit == 0 {
+            return Ok(SearchResult::from_items(Vec::new()));
+        }
 
         let issues = self.search_issues(query, limit, skip)?;
         let items: Vec<Issue> = issues.into_iter().map(Into::into).collect();
+        let item_count = items.len();
+
+        if item_count < limit {
+            return Ok(SearchResult::with_total(items, (skip + item_count) as u64));
+        }
+
+        // Best-effort count -- don't fail the search if counting fails.
+        // Normal interactive search gets one no-sleep attempt; explicit counts
+        // keep the public retrying behavior through `count_issues`.
+        let total = self
+            .count_issues_with_retry(query, 1, std::time::Duration::ZERO)
+            .ok()
+            .flatten();
 
         match total {
             Some(count) => Ok(SearchResult::with_total(items, count)),
             None => Ok(SearchResult::from_items(items)),
         }
+    }
+
+    fn search_all_issues(&self, query: &str, max_results: usize) -> Result<Vec<Issue>> {
+        tracker_core::pagination::fetch_all_pages_keyed(
+            |offset, limit| {
+                let issues = self.search_issues(query, limit, offset)?;
+                Ok(issues.into_iter().map(Into::into).collect::<Vec<Issue>>())
+            },
+            100,
+            max_results,
+            |issue: &Issue| issue.id.clone(),
+        )
     }
 
     fn get_issue_count(&self, query: &str) -> Result<Option<u64>> {


### PR DESCRIPTION
## Summary
- add a YouTrack search_all_issues override that pages without count requests
- fetch normal search pages before counting and infer totals for short pages
- keep explicit count behavior retrying while using one no-sleep count attempt for full interactive pages

## Validation
- cargo fmt --package youtrack-backend
- cargo test --package youtrack-backend
- git diff --check