### PR TITLE
[codex] perf(track): add native all-articles pagination

### DIFF
--- a/crates/github-backend/src/trait_impl.rs
+++ b/crates/github-backend/src/trait_impl.rs
@@ -428,6 +428,36 @@ fn wiki_page_to_article(page: WikiPage, owner: &str, repo: &str) -> Article {
     }
 }
 
+fn wiki_pages_to_articles(
+    pages: Vec<WikiPage>,
+    owner: &str,
+    repo: &str,
+    limit: usize,
+    skip: usize,
+) -> Vec<Article> {
+    let parent_slugs: HashSet<String> = pages.iter().filter_map(|p| p.parent.clone()).collect();
+
+    pages
+        .into_iter()
+        .skip(skip)
+        .take(limit)
+        .map(|page| {
+            let mut article = wiki_page_to_article(page, owner, repo);
+            article.has_children = parent_slugs.contains(&article.id);
+            article
+        })
+        .collect()
+}
+
+fn wiki_page_matches_query(page: &WikiPage, query_lower: &str) -> bool {
+    page.title.to_lowercase().contains(query_lower)
+        || page.content.to_lowercase().contains(query_lower)
+        || page
+            .tags
+            .iter()
+            .any(|tag| tag.to_lowercase().contains(query_lower))
+}
+
 impl KnowledgeBase for GitHubClient {
     fn get_article(&self, id: &str) -> Result<Article> {
         let wiki = self.wiki();
@@ -459,42 +489,75 @@ impl KnowledgeBase for GitHubClient {
         let wiki = self.wiki();
         let pages = wiki.list_pages()?;
 
-        // Single-pass parent set for has_children
-        let parent_slugs: HashSet<String> = pages.iter().filter_map(|p| p.parent.clone()).collect();
-
-        let articles: Vec<Article> = pages
-            .into_iter()
-            .skip(skip)
-            .take(limit)
-            .map(|page| {
-                let mut article = wiki_page_to_article(page, self.owner(), self.repo());
-                article.has_children = parent_slugs.contains(&article.id);
-                article
-            })
-            .collect();
-
-        Ok(articles)
+        Ok(wiki_pages_to_articles(
+            pages,
+            self.owner(),
+            self.repo(),
+            limit,
+            skip,
+        ))
     }
 
     fn search_articles(&self, query: &str, limit: usize, skip: usize) -> Result<Vec<Article>> {
         let wiki = self.wiki();
         let pages = wiki.search_pages(query)?;
 
-        // Single-pass parent set for has_children
-        let parent_slugs: HashSet<String> = pages.iter().filter_map(|p| p.parent.clone()).collect();
+        Ok(wiki_pages_to_articles(
+            pages,
+            self.owner(),
+            self.repo(),
+            limit,
+            skip,
+        ))
+    }
 
-        let articles: Vec<Article> = pages
+    fn list_all_articles(
+        &self,
+        project_id: Option<&str>,
+        max_results: usize,
+    ) -> Result<Vec<Article>> {
+        if let Some(proj) = project_id {
+            let expected_project = format!("{}/{}", self.owner(), self.repo());
+            if proj != expected_project {
+                return Ok(Vec::new());
+            }
+        }
+        if max_results == 0 {
+            return Ok(Vec::new());
+        }
+
+        let wiki = self.wiki();
+        let pages = wiki.list_pages()?;
+
+        Ok(wiki_pages_to_articles(
+            pages,
+            self.owner(),
+            self.repo(),
+            max_results,
+            0,
+        ))
+    }
+
+    fn search_all_articles(&self, query: &str, max_results: usize) -> Result<Vec<Article>> {
+        if max_results == 0 {
+            return Ok(Vec::new());
+        }
+
+        let wiki = self.wiki();
+        let query_lower = query.to_lowercase();
+        let pages: Vec<WikiPage> = wiki
+            .list_pages()?
             .into_iter()
-            .skip(skip)
-            .take(limit)
-            .map(|page| {
-                let mut article = wiki_page_to_article(page, self.owner(), self.repo());
-                article.has_children = parent_slugs.contains(&article.id);
-                article
-            })
+            .filter(|page| wiki_page_matches_query(page, &query_lower))
             .collect();
 
-        Ok(articles)
+        Ok(wiki_pages_to_articles(
+            pages,
+            self.owner(),
+            self.repo(),
+            max_results,
+            0,
+        ))
     }
 
     fn create_article(&self, article: &CreateArticle) -> Result<Article> {
@@ -618,7 +681,21 @@ impl KnowledgeBase for GitHubClient {
 
 #[cfg(test)]
 mod slugify_tests {
-    use super::slugify;
+    use super::{slugify, wiki_page_matches_query, wiki_pages_to_articles};
+    use crate::wiki::WikiPage;
+
+    fn wiki_page(slug: &str, title: &str, content: &str, parent: Option<&str>) -> WikiPage {
+        WikiPage {
+            slug: slug.to_string(),
+            title: title.to_string(),
+            content: content.to_string(),
+            parent: parent.map(str::to_string),
+            tags: Vec::new(),
+            created: chrono::Utc::now(),
+            updated: chrono::Utc::now(),
+            author: None,
+        }
+    }
 
     #[test]
     fn ascii_titles_unchanged() {
@@ -678,5 +755,33 @@ mod slugify_tests {
         assert_ne!(a, b);
         assert_ne!(a, c);
         assert_ne!(b, c);
+    }
+
+    #[test]
+    fn wiki_pages_to_articles_sets_children_and_truncates() {
+        let pages = vec![
+            wiki_page("Parent", "Parent", "root", None),
+            wiki_page("Parent/Child", "Child", "nested", Some("Parent")),
+            wiki_page("Other", "Other", "root", None),
+        ];
+
+        let articles = wiki_pages_to_articles(pages, "owner", "repo", 2, 0);
+
+        assert_eq!(articles.len(), 2);
+        assert_eq!(articles[0].id, "Parent");
+        assert!(articles[0].has_children);
+        assert_eq!(articles[1].id, "Parent/Child");
+        assert!(!articles[1].has_children);
+    }
+
+    #[test]
+    fn wiki_page_matches_query_searches_title_content_and_tags() {
+        let mut page = wiki_page("Guide", "Install Guide", "setup notes", None);
+        page.tags = vec!["docs".to_string()];
+
+        assert!(wiki_page_matches_query(&page, "install"));
+        assert!(wiki_page_matches_query(&page, "setup"));
+        assert!(wiki_page_matches_query(&page, "docs"));
+        assert!(!wiki_page_matches_query(&page, "missing"));
     }
 }

--- a/crates/gitlab-backend/src/client_tests.rs
+++ b/crates/gitlab-backend/src/client_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use crate::client::GitLabClient;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
-    use tracker_core::{AttachmentUpload, AttachmentUploadFile, IssueTracker};
+    use tracker_core::{AttachmentUpload, AttachmentUploadFile, IssueTracker, KnowledgeBase};
     use wiremock::matchers::{body_string_contains, header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -66,6 +66,16 @@ mod tests {
             "path_with_namespace": format!("group/{}", name.to_lowercase().replace(' ', "-")),
             "description": "Project description",
             "web_url": format!("https://gitlab.com/group/{}", name.to_lowercase().replace(' ', "-"))
+        })
+    }
+
+    fn mock_wiki_page(slug: &str, title: &str, content: &str) -> serde_json::Value {
+        serde_json::json!({
+            "slug": slug,
+            "title": title,
+            "content": content,
+            "format": "markdown",
+            "encoding": "UTF-8"
         })
     }
 
@@ -855,6 +865,58 @@ mod tests {
         let client = GitLabClient::new("https://gitlab.com/api/v4", "test-token", Some("123"));
 
         assert_eq!(client.resolve_link_type("nonexistent"), "nonexistent");
+    }
+
+    #[tokio::test]
+    async fn test_list_all_articles_fetches_wiki_once_and_truncates() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/projects/123/wikis"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("with_content", "1"))
+            .and(query_param("per_page", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                mock_wiki_page("first", "First", "alpha"),
+                mock_wiki_page("second", "Second", "beta"),
+                mock_wiki_page("third", "Third", "gamma")
+            ])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let articles = client.list_all_articles(Some("123"), 2).unwrap();
+
+        assert_eq!(articles.len(), 2);
+        assert_eq!(articles[0].id, "first");
+        assert_eq!(articles[1].id, "second");
+    }
+
+    #[tokio::test]
+    async fn test_search_all_articles_fetches_wiki_once_filters_and_truncates() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/projects/123/wikis"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("with_content", "1"))
+            .and(query_param("per_page", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                mock_wiki_page("install", "Install Guide", "alpha"),
+                mock_wiki_page("deploy", "Deploy", "contains guide details"),
+                mock_wiki_page("other", "Other", "guide appendix")
+            ])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let articles = client.search_all_articles("guide", 2).unwrap();
+
+        assert_eq!(articles.len(), 2);
+        assert_eq!(articles[0].id, "install");
+        assert_eq!(articles[1].id, "deploy");
     }
 
     // ==================== Issue History (3-endpoint merge) Tests ====================

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -499,6 +499,51 @@ impl KnowledgeBase for GitLabClient {
             .collect())
     }
 
+    fn list_all_articles(
+        &self,
+        project_id: Option<&str>,
+        max_results: usize,
+    ) -> Result<Vec<Article>> {
+        if let Some(project) = project_id
+            && project != self.project_id_str()
+        {
+            return Ok(Vec::new());
+        }
+        if max_results == 0 {
+            return Ok(Vec::new());
+        }
+
+        Ok(self
+            .list_wiki_pages(true)?
+            .into_iter()
+            .take(max_results)
+            .map(|page| gitlab_wiki_page_to_article(page, &self.project_id_str()))
+            .collect())
+    }
+
+    fn search_all_articles(&self, query: &str, max_results: usize) -> Result<Vec<Article>> {
+        if max_results == 0 {
+            return Ok(Vec::new());
+        }
+
+        let query = query.to_lowercase();
+        Ok(self
+            .list_wiki_pages(true)?
+            .into_iter()
+            .filter(|page| {
+                page.title.to_lowercase().contains(&query)
+                    || page
+                        .content
+                        .as_deref()
+                        .unwrap_or_default()
+                        .to_lowercase()
+                        .contains(&query)
+            })
+            .take(max_results)
+            .map(|page| gitlab_wiki_page_to_article(page, &self.project_id_str()))
+            .collect())
+    }
+
     fn create_article(&self, article: &CreateArticle) -> Result<Article> {
         if article.project_id != self.project_id_str() {
             return Err(TrackerError::InvalidInput(format!(

--- a/crates/jira-backend/src/confluence_impl.rs
+++ b/crates/jira-backend/src/confluence_impl.rs
@@ -65,6 +65,46 @@ impl KnowledgeBase for ConfluenceClient {
         Ok(articles)
     }
 
+    fn list_all_articles(
+        &self,
+        project_id: Option<&str>,
+        max_results: usize,
+    ) -> Result<Vec<Article>> {
+        if max_results == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut articles = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let remaining = max_results - articles.len();
+            let page_limit = remaining.min(100);
+            let page = self
+                .list_pages(project_id, page_limit, cursor.as_deref())
+                .map_err(TrackerError::from)?;
+            let page_len = page.results.len();
+
+            articles.extend(
+                page.results
+                    .into_iter()
+                    .take(remaining)
+                    .map(confluence_page_to_article),
+            );
+
+            if articles.len() >= max_results || page_len == 0 {
+                break;
+            }
+
+            cursor = page.links.as_ref().and_then(extract_next_cursor);
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        Ok(articles)
+    }
+
     fn search_articles(&self, query: &str, limit: usize, skip: usize) -> Result<Vec<Article>> {
         self.search_pages(query, limit, skip)
             .map(|r| {
@@ -446,5 +486,51 @@ mod tests {
         assert_eq!(articles.len(), 2);
         assert_eq!(articles[0].id, "3");
         assert_eq!(articles[1].id, "4");
+    }
+
+    #[tokio::test]
+    async fn list_all_articles_walks_cursor_pages_once_and_truncates() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/wiki/api/v2/pages"))
+            .and(query_param("limit", "3"))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "results": [
+                    page("1", "First"),
+                    page("2", "Second")
+                ],
+                "_links": {
+                    "next": "/wiki/api/v2/pages?cursor=next-page"
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/wiki/api/v2/pages"))
+            .and(query_param("limit", "1"))
+            .and(query_param("cursor", "next-page"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "results": [
+                    page("3", "Third")
+                ],
+                "_links": {
+                    "next": "/wiki/api/v2/pages?cursor=unused-page"
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ConfluenceClient::new(&mock_server.uri(), "test@example.com", "token");
+        let articles = client.list_all_articles(None, 3).unwrap();
+
+        assert_eq!(articles.len(), 3);
+        assert_eq!(articles[0].id, "1");
+        assert_eq!(articles[1].id, "2");
+        assert_eq!(articles[2].id, "3");
     }
 }

--- a/crates/track/src/commands/article.rs
+++ b/crates/track/src/commands/article.rs
@@ -1,7 +1,7 @@
 use crate::cli::{ArticleCommands, OutputFormat};
 use crate::output::{output_list, output_page_hint, output_progress, output_result};
 use anyhow::{Context, Result, anyhow};
-use tracker_core::{CreateArticle, IssueTracker, KnowledgeBase, UpdateArticle, fetch_all_pages};
+use tracker_core::{CreateArticle, IssueTracker, KnowledgeBase, UpdateArticle, get_max_results};
 
 pub fn handle_article(
     issue_client: &dyn IssueTracker,
@@ -135,12 +135,9 @@ fn handle_list(
     format: OutputFormat,
 ) -> Result<()> {
     let articles = if all {
-        let page_size = 100usize;
-        let res = fetch_all_pages(
-            |offset, page_limit| client.list_articles(project, page_limit, offset),
-            page_size,
-        )
-        .context("Failed to list articles (pagination)")?;
+        let res = client
+            .list_all_articles(project, get_max_results())
+            .context("Failed to list articles (pagination)")?;
         output_progress(&format!("Fetched {} articles", res.len()), format);
         res
     } else {
@@ -165,17 +162,14 @@ fn handle_search(
     format: OutputFormat,
 ) -> Result<()> {
     let articles = if all {
-        let page_size = 100usize;
-        let res = fetch_all_pages(
-            |offset, page_limit| client.search_articles(query, page_limit, offset),
-            page_size,
-        )
-        .with_context(|| {
-            format!(
-                "Failed to search articles with query '{}' (pagination)",
-                query
-            )
-        })?;
+        let res = client
+            .search_all_articles(query, get_max_results())
+            .with_context(|| {
+                format!(
+                    "Failed to search articles with query '{}' (pagination)",
+                    query
+                )
+            })?;
         output_progress(&format!("Fetched {} articles", res.len()), format);
         res
     } else {

--- a/crates/tracker-core/src/traits.rs
+++ b/crates/tracker-core/src/traits.rs
@@ -300,6 +300,39 @@ pub trait KnowledgeBase: Send + Sync {
     /// Search articles using the backend's query language
     fn search_articles(&self, query: &str, limit: usize, skip: usize) -> Result<Vec<Article>>;
 
+    /// Fetch all articles, auto-paginating up to `max_results`.
+    ///
+    /// The default implementation pages through [`Self::list_articles`] in
+    /// offset windows of 100, deduplicating by article id and failing with
+    /// [`crate::TrackerError::PaginationStalled`] if a full page yields no
+    /// new articles. Backends with native cursor or full-scan APIs should
+    /// override this to avoid replaying earlier pages through offset emulation.
+    fn list_all_articles(
+        &self,
+        project_id: Option<&str>,
+        max_results: usize,
+    ) -> Result<Vec<Article>> {
+        crate::pagination::fetch_all_pages_keyed(
+            |offset, limit| self.list_articles(project_id, limit, offset),
+            100,
+            max_results,
+            |article: &Article| article.id.clone(),
+        )
+    }
+
+    /// Search all articles, auto-paginating up to `max_results`.
+    ///
+    /// The default implementation pages through [`Self::search_articles`] in
+    /// offset windows of 100, deduplicating by article id.
+    fn search_all_articles(&self, query: &str, max_results: usize) -> Result<Vec<Article>> {
+        crate::pagination::fetch_all_pages_keyed(
+            |offset, limit| self.search_articles(query, limit, offset),
+            100,
+            max_results,
+            |article: &Article| article.id.clone(),
+        )
+    }
+
     /// Create a new article
     fn create_article(&self, article: &CreateArticle) -> Result<Article>;
 
@@ -386,6 +419,26 @@ mod tests {
         }
     }
 
+    fn test_article(n: usize) -> Article {
+        Article {
+            id: format!("article-{n}"),
+            id_readable: format!("TEST-A-{n}"),
+            summary: format!("Article {n}"),
+            content: None,
+            project: ProjectRef {
+                id: "proj-1".to_string(),
+                name: None,
+                short_name: None,
+            },
+            parent_article: None,
+            has_children: false,
+            tags: Vec::new(),
+            created: chrono::Utc::now(),
+            updated: chrono::Utc::now(),
+            reporter: None,
+        }
+    }
+
     /// Offset-window search stub. `ignore_skip` simulates the issue #252
     /// failure mode where the server ignores the offset parameter.
     struct StubTracker {
@@ -401,6 +454,91 @@ mod tests {
                 ignore_skip,
                 calls: Mutex::new(Vec::new()),
             }
+        }
+    }
+
+    struct StubKnowledgeBase {
+        articles: Vec<Article>,
+        ignore_skip: bool,
+        list_calls: Mutex<Vec<(usize, usize)>>,
+        search_calls: Mutex<Vec<(usize, usize)>>,
+    }
+
+    impl StubKnowledgeBase {
+        fn new(count: usize, ignore_skip: bool) -> Self {
+            Self {
+                articles: (1..=count).map(test_article).collect(),
+                ignore_skip,
+                list_calls: Mutex::new(Vec::new()),
+                search_calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl KnowledgeBase for StubKnowledgeBase {
+        fn get_article(&self, _: &str) -> Result<Article> {
+            unimplemented!()
+        }
+
+        fn list_articles(
+            &self,
+            _: Option<&str>,
+            limit: usize,
+            skip: usize,
+        ) -> Result<Vec<Article>> {
+            self.list_calls.lock().unwrap().push((skip, limit));
+            let skip = if self.ignore_skip { 0 } else { skip };
+            Ok(self
+                .articles
+                .iter()
+                .skip(skip)
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+
+        fn search_articles(&self, _: &str, limit: usize, skip: usize) -> Result<Vec<Article>> {
+            self.search_calls.lock().unwrap().push((skip, limit));
+            let skip = if self.ignore_skip { 0 } else { skip };
+            Ok(self
+                .articles
+                .iter()
+                .skip(skip)
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+
+        fn create_article(&self, _: &CreateArticle) -> Result<Article> {
+            unimplemented!()
+        }
+
+        fn update_article(&self, _: &str, _: &UpdateArticle) -> Result<Article> {
+            unimplemented!()
+        }
+
+        fn delete_article(&self, _: &str) -> Result<()> {
+            unimplemented!()
+        }
+
+        fn get_child_articles(&self, _: &str) -> Result<Vec<Article>> {
+            unimplemented!()
+        }
+
+        fn move_article(&self, _: &str, _: Option<&str>) -> Result<Article> {
+            unimplemented!()
+        }
+
+        fn list_article_attachments(&self, _: &str) -> Result<Vec<ArticleAttachment>> {
+            unimplemented!()
+        }
+
+        fn get_article_comments(&self, _: &str) -> Result<Vec<Comment>> {
+            unimplemented!()
+        }
+
+        fn add_article_comment(&self, _: &str, _: &str) -> Result<Comment> {
+            unimplemented!()
         }
     }
 
@@ -493,5 +631,23 @@ mod tests {
         let result = tracker.search_all_issues("query", 1000);
         assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
         assert_eq!(tracker.calls.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn list_all_articles_default_respects_max_results() {
+        let kb = StubKnowledgeBase::new(250, false);
+        let result = kb.list_all_articles(None, 150).unwrap();
+        assert_eq!(result.len(), 150);
+        assert_eq!(result[0].id, "article-1");
+        assert_eq!(result[149].id, "article-150");
+        assert_eq!(*kb.list_calls.lock().unwrap(), vec![(0, 100), (100, 50)]);
+    }
+
+    #[test]
+    fn search_all_articles_default_errors_when_backend_ignores_skip() {
+        let kb = StubKnowledgeBase::new(250, true);
+        let result = kb.search_all_articles("query", 1000);
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
+        assert_eq!(kb.search_calls.lock().unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
## Summary
- add KnowledgeBase list_all_articles and search_all_articles defaults
- use one-pass all-list/search paths for GitHub and GitLab wiki backends
- add Confluence cursor-native all-listing and update track article --all commands

## Validation
- cargo fmt --all
- cargo test -p tracker-core
- cargo test -p github-backend
- cargo test -p github-backend trait_impl::slugify_tests
- cargo test -p gitlab-backend
- cargo test -p jira-backend
- cargo test -p track article