### PR TITLE
[codex] perf(track): add native all-comments pagination

### DIFF
--- a/crates/gitlab-backend/src/client_tests.rs
+++ b/crates/gitlab-backend/src/client_tests.rs
@@ -426,6 +426,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_all_comments_walks_native_note_pages_once() {
+        let mock_server = MockServer::start().await;
+
+        let first_page: Vec<_> = (1..=100)
+            .map(|id| {
+                serde_json::json!({
+                    "id": id,
+                    "body": format!("Comment {id}"),
+                    "author": {"id": 1, "username": "user", "name": "User"},
+                    "created_at": "2024-01-15T10:00:00.000Z",
+                    "updated_at": "2024-01-15T10:00:00.000Z",
+                    "system": id == 50
+                })
+            })
+            .collect();
+
+        Mock::given(method("GET"))
+            .and(path("/projects/123/issues/42/notes"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("per_page", "100"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(first_page))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/projects/123/issues/42/notes"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("per_page", "100"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": 101,
+                    "body": "Comment 101",
+                    "author": {"id": 1, "username": "user", "name": "User"},
+                    "created_at": "2024-01-15T11:00:00.000Z",
+                    "updated_at": "2024-01-15T11:00:00.000Z",
+                    "system": false
+                },
+                {
+                    "id": 102,
+                    "body": "Comment 102",
+                    "author": {"id": 1, "username": "user", "name": "User"},
+                    "created_at": "2024-01-15T12:00:00.000Z",
+                    "updated_at": "2024-01-15T12:00:00.000Z",
+                    "system": false
+                }
+            ])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let comments = <GitLabClient as IssueTracker>::get_all_comments(&client, "#42", 101)
+            .expect("get_all_comments should succeed");
+
+        assert_eq!(comments.len(), 101);
+        assert!(!comments.iter().any(|comment| comment.id == "50"));
+        assert_eq!(comments[0].id, "1");
+        assert_eq!(comments[100].id, "102");
+    }
+
+    #[tokio::test]
     async fn test_get_issue_links() {
         let mock_server = MockServer::start().await;
 

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -435,6 +435,39 @@ impl IssueTracker for GitLabClient {
         Ok(comments)
     }
 
+    fn get_all_comments(&self, issue_id: &str, max_results: usize) -> Result<Vec<Comment>> {
+        if max_results == 0 {
+            return Ok(Vec::new());
+        }
+
+        let iid = parse_issue_iid(issue_id)?;
+        let per_page = 100;
+        let mut page = 1;
+        let mut comments = Vec::new();
+
+        while comments.len() < max_results {
+            let raw_notes = self.get_notes_page_raw(iid, per_page, page)?;
+            let page_len = raw_notes.len();
+            let remaining = max_results - comments.len();
+
+            comments.extend(
+                raw_notes
+                    .into_iter()
+                    .filter(|note| !note.system)
+                    .take(remaining)
+                    .map(Into::into),
+            );
+
+            if comments.len() >= max_results || page_len < per_page {
+                break;
+            }
+
+            page += 1;
+        }
+
+        Ok(comments)
+    }
+
     fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
         let iid = parse_issue_iid(issue_id)?;
 

--- a/crates/linear-backend/src/client_tests.rs
+++ b/crates/linear-backend/src/client_tests.rs
@@ -4,7 +4,7 @@
 mod tests {
     use crate::client::LinearClient;
     use crate::error::LinearError;
-    use tracker_core::IssueTracker;
+    use tracker_core::{IssueTracker, TrackerError};
     use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -67,6 +67,15 @@ mod tests {
             "key": key,
             "name": format!("{key} Team"),
             "description": "Team description"
+        })
+    }
+
+    fn mock_comment(id: usize) -> serde_json::Value {
+        serde_json::json!({
+            "id": format!("comment-{id}"),
+            "body": format!("Comment {id}"),
+            "createdAt": "2024-01-15T10:30:00Z",
+            "user": null
         })
     }
 
