### PR TITLE
[codex] perf(linear): walk search-all with native cursor

### DIFF
--- a/crates/linear-backend/src/client_tests.rs
+++ b/crates/linear-backend/src/client_tests.rs
@@ -4,7 +4,7 @@
 mod tests {
     use crate::client::LinearClient;
     use crate::error::LinearError;
-    use tracker_core::IssueTracker;
+    use tracker_core::{IssueTracker, TrackerError};
     use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -68,6 +68,76 @@ mod tests {
             "name": format!("{key} Team"),
             "description": "Team description"
         })
+    }
+
+    fn request_variables(request: &wiremock::Request) -> serde_json::Value {
+        request.body_json::<serde_json::Value>().unwrap()["variables"].clone()
+    }
+
+    struct SearchAllIssuePages;
+
+    impl wiremock::Respond for SearchAllIssuePages {
+        fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+            let variables = request_variables(request);
+            let (nodes, has_next_page, end_cursor) = match variables["after"].as_str() {
+                None => (
+                    (1..=100)
+                        .map(|idx| {
+                            mock_linear_issue(&format!("ORE-{idx}"), &format!("Issue {idx}"))
+                        })
+                        .collect::<Vec<_>>(),
+                    true,
+                    Some("cursor-1"),
+                ),
+                Some("cursor-1") => (
+                    (101..=120)
+                        .map(|idx| {
+                            mock_linear_issue(&format!("ORE-{idx}"), &format!("Issue {idx}"))
+                        })
+                        .collect::<Vec<_>>(),
+                    true,
+                    Some("cursor-2"),
+                ),
+                other => panic!("unexpected Linear search cursor: {other:?}"),
+            };
+
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issues": {
+                        "nodes": nodes,
+                        "pageInfo": {
+                            "hasNextPage": has_next_page,
+                            "endCursor": end_cursor
+                        }
+                    }
+                }
+            }))
+        }
+    }
+
+    struct NonAdvancingSearchPages;
+
+    impl wiremock::Respond for NonAdvancingSearchPages {
+        fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+            let variables = request_variables(request);
+            let (nodes, end_cursor) = match variables["after"].as_str() {
+                None => (vec![mock_linear_issue("ORE-1", "Issue 1")], "cursor-1"),
+                Some("cursor-1") => (vec![mock_linear_issue("ORE-2", "Issue 2")], "cursor-1"),
+                other => panic!("unexpected Linear search cursor: {other:?}"),
+            };
+
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issues": {
+                        "nodes": nodes,
+                        "pageInfo": {
+                            "hasNextPage": true,
+                            "endCursor": end_cursor
+                        }
+                    }
+                }
+            }))
+        }
     }
 
     #[tokio::test]
@@ -233,6 +303,53 @@ mod tests {
         assert_eq!(result.items[0].id_readable, "ORE-26");
         assert_eq!(result.items[19].id_readable, "ORE-45");
         assert_eq!(result.total, None);
+    }
+
+    #[tokio::test]
+    async fn test_search_all_issues_walks_cursor_chain_once_and_respects_max_results() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(SearchAllIssuePages)
+            .mount(&mock_server)
+            .await;
+
+        let client = LinearClient::with_base_url(&mock_server.uri(), "test-token");
+        let result =
+            <LinearClient as IssueTracker>::search_all_issues(&client, "#Unresolved", 120).unwrap();
+
+        assert_eq!(result.len(), 120);
+        assert_eq!(result[0].id_readable, "ORE-1");
+        assert_eq!(result[119].id_readable, "ORE-120");
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert_eq!(
+            requests.len(),
+            2,
+            "expected a native cursor walk, got {requests:#?}"
+        );
+        let first_request = request_variables(&requests[0]);
+        assert_eq!(first_request["after"], serde_json::Value::Null);
+        assert_eq!(first_request["first"], 100);
+
+        let second_request = request_variables(&requests[1]);
+        assert_eq!(second_request["after"], "cursor-1");
+        assert_eq!(second_request["first"], 20);
+    }
+
+    #[tokio::test]
+    async fn test_search_all_issues_errors_on_non_advancing_cursor() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(NonAdvancingSearchPages)
+            .mount(&mock_server)
+            .await;
+
+        let client = LinearClient::with_base_url(&mock_server.uri(), "test-token");
+        let result = <LinearClient as IssueTracker>::search_all_issues(&client, "#Unresolved", 10);
+
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
     }
 
     #[tokio::test]

