### PR TITLE
[codex] perf(track): relax runtime cache writes

### DIFF
--- a/crates/track/src/cache.rs
+++ b/crates/track/src/cache.rs
@@ -432,9 +432,9 @@ impl TrackerCache {
         let root = Self::cache_dir_path(cache_dir)?;
         let runtime_dir = root.join("runtime");
         create_dir_all_secure(&runtime_dir)?;
-        Self::atomic_write(
+        Self::atomic_write_relaxed(
             &runtime_dir.join("recent_issues.json"),
-            serde_json::to_string_pretty(&self.recent_issues)?.as_bytes(),
+            &serde_json::to_vec(&self.recent_issues)?,
         )?;
         Ok(())
     }
@@ -662,6 +662,19 @@ impl TrackerCache {
 
     /// Atomic write helper: write temp -> fsync -> rename
     fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
+        Self::atomic_write_inner(path, content, true)
+    }
+
+    /// Relaxed atomic write helper: write temp -> rename, without fsync.
+    ///
+    /// Used for non-critical runtime metadata on hot paths where preserving
+    /// atomic replacement and file permissions matters more than durability
+    /// across sudden power loss.
+    fn atomic_write_relaxed(path: &Path, content: &[u8]) -> Result<()> {
+        Self::atomic_write_inner(path, content, false)
+    }
+
+    fn atomic_write_inner(path: &Path, content: &[u8], durable: bool) -> Result<()> {
         let temp_path = path.with_extension("tmp");
 
         // Create parent directory if needed
@@ -691,8 +704,11 @@ impl TrackerCache {
             file.write_all(content).with_context(|| {
                 format!("Failed to write to temp file: {}", temp_path.display())
             })?;
-            file.sync_all()
-                .with_context(|| format!("Failed to sync temp file: {}", temp_path.display()))?;
+            if durable {
+                file.sync_all().with_context(|| {
+                    format!("Failed to sync temp file: {}", temp_path.display())
+                })?;
+            }
         }
 
         #[cfg(unix)]

--- a/crates/track/tests/cache_integration_tests.rs
+++ b/crates/track/tests/cache_integration_tests.rs
@@ -608,6 +608,19 @@ fn test_issue_access_preserves_other_shards() {
     );
     assert_eq!(recent_arr[0]["id_readable"], "DEMO-1");
 
+    // Verify the compact runtime shard is loadable through normal cache loading.
+    let output = track_in_no_mock(&dir)
+        .args(["-o", "json", "cache", "show"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "cache show should load runtime shard, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let loaded: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(loaded["recent_issues"][0]["id_readable"], "DEMO-1");
+
     fs::remove_dir_all(&dir).unwrap();
 }
 


### PR DESCRIPTION
## Why

`track issue get` and the `track DEMO-1` shortcut are read-style commands, but after a successful fetch they also update the local `runtime/recent_issues.json` shard for LRU/context features. That recent-issues shard is opportunistic runtime metadata, not authoritative tracker data.

Before this PR, that hot-path metadata update used the same durable atomic write helper as full cache refresh: write temp file, `fsync`, then rename. That is stronger durability than this metadata needs, and it adds local disk latency to otherwise successful issue reads.

This change keeps full cache saves on the durable `fsync` path, but moves the runtime-only recent-issues write to a relaxed atomic path: write temp file, preserve restricted file permissions, then rename without `fsync`. If the process or machine dies at the wrong moment, losing the latest recent-issue entry is acceptable; the replacement is still atomic to avoid a partially written JSON file.

## Summary

- add a relaxed atomic write path for non-critical runtime LRU metadata
- keep full cache saves and cache refresh writes on the durable sync path
- write `runtime/recent_issues.json` as compact JSON on the hot path
- verify compact runtime shards still load through normal cache loading

## Benchmark

Benchmarked the hot path this PR changes: `track issue get DEMO-1` with an existing project-local cache, using release binaries and the mock backend so network/API variance does not hide the local cache-write cost.

Methodology:

- compared `main` release binary against this PR release binary
- prepopulated `.tracker-cache` once per run using `fixtures/scenarios/cache-operations`
- timed repeated `issue get DEMO-1` calls with `TRACK_MOCK_DIR=fixtures/scenarios/basic-workflow`
- discarded command output, while still exercising cache load, `record_issue_access`, and `save_runtime`
- alternated execution order between main and PR to reduce ordering bias
- measured command-level latency, so the runtime-cache delta is diluted by process startup and mock issue loading

Initial run, 200 measured iterations per version after warmup:

| Version | Mean | Median | p90 | p95 |
| --- | ---: | ---: | ---: | ---: |
| main | 11.58 ms | 11.63 ms | 12.18 ms | 12.47 ms |
| PR #273 | 7.05 ms | 7.05 ms | 7.58 ms | 7.76 ms |

Paired main-minus-PR delta: mean 4.53 ms, median 4.50 ms.

Repeat runs, 150 measured iterations per version after warmup:

| Repeat | Median Delta |
| --- | ---: |
| 1 | 4.37 ms |
| 2 | 4.23 ms |
| 3 | 4.32 ms |

Interpretation: this consistently saves about 4.2-4.5 ms per cached issue read on this machine. The win is from skipping `fsync` for disposable runtime metadata; compact JSON is secondary. This does not optimize backend search, backend fetch time, full cache refresh, or durable cache saves.

## Validation

- `cargo fmt --package track`
- `cargo test --package track --test cache_integration_tests`
- `cargo test --package track cache`
- Live YouTrack runtime cache validation: issue search plus direct `OGIT-2` read wrote a valid `runtime/recent_issues.json` shard with `id_readable=OGIT-2`, `project_short_name=OGIT`, `state=Done`, and `last_accessed` present.