@@ -288,6 +297,131 @@ mod tests {
         assert!(fields.iter().any(|field| field.name == "Priority"));
         assert!(fields.iter().any(|field| field.name == "Labels"));
         assert!(fields.iter().any(|field| field.name == "Project"));
+    }
+
+    #[tokio::test]
+    async fn test_get_all_comments_walks_cursor_pages_once() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("query Issue"))
+            .and(body_string_contains("ORE-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "issue": mock_linear_issue("ORE-123", "Comment issue") }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueComments"))
+            .and(body_string_contains("cursor-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "comments": {
+                            "nodes": [mock_comment(101)],
+                            "pageInfo": { "hasNextPage": false, "endCursor": null }
+                        }
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let first_page: Vec<_> = (1..=100).map(mock_comment).collect();
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueComments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "comments": {
+                            "nodes": first_page,
+                            "pageInfo": { "hasNextPage": true, "endCursor": "cursor-1" }
+                        }
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = LinearClient::with_base_url(&mock_server.uri(), "test-token");
+        let comments = <LinearClient as IssueTracker>::get_all_comments(&client, "ORE-123", 101)
+            .expect("get_all_comments should succeed");
+
+        assert_eq!(comments.len(), 101);
+        assert_eq!(comments[0].id, "comment-1");
+        assert_eq!(comments[100].id, "comment-101");
+    }
+
+    #[tokio::test]
+    async fn test_get_all_comments_errors_when_cursor_does_not_advance() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("query Issue"))
+            .and(body_string_contains("ORE-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "issue": mock_linear_issue("ORE-123", "Comment issue") }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueComments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "comments": {
+                            "nodes": [mock_comment(1)],
+                            "pageInfo": { "hasNextPage": true, "endCursor": null }
+                        }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = LinearClient::with_base_url(&mock_server.uri(), "test-token");
+        let result = <LinearClient as IssueTracker>::get_all_comments(&client, "ORE-123", 10);
+
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
+    }
+
+    #[tokio::test]
+    async fn test_get_all_comments_errors_when_page_makes_no_progress() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("query Issue"))
+            .and(body_string_contains("ORE-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "issue": mock_linear_issue("ORE-123", "Comment issue") }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("query IssueComments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "issue": {
+                        "comments": {
+                            "nodes": [],
+                            "pageInfo": { "hasNextPage": true, "endCursor": "cursor-1" }
+                        }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = LinearClient::with_base_url(&mock_server.uri(), "test-token");
+        let result = <LinearClient as IssueTracker>::get_all_comments(&client, "ORE-123", 10);
+
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
     }
 
     #[tokio::test]

--- a/crates/linear-backend/src/trait_impl.rs
+++ b/crates/linear-backend/src/trait_impl.rs
@@ -313,6 +313,52 @@ impl IssueTracker for LinearClient {
         Ok(comments)
     }
 
+    fn get_all_comments(&self, issue_id: &str, max_results: usize) -> Result<Vec<Comment>> {
+        const MAX_PAGES: usize = 10_000;
+
+        if max_results == 0 {
+            return Ok(Vec::new());
+        }
+
+        let issue = self.get_issue(issue_id)?;
+        let mut comments = Vec::new();
+        let mut after = None;
+
+        for _ in 0..MAX_PAGES {
+            let remaining = max_results - comments.len();
+            let prev_after = after.clone();
+            let (page, page_info) = self.get_comments_page(&issue.id, remaining.min(100), after)?;
+            let page_len = page.len();
+
+            comments.extend(page.into_iter().map(Into::into));
+
+            if comments.len() >= max_results || !page_info.has_next_page {
+                return Ok(comments);
+            }
+
+            if page_len == 0 {
+                return Err(TrackerError::PaginationStalled(format!(
+                    "issue '{}' comments returned no results with hasNextPage=true",
+                    issue_id
+                )));
+            }
+
+            let next_after = page_info.end_cursor;
+            if next_after.is_none() || next_after == prev_after {
+                return Err(TrackerError::PaginationStalled(format!(
+                    "issue '{}' comments cursor did not advance",
+                    issue_id
+                )));
+            }
+            after = next_after;
+        }
+
+        Err(TrackerError::PaginationStalled(format!(
+            "issue '{}' comments did not terminate after {} pages",
+            issue_id, MAX_PAGES
+        )))
+    }
+
     fn get_issue_history(&self, issue_id: &str) -> Result<Vec<IssueHistoryEvent>> {
         // Generous backstop against a server that keeps reporting `hasNextPage`
         // without advancing the cursor; large enough never to truncate a real

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, anyhow};
 use serde::Deserialize;
 use tracker_core::{
     CreateIssue, CustomFieldUpdate, Issue, IssueTracker, ProjectCustomField, UpdateIssue,
-    canonical_field_name, fetch_all_pages, get_max_results, unicode_eq_ignore_case,
+    canonical_field_name, get_max_results, unicode_eq_ignore_case,
 };
 
 /// Shared fields for create, update, and batch-update commands.
@@ -1065,11 +1065,9 @@ fn handle_comments(
     format: OutputFormat,
 ) -> Result<()> {
     let comments = if all {
-        fetch_all_pages(
-            |offset, page_limit| client.get_comments_page(id, page_limit, offset),
-            100,
-        )
-        .with_context(|| format!("Failed to get comments for issue '{}'", id))?
+        client
+            .get_all_comments(id, get_max_results())
+            .with_context(|| format!("Failed to get comments for issue '{}'", id))?
     } else {
         client
             .get_comments_page(id, limit, 0)

--- a/crates/tracker-core/src/traits.rs
+++ b/crates/tracker-core/src/traits.rs
@@ -257,6 +257,23 @@ pub trait IssueTracker: Send + Sync {
             .collect())
     }
 
+    /// Fetch all comments on an issue, auto-paginating up to `max_results`.
+    ///
+    /// The default implementation pages through [`Self::get_comments_page`] in
+    /// offset windows of 100, deduplicating by comment id and failing with
+    /// [`crate::TrackerError::PaginationStalled`] if a full page yields no new
+    /// comments. Backends whose native APIs are cursor-based, or whose
+    /// `get_comments_page` emulates offsets client-side, should override this
+    /// with a native one-pass walk.
+    fn get_all_comments(&self, issue_id: &str, max_results: usize) -> Result<Vec<Comment>> {
+        crate::pagination::fetch_all_pages_keyed(
+            |offset, limit| self.get_comments_page(issue_id, limit, offset),
+            100,
+            max_results,
+            |comment: &Comment| comment.id.clone(),
+        )
+    }
+
     // ========== History Operations ==========
 
     /// Get an issue's change history (the field-transition timeline).
@@ -390,17 +407,30 @@ mod tests {
     /// failure mode where the server ignores the offset parameter.
     struct StubTracker {
         issues: Vec<Issue>,
+        comments: Vec<Comment>,
         ignore_skip: bool,
         calls: Mutex<Vec<(usize, usize)>>,
+        comment_calls: Mutex<Vec<(usize, usize)>>,
     }
 
     impl StubTracker {
         fn new(count: usize, ignore_skip: bool) -> Self {
             Self {
                 issues: (1..=count).map(test_issue).collect(),
+                comments: (1..=count).map(test_comment).collect(),
                 ignore_skip,
                 calls: Mutex::new(Vec::new()),
+                comment_calls: Mutex::new(Vec::new()),
             }
+        }
+    }
+
+    fn test_comment(n: usize) -> Comment {
+        Comment {
+            id: format!("comment-{n}"),
+            text: format!("Comment {n}"),
+            author: None,
+            created: None,
         }
     }
 
@@ -461,6 +491,17 @@ mod tests {
         fn get_comments(&self, _: &str) -> Result<Vec<Comment>> {
             unimplemented!()
         }
+        fn get_comments_page(&self, _: &str, limit: usize, skip: usize) -> Result<Vec<Comment>> {
+            self.comment_calls.lock().unwrap().push((skip, limit));
+            let skip = if self.ignore_skip { 0 } else { skip };
+            Ok(self
+                .comments
+                .iter()
+                .skip(skip)
+                .take(limit)
+                .cloned()
+                .collect())
+        }
     }
 
     #[test]
@@ -493,5 +534,37 @@ mod tests {
         let result = tracker.search_all_issues("query", 1000);
         assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
         assert_eq!(tracker.calls.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn get_all_comments_default_pages_with_offset() {
+        let tracker = StubTracker::new(150, false);
+        let result = tracker.get_all_comments("TEST-1", 1000).unwrap();
+        assert_eq!(result.len(), 150);
+        assert_eq!(result[0].id, "comment-1");
+        assert_eq!(result[149].id, "comment-150");
+        assert_eq!(
+            *tracker.comment_calls.lock().unwrap(),
+            vec![(0, 100), (100, 100)]
+        );
+    }
+
+    #[test]
+    fn get_all_comments_default_respects_max_results() {
+        let tracker = StubTracker::new(250, false);
+        let result = tracker.get_all_comments("TEST-1", 125).unwrap();
+        assert_eq!(result.len(), 125);
+        assert_eq!(
+            *tracker.comment_calls.lock().unwrap(),
+            vec![(0, 100), (100, 25)]
+        );
+    }
+
+    #[test]
+    fn get_all_comments_default_errors_when_backend_ignores_skip() {
+        let tracker = StubTracker::new(250, true);
+        let result = tracker.get_all_comments("TEST-1", 1000);
+        assert!(matches!(result, Err(TrackerError::PaginationStalled(_))));
+        assert_eq!(tracker.comment_calls.lock().unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
## Why

`track issue comments --all` is intended for complete comment exports, but the previous implementation shared the offset-window default path. That is fine for a single page, but inefficient for multi-page threads on backends whose native APIs do not support direct offset reads.

Linear comments are cursor-paginated. The default `get_all_comments` path repeatedly called `get_comments_page(skip=N)`, and each offset window had to replay earlier cursor pages to reach `N`. For `P` comment pages, that costs `P` issue lookups plus `1 + 2 + ... + P` comment-page GraphQL calls. A 10-page thread is therefore 65 GraphQL requests. The native all-comments path resolves the issue once and walks each cursor page once, so the same 10-page thread is 11 GraphQL requests.

GitLab notes are page-paginated, but offset emulation through `get_comments_page` still refetches prior note pages for each successive `--all` window. For 10 pages, the old path could issue 55 notes-page requests; the native all-comments path issues 10.

This is an API round-trip optimization for `issue comments --all`, not a JSON/output formatting change.

## Summary

- Add `IssueTracker::get_all_comments(issue_id, max_results)` with keyed default pagination and stall detection.
- Route `track issue comments --all` through `get_all_comments`; limited comment reads still use `get_comments_page`.
- Override GitLab and Linear with native one-pass paging.
- Preserve the existing `TRACK_MAX_RESULTS` cap for `--all`.

## Design Notes

- Linear still resolves the readable issue id once before walking comments because the comments query keys on the internal issue id.
- Linear detects empty pages with `hasNextPage=true` and non-advancing cursors so it fails loudly instead of looping or silently truncating.
- GitLab continues filtering system notes, but page termination remains based on raw note page size so a page containing only system notes does not prematurely stop a later user-note page.
- Other backends keep the trait default until they need a native pagination override.
- The merge conflict with `main` was resolved by retaining both #275's all-articles helper/tests and this PR's all-comments helper/tests.

## Validation

- `cargo fmt --all --check`
- `cargo test -p tracker-core`
- `cargo test -p linear-backend get_all_comments`
- `cargo test -p gitlab-backend get_all_comments`
- `cargo test -p track test_issue_comments_all_fetches_multiple_pages`

## Latest Branch State

- Merged current `origin/main` into `codex/perf-comments-all` and resolved conflicts in `crates/tracker-core/src/traits.rs` and `crates/linear-backend/src/client_tests.rs`.
- Latest commit: `7d899ce Merge origin/main into perf comments pagination`