--- a/crates/linear-backend/src/trait_impl.rs
+++ b/crates/linear-backend/src/trait_impl.rs
@@ -87,6 +87,87 @@ impl IssueTracker for LinearClient {
         }
     }
 
+    fn search_all_issues(&self, query: &str, max_results: usize) -> Result<Vec<Issue>> {
+        if max_results == 0 {
+            return Ok(Vec::new());
+        }
+
+        let parsed = parse_linear_query(query);
+        let team_id = if let Some(team) = parsed.team.as_deref() {
+            Some(self.resolve_team_id(team)?)
+        } else {
+            None
+        };
+        let assignee_id = if parsed
+            .assignee
+            .as_deref()
+            .is_some_and(|assignee| assignee.eq_ignore_ascii_case("me"))
+        {
+            Some(self.viewer()?.id)
+        } else {
+            None
+        };
+        let filter = build_filter_from_parsed(&parsed, team_id.as_deref(), assignee_id.as_deref());
+        let term = if parsed.text.is_empty() {
+            None
+        } else {
+            Some(parsed.text.join(" "))
+        };
+
+        let mut items = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        let mut after = None;
+        let mut no_progress_pages = 0usize;
+
+        loop {
+            let remaining = max_results.saturating_sub(items.len());
+            if remaining == 0 {
+                break;
+            }
+
+            let prev_after = after.clone();
+            let page_size = remaining.min(100);
+            let (page, _total, page_info) =
+                self.search_issues_page(filter.clone(), term.as_deref(), page_size, after)?;
+
+            let before = items.len();
+            for linear_issue in page {
+                let issue = linear_issue_to_core(linear_issue);
+                if seen.insert(issue.id.clone()) {
+                    items.push(issue);
+                    if items.len() >= max_results {
+                        break;
+                    }
+                }
+            }
+
+            if !page_info.has_next_page || items.len() >= max_results {
+                break;
+            }
+
+            if items.len() == before {
+                no_progress_pages += 1;
+                if no_progress_pages >= MAX_NO_PROGRESS_PAGES {
+                    return Err(TrackerError::PaginationStalled(
+                        "Linear search cursor pages stopped yielding new issues".to_string(),
+                    ));
+                }
+            } else {
+                no_progress_pages = 0;
+            }
+
+            let next_after = page_info.end_cursor;
+            if next_after == prev_after {
+                return Err(TrackerError::PaginationStalled(
+                    "Linear search cursor did not advance".to_string(),
+                ));
+            }
+            after = next_after;
+        }
+
+        Ok(items)
+    }
+
     fn get_issue_count(&self, query: &str) -> Result<Option<u64>> {
         let parsed = parse_linear_query(query);
         if parsed.text.is_empty() {
@@ -365,6 +446,8 @@ impl IssueTracker for LinearClient {
         )))
     }
 }
+
+const MAX_NO_PROGRESS_PAGES: usize = 5;
 
 impl LinearClient {
     fn build_create_input(&self, issue: &CreateIssue) -> Result<LinearIssueCreateInput> {


### PR DESCRIPTION
## Summary
- add a Linear search_all_issues override that walks native cursors once
- dedupe by core issue id and detect stalled cursors/no-progress pages
- add Linear backend tests for cursor walking, max_results, and stalled cursors

## Validation
- cargo fmt --package linear-backend --check
- cargo test --package linear-backend