### PR TITLE
feat(backends): surface all issue fields losslessly (#277)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -572,11 +572,12 @@ track --format json p ls    # JSON
 ### Jira
 - **Knowledge Base**: Uses Confluence API (automatically at same domain with `/wiki` path)
 - **Authentication**: Basic Auth with email and API token
-- **Rich Text**: Uses Atlassian Document Format (ADF) for descriptions
+- **Rich Text**: Uses Atlassian Document Format (ADF) for descriptions. ADF rich-text *custom* fields (e.g. "Repro Steps", "Expected Results") are surfaced as rendered plain text, the same way descriptions and comments are.
 - **Project Creation**: Requires admin permissions (use web interface)
 - **Subtasks**: Create as subtask with `--parent`, or link existing issues with `issue link -t subtask`
 - **Labels**: Map to tags
-- **Components**: Jira's standard Components field is surfaced as a `Components` multi-value custom field on `issue get`/`issue search` (read-only for now; filter server-side with JQL such as `component = "Rendering"`)
+- **System & custom fields**: `issue get`/`issue search` surface *all* populated fields Jira returns — standard system fields (`fixVersions`, `reporter`, `environment`, `duedate`, `resolution`, …) and every custom field — as `custom_fields` entries, not just a hardcoded subset. Single-issue reads (`track <KEY>`) fetch the full field set too. Anything that can't be mapped to a typed variant is preserved verbatim as `Unknown { value }`, so no data is lost. `--field <name>` write attempts flow straight to Jira; if a field isn't editable, Jira's error is surfaced.
+- **Components**: Jira's standard Components field is surfaced as a `Components` multi-value custom field. To filter by area, use server-side JQL such as `component = "Rendering"`.
 
 ### GitHub
 - **Scope**: Repository-scoped (requires owner and repo configuration)

--- a/agent-skills/SKILL.md
+++ b/agent-skills/SKILL.md
@@ -371,7 +371,8 @@ track completions zsh      # Shell completions (bash|zsh|fish|powershell|elvish)
     {"SingleEnum": {"name": "Priority", "value": "Major"}},
     {"SingleUser": {"name": "Assignee", "login": "...", "display_name": "..."}},
     {"Text":       {"name": "...", "value": "..."}},
-    {"MultiEnum":  {"name": "Components", "values": ["Rendering", "Audio"]}}
+    {"MultiEnum":  {"name": "Components", "values": ["Rendering", "Audio"]}},
+    {"Unknown":    {"name": "Sprint", "value": [{"id": 12, "name": "Sprint 4", "state": "active"}]}}
   ],
   "tags": [{"id": "...", "name": "..."}],
   "created": "2024-01-15T10:00:00Z", "updated": "...",
@@ -380,7 +381,8 @@ track completions zsh      # Shell completions (bash|zsh|fish|powershell|elvish)
 ```
 
 - `custom_fields` entries are **externally tagged** — the variant name (`State`, `SingleEnum`, ...) is the JSON key.
-- **Jira `Components`** (the standard subsystem/area field) is surfaced as a `MultiEnum` custom field named `Components`. To find issues by area, read `custom_fields` for that entry (or filter server-side with JQL, e.g. `component = "Rendering"`). Setting components on create/update is not yet supported.
+- `custom_fields` is a **best-effort-lossless projection**: every backend surfaces a field as the most specific variant it can (`State`/`SingleEnum`/`SingleUser`/`Text`/`MultiEnum`), and anything it can't classify is preserved verbatim as `{"Unknown": {"name": "...", "value": <raw json>}}`. `value` is omitted only when the value is structurally unretrievable. This is additive — older consumers that read just `name` still work.
+- **Jira** surfaces *all* populated fields (system fields like `fixVersions`/`reporter`/`environment` and every custom field), not a hardcoded subset; ADF rich-text custom fields render to plain text. **`Components`** is a `MultiEnum` named `Components` — filter by area server-side with JQL, e.g. `component = "Rendering"`.
 - `resolved` is the **resolution timestamp**, not a closed flag: it can be `null` even for Done issues (e.g. a Jira workflow that never sets Resolution). Test closedness via the State field's `is_resolved`.
 - **`--full`** wraps the issue in an envelope: `{"issue": {...}, "links": [{"id", "direction", "link_type", "issues": [...]}], "comments": [{"id", "text", "author", "created"}]}`. Attachments are NOT included — use `track i attachments`.
 - **`i s -o json`** returns a bare array — no total or pagination metadata (hints go to stderr in text mode only).

--- a/crates/github-backend/src/convert.rs
+++ b/crates/github-backend/src/convert.rs
@@ -49,6 +49,27 @@ pub fn github_issue_to_core(issue: GitHubIssue, owner: &str, repo: &str) -> Issu
         });
     }
 
+    // Catch-all: surface every field GitHub returned that no named field
+    // claimed (captured by `#[serde(flatten)]` into `issue.extra`). This keeps
+    // the projection lossless per the CustomField contract — present values are
+    // typed if provable and otherwise round-tripped via Unknown{value}. Keys
+    // are sorted for deterministic output. `issue.extra` is borrowed here and
+    // is not moved into the `Issue {..}` below, so the borrow is fine.
+    let mut keys: Vec<&String> = issue.extra.keys().collect();
+    keys.sort();
+    for key in keys {
+        let value = &issue.extra[key];
+        if value.is_null() {
+            continue;
+        }
+        if is_github_noise(key) {
+            continue;
+        }
+        if let Some(cf) = github_json_to_custom_field(key.clone(), value) {
+            custom_fields.push(cf);
+        }
+    }
+
     let tags: Vec<Tag> = issue
         .labels
         .iter()
@@ -73,6 +94,167 @@ pub fn github_issue_to_core(issue: GitHubIssue, owner: &str, repo: &str) -> Issu
         created: parse_github_datetime(&issue.created_at).unwrap_or_else(Utc::now),
         updated: parse_github_datetime(&issue.updated_at).unwrap_or_else(Utc::now),
         resolved: issue.closed_at.as_deref().and_then(parse_github_datetime),
+    }
+}
+
+/// GitHub issue-payload keys that carry no reporting value and are deliberately
+/// dropped from the lossless projection (the per-backend NOISE denylist allowed
+/// by the [`CustomField`] contract).
+///
+/// This covers hypermedia link keys (`url` and any `*_url`) plus a fixed set of
+/// API-plumbing / UI-only fields. Everything else GitHub returns is surfaced.
+fn is_github_noise(key: &str) -> bool {
+    key == "url"
+        || key.ends_with("_url")
+        || matches!(
+            key,
+            "node_id"
+                | "reactions"
+                | "performed_via_github_app"
+                | "author_association"
+                | "active_lock_reason"
+                | "locked"
+                | "comments"
+                | "score"
+                | "draft"
+                | "repository"
+                | "sub_issues_summary"
+                | "timeline_url"
+                | "events_url"
+        )
+}
+
+/// Project a single raw GitHub field value onto the most specific
+/// [`CustomField`] variant we can prove, falling back to `Unknown { value }` so
+/// the payload round-trips verbatim. Returns `None` only when the value carries
+/// nothing to surface (e.g. an empty array).
+fn github_json_to_custom_field(name: String, value: &serde_json::Value) -> Option<CustomField> {
+    use serde_json::Value;
+    match value {
+        Value::String(s) => Some(CustomField::Text {
+            name,
+            value: Some(s.clone()),
+        }),
+        Value::Number(n) => Some(CustomField::Text {
+            name,
+            value: Some(format_github_number(n)),
+        }),
+        Value::Bool(b) => Some(CustomField::Text {
+            name,
+            value: Some(b.to_string()),
+        }),
+        Value::Object(map) => {
+            // A user-shaped object (`login`) becomes a SingleUser; a named
+            // object (`name`/`title`) becomes a SingleEnum; anything richer
+            // round-trips as Unknown.
+            if let Some(login) = map.get("login").and_then(|v| v.as_str()) {
+                let display_name = map
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(login)
+                    .to_string();
+                Some(CustomField::SingleUser {
+                    name,
+                    login: Some(login.to_string()),
+                    display_name: Some(display_name),
+                })
+            } else if let Some(label) = map
+                .get("name")
+                .and_then(|v| v.as_str())
+                .or_else(|| map.get("title").and_then(|v| v.as_str()))
+            {
+                Some(CustomField::SingleEnum {
+                    name,
+                    value: Some(label.to_string()),
+                })
+            } else {
+                Some(CustomField::Unknown {
+                    name,
+                    value: Some(value.clone()),
+                })
+            }
+        }
+        Value::Array(arr) => github_json_array_to_custom_field(name, arr, value),
+        Value::Null => None,
+    }
+}
+
+/// Display keys an array item may carry while still counting as a "plain"
+/// single-display-key object (vs. a rich object that forces Unknown).
+const GITHUB_ARRAY_DISPLAY_KEYS: [&str; 5] = ["name", "title", "value", "login", "display_name"];
+
+/// Project an array value. Per the maintainer HEURISTIC: an array whose items
+/// are rich objects (more than one key, or a key outside the display-key set)
+/// or nested arrays round-trips whole as `Unknown { value }`; plain string /
+/// single-display-key arrays become a `MultiEnum`. `whole` is the original
+/// array `Value` so Unknown can carry it verbatim.
+fn github_json_array_to_custom_field(
+    name: String,
+    arr: &[serde_json::Value],
+    whole: &serde_json::Value,
+) -> Option<CustomField> {
+    use serde_json::Value;
+    if arr.is_empty() {
+        return None;
+    }
+
+    // Detect any item that disqualifies the array from MultiEnum.
+    let has_rich_item = arr.iter().any(|item| match item {
+        Value::Array(_) => true,
+        Value::Object(map) => {
+            map.len() > 1
+                || map
+                    .keys()
+                    .any(|k| !GITHUB_ARRAY_DISPLAY_KEYS.contains(&k.as_str()))
+        }
+        _ => false,
+    });
+    if has_rich_item {
+        return Some(CustomField::Unknown {
+            name,
+            value: Some(whole.clone()),
+        });
+    }
+
+    // Collect display strings from plain items.
+    let values: Vec<String> = arr
+        .iter()
+        .filter_map(|item| match item {
+            Value::String(s) => Some(s.clone()),
+            Value::Number(n) => Some(format_github_number(n)),
+            Value::Bool(b) => Some(b.to_string()),
+            Value::Object(map) => GITHUB_ARRAY_DISPLAY_KEYS
+                .iter()
+                .find_map(|k| map.get(*k).and_then(|v| v.as_str()))
+                .map(|s| s.to_string()),
+            _ => None,
+        })
+        .collect();
+
+    if values.is_empty() {
+        // Items existed but none yielded a display string — round-trip whole.
+        Some(CustomField::Unknown {
+            name,
+            value: Some(whole.clone()),
+        })
+    } else {
+        Some(CustomField::MultiEnum { name, values })
+    }
+}
+
+/// Format a JSON number for display, stripping `.0` from whole values. Mirrors
+/// the jira backend's `format_number`.
+fn format_github_number(n: &serde_json::Number) -> String {
+    if let Some(i) = n.as_i64() {
+        i.to_string()
+    } else if let Some(f) = n.as_f64() {
+        if f.fract() == 0.0 {
+            (f as i64).to_string()
+        } else {
+            f.to_string()
+        }
+    } else {
+        n.to_string()
     }
 }
 

--- a/crates/github-backend/src/convert.rs
+++ b/crates/github-backend/src/convert.rs
@@ -49,6 +49,21 @@ pub fn github_issue_to_core(issue: GitHubIssue, owner: &str, repo: &str) -> Issu
         });
     }
 
+    if !issue.assignees.is_empty() {
+        let value =
+            serde_json::to_value(&issue.assignees).expect("GitHub assignees should serialize");
+        if let Some(cf) = github_json_to_custom_field("assignees".to_string(), &value) {
+            custom_fields.push(cf);
+        }
+    }
+
+    if let Some(user) = issue.user.as_ref() {
+        let value = serde_json::to_value(user).expect("GitHub user should serialize");
+        if let Some(cf) = github_json_to_custom_field("user".to_string(), &value) {
+            custom_fields.push(cf);
+        }
+    }
+
     // Catch-all: surface every field GitHub returned that no named field
     // claimed (captured by `#[serde(flatten)]` into `issue.extra`). This keeps
     // the projection lossless per the CustomField contract — present values are
@@ -247,6 +262,8 @@ fn github_json_array_to_custom_field(
 fn format_github_number(n: &serde_json::Number) -> String {
     if let Some(i) = n.as_i64() {
         i.to_string()
+    } else if let Some(u) = n.as_u64() {
+        u.to_string()
     } else if let Some(f) = n.as_f64() {
         if f.fract() == 0.0 {
             (f as i64).to_string()

--- a/crates/github-backend/src/convert_tests.rs
+++ b/crates/github-backend/src/convert_tests.rs
@@ -258,6 +258,19 @@ mod tests {
     }
 
     #[test]
+    fn projection_preserves_large_unsigned_numbers() {
+        let issue = issue_from_json(serde_json::json!({ "database_id": u64::MAX }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        match fields_named(&core.custom_fields, "database_id")[0] {
+            CustomField::Text { value, .. } => {
+                assert_eq!(value.as_deref(), Some("18446744073709551615"));
+            }
+            other => panic!("expected Text, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn projection_drops_noise_keys() {
         let issue = issue_from_json(serde_json::json!({
             "html_url": "https://github.com/owner/repo/issues/42",
@@ -343,6 +356,81 @@ mod tests {
                 assert_eq!(display_name.as_deref(), Some("alice"));
             }
             other => panic!("expected SingleUser, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn projection_surfaces_named_user_consumed_before_extra() {
+        let issue = issue_from_json(serde_json::json!({
+            "user": {
+                "login": "reporter",
+                "id": 9,
+                "avatar_url": "https://avatars.example/reporter"
+            }
+        }));
+        assert!(
+            !issue.extra.contains_key("user"),
+            "named user should be consumed before flatten extra"
+        );
+
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        let matches = fields_named(&core.custom_fields, "user");
+        assert_eq!(matches.len(), 1);
+        match matches[0] {
+            CustomField::SingleUser {
+                login,
+                display_name,
+                ..
+            } => {
+                assert_eq!(login.as_deref(), Some("reporter"));
+                assert_eq!(display_name.as_deref(), Some("reporter"));
+            }
+            other => panic!("expected SingleUser, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn projection_preserves_named_assignees_without_replacing_assignee() {
+        let assignees = serde_json::json!([
+            {
+                "login": "alice",
+                "id": 7,
+                "avatar_url": "https://avatars.example/alice",
+                "type": "User"
+            },
+            {
+                "login": "bob",
+                "id": 8,
+                "avatar_url": "https://avatars.example/bob",
+                "type": "User"
+            }
+        ]);
+        let issue = issue_from_json(serde_json::json!({
+            "assignee": { "login": "alice", "id": 7 },
+            "assignees": assignees.clone()
+        }));
+        assert!(
+            !issue.extra.contains_key("assignees"),
+            "named assignees should be consumed before flatten extra"
+        );
+
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        let assignee = fields_named(&core.custom_fields, "Assignee");
+        assert_eq!(assignee.len(), 1);
+        match assignee[0] {
+            CustomField::SingleUser { login, .. } => assert_eq!(login.as_deref(), Some("alice")),
+            other => panic!("expected SingleUser, got {:?}", other),
+        }
+
+        let matches = fields_named(&core.custom_fields, "assignees");
+        assert_eq!(matches.len(), 1);
+        match matches[0] {
+            CustomField::Unknown { value, .. } => {
+                assert_eq!(value.as_ref(), Some(&assignees));
+            }
+            other => panic!("expected Unknown, got {:?}", other),
         }
     }
 

--- a/crates/github-backend/src/convert_tests.rs
+++ b/crates/github-backend/src/convert_tests.rs
@@ -184,4 +184,212 @@ mod tests {
             );
         }
     }
+
+    // ------------------------------------------------------------------
+    // Lossless custom-field projection (issue #277)
+    // ------------------------------------------------------------------
+
+    use crate::convert::github_issue_to_core;
+    use crate::models::GitHubIssue;
+    use tracker_core::CustomField;
+
+    /// Build a GitHubIssue from a JSON object that supplies the required base
+    /// fields plus whatever extra keys the test exercises. `#[serde(flatten)]`
+    /// routes the extras into `issue.extra`.
+    fn issue_from_json(extra: serde_json::Value) -> GitHubIssue {
+        let mut base = serde_json::json!({
+            "id": 1,
+            "number": 42,
+            "title": "Example issue",
+            "body": null,
+            "state": "open",
+            "created_at": "2024-01-01T10:00:00Z",
+            "updated_at": "2024-01-02T10:00:00Z",
+            "closed_at": null
+        });
+        let map = base.as_object_mut().unwrap();
+        for (k, v) in extra.as_object().unwrap() {
+            map.insert(k.clone(), v.clone());
+        }
+        serde_json::from_value(base).unwrap()
+    }
+
+    /// Find custom fields surfaced under `name` (case-sensitive).
+    fn fields_named<'a>(fields: &'a [CustomField], name: &str) -> Vec<&'a CustomField> {
+        fields
+            .iter()
+            .filter(|cf| match cf {
+                CustomField::SingleEnum { name: n, .. }
+                | CustomField::State { name: n, .. }
+                | CustomField::SingleUser { name: n, .. }
+                | CustomField::Text { name: n, .. }
+                | CustomField::MultiEnum { name: n, .. }
+                | CustomField::Unknown { name: n, .. } => n == name,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn projection_surfaces_scalar_as_text() {
+        let issue = issue_from_json(serde_json::json!({ "state_reason": "completed" }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        let matches = fields_named(&core.custom_fields, "state_reason");
+        assert_eq!(matches.len(), 1);
+        match matches[0] {
+            CustomField::Text { value, .. } => assert_eq!(value.as_deref(), Some("completed")),
+            other => panic!("expected Text, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn projection_strips_trailing_zero_from_numbers() {
+        let issue = issue_from_json(serde_json::json!({ "weight": 3.0, "count": 7 }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        match fields_named(&core.custom_fields, "weight")[0] {
+            CustomField::Text { value, .. } => assert_eq!(value.as_deref(), Some("3")),
+            other => panic!("expected Text, got {:?}", other),
+        }
+        match fields_named(&core.custom_fields, "count")[0] {
+            CustomField::Text { value, .. } => assert_eq!(value.as_deref(), Some("7")),
+            other => panic!("expected Text, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn projection_drops_noise_keys() {
+        let issue = issue_from_json(serde_json::json!({
+            "html_url": "https://github.com/owner/repo/issues/42",
+            "node_id": "I_abc123",
+            "reactions": { "total_count": 3, "+1": 2 },
+            "author_association": "OWNER"
+        }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        for noise in ["html_url", "node_id", "reactions", "author_association"] {
+            assert!(
+                fields_named(&core.custom_fields, noise).is_empty(),
+                "noise key {} leaked into projection",
+                noise
+            );
+        }
+    }
+
+    #[test]
+    fn projection_does_not_duplicate_typed_fields() {
+        // Real state/assignee/milestone live on named fields and are surfaced by
+        // the hardcoded pushes. They must NOT also appear via `extra`, proving
+        // serde flatten never re-captures a matched key.
+        let issue = issue_from_json(serde_json::json!({
+            "state": "closed",
+            "assignee": { "login": "alice", "id": 7 },
+            "milestone": { "id": 1, "number": 1, "title": "v1.0" }
+        }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        // Exactly one Status (from named `state`), is_resolved true.
+        let status = fields_named(&core.custom_fields, "Status");
+        assert_eq!(status.len(), 1);
+        match status[0] {
+            CustomField::State {
+                value, is_resolved, ..
+            } => {
+                assert_eq!(value.as_deref(), Some("closed"));
+                assert!(is_resolved);
+            }
+            other => panic!("expected State, got {:?}", other),
+        }
+
+        // Exactly one Assignee SingleUser from the named field.
+        let assignee = fields_named(&core.custom_fields, "Assignee");
+        assert_eq!(assignee.len(), 1);
+        match assignee[0] {
+            CustomField::SingleUser { login, .. } => assert_eq!(login.as_deref(), Some("alice")),
+            other => panic!("expected SingleUser, got {:?}", other),
+        }
+
+        // Exactly one Milestone SingleEnum from the named field.
+        let milestone = fields_named(&core.custom_fields, "Milestone");
+        assert_eq!(milestone.len(), 1);
+        match milestone[0] {
+            CustomField::SingleEnum { value, .. } => assert_eq!(value.as_deref(), Some("v1.0")),
+            other => panic!("expected SingleEnum, got {:?}", other),
+        }
+
+        // No lowercase leak from extra (proves no duplication).
+        assert!(fields_named(&core.custom_fields, "state").is_empty());
+        assert!(fields_named(&core.custom_fields, "assignee").is_empty());
+        assert!(fields_named(&core.custom_fields, "milestone").is_empty());
+    }
+
+    #[test]
+    fn projection_surfaces_user_object_as_single_user() {
+        let issue = issue_from_json(serde_json::json!({
+            "closed_by": { "login": "alice", "id": 7 }
+        }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        let matches = fields_named(&core.custom_fields, "closed_by");
+        assert_eq!(matches.len(), 1);
+        match matches[0] {
+            CustomField::SingleUser {
+                login,
+                display_name,
+                ..
+            } => {
+                assert_eq!(login.as_deref(), Some("alice"));
+                // No `name` on the object, so display falls back to login.
+                assert_eq!(display_name.as_deref(), Some("alice"));
+            }
+            other => panic!("expected SingleUser, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn projection_array_of_strings_is_multi_enum() {
+        let issue = issue_from_json(serde_json::json!({
+            "topics": ["alpha", "beta", "gamma"]
+        }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        let matches = fields_named(&core.custom_fields, "topics");
+        assert_eq!(matches.len(), 1);
+        match matches[0] {
+            CustomField::MultiEnum { values, .. } => {
+                assert_eq!(values, &vec!["alpha", "beta", "gamma"]);
+            }
+            other => panic!("expected MultiEnum, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn projection_array_of_rich_objects_is_unknown_whole() {
+        let arr = serde_json::json!([
+            { "login": "alice", "id": 7, "type": "User" },
+            { "login": "bob", "id": 8, "type": "User" }
+        ]);
+        let issue = issue_from_json(serde_json::json!({ "requested_reviewers": arr.clone() }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        let matches = fields_named(&core.custom_fields, "requested_reviewers");
+        assert_eq!(matches.len(), 1);
+        match matches[0] {
+            CustomField::Unknown { value, .. } => {
+                assert_eq!(value.as_ref(), Some(&arr));
+            }
+            other => panic!("expected Unknown, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn projection_skips_null_extra() {
+        let issue = issue_from_json(serde_json::json!({ "state_reason": null }));
+        let core = github_issue_to_core(issue, "owner", "repo");
+
+        assert!(
+            fields_named(&core.custom_fields, "state_reason").is_empty(),
+            "null extra should not be surfaced"
+        );
+    }
 }

--- a/crates/github-backend/src/models/issue.rs
+++ b/crates/github-backend/src/models/issue.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use super::label::GitHubLabel;
 
@@ -43,6 +46,12 @@ pub struct GitHubIssue {
     pub user: Option<GitHubUser>,
     /// If present (non-null), this "issue" is actually a pull request
     pub pull_request: Option<GitHubPullRequest>,
+    /// Any field GitHub returned that no named field above claimed. Serde
+    /// `flatten` only captures unmatched keys, so typed fields are never
+    /// duplicated here and a typed field's own deserialize failure is never
+    /// masked. Surfaced losslessly as custom fields by the converter.
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
 impl GitHubIssue {

--- a/crates/github-backend/src/models/issue.rs
+++ b/crates/github-backend/src/models/issue.rs
@@ -10,6 +10,8 @@ use super::label::GitHubLabel;
 pub struct GitHubUser {
     pub login: String,
     pub id: u64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
 /// GitHub milestone

--- a/crates/gitlab-backend/src/convert.rs
+++ b/crates/gitlab-backend/src/convert.rs
@@ -39,6 +39,80 @@ pub fn gitlab_issue_to_core(issue: GitLabIssue, project_id: &str) -> tracker_cor
         });
     }
 
+    // --- Step A: typed promotions for high-value fields. ---
+    if let Some(w) = issue.weight {
+        custom_fields.push(CustomField::Text {
+            name: "Weight".into(),
+            value: Some(w.to_string()),
+        });
+    }
+    if let Some(d) = issue.due_date.clone().filter(|s| !s.is_empty()) {
+        custom_fields.push(CustomField::Text {
+            name: "Due Date".into(),
+            value: Some(d),
+        });
+    }
+    custom_fields.push(CustomField::Text {
+        name: "Confidential".into(),
+        value: Some(issue.confidential.to_string()),
+    });
+
+    // --- Step B: surface any remaining API fields losslessly. ---
+    // NOISE: fields that are structural/transport noise, not user-facing data.
+    const NOISE: &[&str] = &[
+        "web_url",
+        "_links",
+        "references",
+        "time_stats",
+        "task_completion_status",
+        "epic_iid",
+        "project_id",
+        "id",
+        "iid",
+        "subscribed",
+        "user_notes_count",
+        "blocking_issues_count",
+        "upvotes",
+        "downvotes",
+        "merge_requests_count",
+        "moved_to_id",
+        "service_desk_reply_to",
+        "imported",
+        "imported_from",
+    ];
+    // Fields already surfaced as typed/hardcoded variants above.
+    let known_titles = [
+        "Status",
+        "Assignee",
+        "Milestone",
+        "Weight",
+        "Due Date",
+        "Confidential",
+    ];
+
+    // Sort keys for deterministic output ordering.
+    let mut extra_keys: Vec<&String> = issue.extra.keys().collect();
+    extra_keys.sort();
+    for key in extra_keys {
+        if NOISE.contains(&key.as_str()) {
+            continue;
+        }
+        let val = &issue.extra[key];
+        if val.is_null() {
+            continue;
+        }
+        let title = canonical_field_name(key);
+        if known_titles
+            .iter()
+            .any(|kt| kt.eq_ignore_ascii_case(&title))
+        {
+            continue;
+        }
+        if let Some(field) = classify_gitlab_extra(&title, val) {
+            custom_fields.push(field);
+        }
+    }
+
     let tags: Vec<Tag> = issue
         .labels
         .iter()
@@ -64,6 +138,122 @@ pub fn gitlab_issue_to_core(issue: GitLabIssue, project_id: &str) -> tracker_cor
         updated: parse_gitlab_datetime(&issue.updated_at).unwrap_or_else(Utc::now),
         resolved: parse_gitlab_datetime(&issue.closed_at),
     }
+}
+
+/// Classify a single unmodeled GitLab issue field into the most specific
+/// [`CustomField`] variant we can prove. Per the projection contract, a
+/// present-but-untypeable value falls back to `Unknown { value: Some(raw) }`.
+fn classify_gitlab_extra(name: &str, val: &serde_json::Value) -> Option<CustomField> {
+    use serde_json::Value;
+    match val {
+        Value::Null => None,
+        Value::String(s) => Some(CustomField::Text {
+            name: name.to_string(),
+            value: Some(s.clone()),
+        }),
+        Value::Bool(b) => Some(CustomField::Text {
+            name: name.to_string(),
+            value: Some(b.to_string()),
+        }),
+        Value::Number(n) => Some(CustomField::Text {
+            name: name.to_string(),
+            value: Some(n.to_string()),
+        }),
+        Value::Array(arr) => classify_array(name, arr),
+        Value::Object(obj) => {
+            // A user object: surface as SingleUser.
+            if obj.contains_key("username") {
+                return Some(CustomField::SingleUser {
+                    name: name.to_string(),
+                    login: obj
+                        .get("username")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    display_name: obj.get("name").and_then(|v| v.as_str()).map(String::from),
+                });
+            }
+            // A single-display-key reference (only `name`/`title`): surface that
+            // display value as SingleEnum. A richer object carrying sub-fields
+            // beyond the lone display key cannot be losslessly flattened, so per
+            // the array-of-objects heuristic (applied here to a single object)
+            // it is preserved verbatim as Unknown.
+            let display = obj
+                .get("name")
+                .or_else(|| obj.get("title"))
+                .and_then(|v| v.as_str());
+            let is_single_display_key =
+                obj.len() == 1 && (obj.contains_key("name") || obj.contains_key("title"));
+            match (display, is_single_display_key) {
+                (Some(d), true) => Some(CustomField::SingleEnum {
+                    name: name.to_string(),
+                    value: Some(d.to_string()),
+                }),
+                _ => Some(CustomField::Unknown {
+                    name: name.to_string(),
+                    value: Some(val.clone()),
+                }),
+            }
+        }
+    }
+}
+
+/// Classify an array field. Per the maintainer-decided array heuristic:
+/// - empty -> dropped (`None`)
+/// - all plain strings (or single-display-key objects whose only key is
+///   `name`/`title`) -> [`CustomField::MultiEnum`]
+/// - any rich object (sub-fields beyond a single display key) -> the whole
+///   array preserved as [`CustomField::Unknown`].
+fn classify_array(name: &str, arr: &[serde_json::Value]) -> Option<CustomField> {
+    use serde_json::Value;
+    if arr.is_empty() {
+        return None;
+    }
+
+    let mut values = Vec::with_capacity(arr.len());
+    for item in arr {
+        match item {
+            Value::String(s) => values.push(s.clone()),
+            Value::Object(obj) => {
+                // Acceptable only if its sole content is a single display key.
+                let is_single_display_key =
+                    obj.len() == 1 && (obj.contains_key("name") || obj.contains_key("title"));
+                if !is_single_display_key {
+                    // Rich object: preserve the whole array verbatim.
+                    return Some(CustomField::Unknown {
+                        name: name.to_string(),
+                        value: Some(Value::Array(arr.to_vec())),
+                    });
+                }
+                let display = obj
+                    .get("name")
+                    .or_else(|| obj.get("title"))
+                    .and_then(|v| v.as_str());
+                match display {
+                    Some(s) => values.push(s.to_string()),
+                    // Single display key present but not a string: not plainly
+                    // representable -> preserve the whole array.
+                    None => {
+                        return Some(CustomField::Unknown {
+                            name: name.to_string(),
+                            value: Some(Value::Array(arr.to_vec())),
+                        });
+                    }
+                }
+            }
+            // Numbers, bools, nested arrays, nulls: not a plain display list.
+            _ => {
+                return Some(CustomField::Unknown {
+                    name: name.to_string(),
+                    value: Some(Value::Array(arr.to_vec())),
+                });
+            }
+        }
+    }
+
+    Some(CustomField::MultiEnum {
+        name: name.to_string(),
+        values,
+    })
 }
 
 impl From<GitLabNote> for Comment {
@@ -858,5 +1048,197 @@ mod tests {
         assert_eq!(events[0].field, "labels");
         assert_eq!(events[0].from, None);
         assert_eq!(events[0].to, None);
+    }
+
+    // ==================== custom-field projection tests ====================
+
+    use crate::models::issue::GitLabIssue;
+    use serde_json::json;
+
+    /// Deserialize a GitLabIssue from JSON, filling in the minimal required
+    /// fields and merging the supplied extra keys.
+    fn issue_from_extra(extra: serde_json::Value) -> GitLabIssue {
+        let mut base = json!({
+            "id": 1,
+            "iid": 10,
+            "project_id": 100,
+            "title": "Test",
+            "state": "opened",
+        });
+        if let serde_json::Value::Object(extra_map) = extra {
+            let base_map = base.as_object_mut().unwrap();
+            for (k, v) in extra_map {
+                base_map.insert(k, v);
+            }
+        }
+        serde_json::from_value(base).expect("GitLabIssue should deserialize")
+    }
+
+    fn find_text<'a>(fields: &'a [CustomField], name: &str) -> Option<&'a Option<String>> {
+        fields.iter().find_map(|f| match f {
+            CustomField::Text { name: n, value } if n == name => Some(value),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn lossless_projection_promotes_and_surfaces() {
+        let issue = issue_from_extra(json!({
+            "weight": 5,
+            "due_date": "2024-06-01",
+            "confidential": true,
+            "discussion_locked": true,
+            "epic": { "id": 7, "iid": 2, "title": "Q3" },
+            "iteration": { "title": "Sprint 4" },
+        }));
+
+        let core = gitlab_issue_to_core(issue, "100");
+        let fields = &core.custom_fields;
+
+        // Typed promotions.
+        assert_eq!(find_text(fields, "Weight"), Some(&Some("5".to_string())));
+        assert_eq!(
+            find_text(fields, "Due Date"),
+            Some(&Some("2024-06-01".to_string()))
+        );
+        assert_eq!(
+            find_text(fields, "Confidential"),
+            Some(&Some("true".to_string()))
+        );
+
+        // Unmodeled scalar surfaced as Text.
+        assert_eq!(
+            find_text(fields, "discussion_locked"),
+            Some(&Some("true".to_string()))
+        );
+
+        // Unmodeled rich object (id+iid+title beyond a single display key) is
+        // preserved verbatim as Unknown.
+        let epic = fields
+            .iter()
+            .find_map(|f| match f {
+                CustomField::Unknown { name, value } if name == "epic" => Some(value),
+                _ => None,
+            })
+            .expect("epic should be Unknown");
+        assert_eq!(
+            epic.as_ref().unwrap(),
+            &json!({ "id": 7, "iid": 2, "title": "Q3" })
+        );
+
+        // A single-display-key object collapses to its display value (SingleEnum).
+        let iteration = fields.iter().find_map(|f| match f {
+            CustomField::SingleEnum { name, value } if name == "iteration" => Some(value),
+            _ => None,
+        });
+        assert_eq!(iteration, Some(&Some("Sprint 4".to_string())));
+    }
+
+    #[test]
+    fn no_duplication_of_typed_fields() {
+        let issue = issue_from_extra(json!({
+            "weight": 5,
+            "milestone": { "id": 1, "iid": 1, "title": "v1.0" },
+        }));
+
+        let core = gitlab_issue_to_core(issue, "100");
+        let fields = &core.custom_fields;
+
+        let weight_count = fields
+            .iter()
+            .filter(|f| matches!(f, CustomField::Text { name, .. } if name == "Weight"))
+            .count();
+        assert_eq!(weight_count, 1, "Weight should appear exactly once");
+
+        let milestone_count = fields
+            .iter()
+            .filter(|f| matches!(f, CustomField::SingleEnum { name, .. } if name == "Milestone"))
+            .count();
+        assert_eq!(milestone_count, 1, "Milestone should appear exactly once");
+    }
+
+    #[test]
+    fn noise_fields_are_not_surfaced() {
+        let issue = issue_from_extra(json!({
+            "web_url": "https://example.com/issues/10",
+            "_links": { "self": "https://example.com" },
+            "references": { "short": "#10" },
+            "user_notes_count": 3,
+            "upvotes": 2,
+        }));
+
+        let core = gitlab_issue_to_core(issue, "100");
+        for noise in [
+            "web_url",
+            "_links",
+            "references",
+            "user_notes_count",
+            "upvotes",
+        ] {
+            assert!(
+                !core.custom_fields.iter().any(|f| field_name(f) == noise),
+                "noise field {noise} should not be surfaced"
+            );
+        }
+    }
+
+    #[test]
+    fn null_values_are_skipped() {
+        let issue = issue_from_extra(json!({
+            "some_field": serde_json::Value::Null,
+        }));
+
+        let core = gitlab_issue_to_core(issue, "100");
+        assert!(
+            !core
+                .custom_fields
+                .iter()
+                .any(|f| field_name(f) == "some_field"),
+            "null-valued field should be skipped"
+        );
+    }
+
+    #[test]
+    fn array_heuristic_strings_vs_rich_objects() {
+        // Plain string array -> MultiEnum.
+        let issue = issue_from_extra(json!({ "tag_list": ["a", "b"] }));
+        let core = gitlab_issue_to_core(issue, "100");
+        let values = core
+            .custom_fields
+            .iter()
+            .find_map(|f| match f {
+                CustomField::MultiEnum { name, values } if name == "tag_list" => Some(values),
+                _ => None,
+            })
+            .expect("string array should be MultiEnum");
+        assert_eq!(values, &vec!["a".to_string(), "b".to_string()]);
+
+        // Array of rich objects -> Unknown preserving the whole array.
+        let issue = issue_from_extra(json!({ "things": [{ "id": 1, "state": "x" }] }));
+        let core = gitlab_issue_to_core(issue, "100");
+        let preserved = core
+            .custom_fields
+            .iter()
+            .find_map(|f| match f {
+                CustomField::Unknown { name, value } if name == "things" => Some(value),
+                _ => None,
+            })
+            .expect("rich-object array should be Unknown");
+        assert_eq!(
+            preserved.as_ref().unwrap(),
+            &json!([{ "id": 1, "state": "x" }])
+        );
+    }
+
+    /// Helper: the `name` of any CustomField variant.
+    fn field_name(f: &CustomField) -> &str {
+        match f {
+            CustomField::SingleEnum { name, .. }
+            | CustomField::State { name, .. }
+            | CustomField::SingleUser { name, .. }
+            | CustomField::Text { name, .. }
+            | CustomField::MultiEnum { name, .. }
+            | CustomField::Unknown { name, .. } => name,
+        }
     }
 }

--- a/crates/gitlab-backend/src/convert.rs
+++ b/crates/gitlab-backend/src/convert.rs
@@ -39,6 +39,21 @@ pub fn gitlab_issue_to_core(issue: GitLabIssue, project_id: &str) -> tracker_cor
         });
     }
 
+    if !issue.assignees.is_empty() {
+        let value =
+            serde_json::to_value(&issue.assignees).expect("GitLab assignees should serialize");
+        if let Some(field) = classify_gitlab_extra("assignees", &value) {
+            custom_fields.push(field);
+        }
+    }
+
+    if let Some(author) = issue.author.as_ref() {
+        let value = serde_json::to_value(author).expect("GitLab author should serialize");
+        if let Some(field) = classify_gitlab_extra("author", &value) {
+            custom_fields.push(field);
+        }
+    }
+
     // --- Step A: typed promotions for high-value fields. ---
     if let Some(w) = issue.weight {
         custom_fields.push(CustomField::Text {
@@ -849,6 +864,7 @@ mod tests {
             id: 1,
             username: username.to_string(),
             name: format!("{} Name", username),
+            extra: Default::default(),
         }
     }
 
@@ -1081,6 +1097,10 @@ mod tests {
         })
     }
 
+    fn fields_named<'a>(fields: &'a [CustomField], name: &str) -> Vec<&'a CustomField> {
+        fields.iter().filter(|f| field_name(f) == name).collect()
+    }
+
     #[test]
     fn lossless_projection_promotes_and_surfaces() {
         let issue = issue_from_extra(json!({
@@ -1155,6 +1175,86 @@ mod tests {
             .filter(|f| matches!(f, CustomField::SingleEnum { name, .. } if name == "Milestone"))
             .count();
         assert_eq!(milestone_count, 1, "Milestone should appear exactly once");
+    }
+
+    #[test]
+    fn named_author_consumed_before_extra_is_surfaced() {
+        let issue = issue_from_extra(json!({
+            "author": {
+                "id": 9,
+                "username": "reporter",
+                "name": "Reporter Name",
+                "web_url": "https://gitlab.example/reporter"
+            }
+        }));
+        assert!(
+            !issue.extra.contains_key("author"),
+            "named author should be consumed before flatten extra"
+        );
+
+        let core = gitlab_issue_to_core(issue, "100");
+
+        let matches = fields_named(&core.custom_fields, "author");
+        assert_eq!(matches.len(), 1);
+        match matches[0] {
+            CustomField::SingleUser {
+                login,
+                display_name,
+                ..
+            } => {
+                assert_eq!(login.as_deref(), Some("reporter"));
+                assert_eq!(display_name.as_deref(), Some("Reporter Name"));
+            }
+            other => panic!("expected SingleUser, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn named_assignees_are_preserved_without_replacing_assignee() {
+        let assignees = json!([
+            {
+                "id": 7,
+                "username": "alice",
+                "name": "Alice Name",
+                "web_url": "https://gitlab.example/alice"
+            },
+            {
+                "id": 8,
+                "username": "bob",
+                "name": "Bob Name",
+                "web_url": "https://gitlab.example/bob"
+            }
+        ]);
+        let issue = issue_from_extra(json!({
+            "assignee": {
+                "id": 7,
+                "username": "alice",
+                "name": "Alice Name"
+            },
+            "assignees": assignees.clone()
+        }));
+        assert!(
+            !issue.extra.contains_key("assignees"),
+            "named assignees should be consumed before flatten extra"
+        );
+
+        let core = gitlab_issue_to_core(issue, "100");
+
+        let assignee = fields_named(&core.custom_fields, "Assignee");
+        assert_eq!(assignee.len(), 1);
+        match assignee[0] {
+            CustomField::SingleUser { login, .. } => assert_eq!(login.as_deref(), Some("alice")),
+            other => panic!("expected SingleUser, got {:?}", other),
+        }
+
+        let matches = fields_named(&core.custom_fields, "assignees");
+        assert_eq!(matches.len(), 1);
+        match matches[0] {
+            CustomField::Unknown { value, .. } => {
+                assert_eq!(value.as_ref(), Some(&assignees));
+            }
+            other => panic!("expected Unknown, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/gitlab-backend/src/models/issue.rs
+++ b/crates/gitlab-backend/src/models/issue.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 /// GitLab user reference (used in assignee, author, etc.)
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -6,7 +7,10 @@ pub struct GitLabUser {
     pub id: u64,
     pub username: String,
     #[serde(default)]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub name: String,
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
 }
 
 /// GitLab milestone reference

--- a/crates/gitlab-backend/src/models/issue.rs
+++ b/crates/gitlab-backend/src/models/issue.rs
@@ -37,6 +37,15 @@ pub struct GitLabIssue {
     pub closed_at: Option<String>,
     pub author: Option<GitLabUser>,
     pub web_url: Option<String>,
+    #[serde(default)]
+    pub confidential: bool,
+    pub due_date: Option<String>,
+    pub weight: Option<i64>,
+    /// Catch-all for any API field not modeled above. Named fields are
+    /// consumed before this flatten, so there is no duplication. Surfaced
+    /// losslessly as custom fields during conversion (see `convert.rs`).
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 /// GitLab linked issue (response from GET /projects/:id/issues/:iid/links).

--- a/crates/jira-backend/src/client.rs
+++ b/crates/jira-backend/src/client.rs
@@ -158,7 +158,10 @@ impl JiraClient {
 
     /// Get an issue by key or ID
     pub fn get_issue(&self, key: &str) -> Result<JiraIssue> {
-        let url = self.api_url(&format!("/issue/{}", key));
+        // `fields=*all` mirrors the search endpoint so a single-issue read
+        // surfaces the same set of (system + custom) fields, keeping the
+        // lossless projection consistent between `get` and `search`.
+        let url = self.api_url(&format!("/issue/{}?fields=*all", key));
 
         let response = self
             .agent

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -68,6 +68,17 @@ pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
             .and_then(|u| u.display_name.clone()),
     });
 
+    // Map reporter as a SingleUser custom field. Unlike the extra/custom
+    // fields, `reporter` is a strongly-typed field that never reaches `extra`,
+    // so it is surfaced here in parallel with assignee.
+    if let Some(ref reporter) = j.fields.reporter {
+        custom_fields.push(CustomField::SingleUser {
+            name: "Reporter".to_string(),
+            login: reporter.account_id.clone(),
+            display_name: reporter.display_name.clone(),
+        });
+    }
+
     // Map issue type
     custom_fields.push(CustomField::SingleEnum {
         name: "Type".to_string(),
@@ -93,15 +104,43 @@ pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
         .filter_map(|f| f.schema.as_ref().map(|s| (f.id.as_str(), s)))
         .collect();
 
-    for (key, value) in &j.fields.extra {
-        if !key.starts_with("customfield_")
-            && key != "timeoriginalestimate"
-            && key != "timeestimate"
-            && key != "timetracking"
+    // Tracks the estimate display names already emitted, so the scalar
+    // `timeoriginalestimate`/`timeestimate` keys never re-emit an estimate the
+    // `timetracking` object already produced (Jira can populate both). A scalar
+    // that the timetracking object did NOT cover still emits once. The
+    // `timetracking` object is the authoritative source, so process it before
+    // the scalar keys regardless of the (unordered) HashMap iteration order.
+    let mut emitted_estimates: HashSet<&str> = HashSet::new();
+    if let Some(value) = j.fields.extra.get("timetracking")
+        && let Some(obj) = value.as_object()
+    {
+        if let Some(orig) = obj.get("originalEstimate")
+            && let Some(cf) =
+                json_value_to_custom_field("Original Estimate".to_string(), orig, None)
         {
+            emitted_estimates.insert("Original Estimate");
+            custom_fields.push(cf);
+        }
+        if let Some(rem) = obj.get("remainingEstimate")
+            && let Some(cf) =
+                json_value_to_custom_field("Remaining Estimate".to_string(), rem, None)
+        {
+            emitted_estimates.insert("Remaining Estimate");
+            custom_fields.push(cf);
+        }
+    }
+
+    for (key, value) in &j.fields.extra {
+        // Skip absent values and the enumerated noise denylist; surface
+        // everything else (system fields and custom fields alike) so the
+        // projection stays lossless.
+        if value.is_null() {
             continue;
         }
-        if value.is_null() {
+        if JIRA_NOISE_FIELDS
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case(key))
+        {
             continue;
         }
         let name = id_to_name
@@ -111,30 +150,23 @@ pub fn jira_issue_to_core(j: JiraIssue, jira_fields: &[JiraField]) -> Issue {
         let schema = id_to_schema.get(key.as_str()).copied();
 
         if key == "timetracking" {
-            if let Some(obj) = value.as_object() {
-                if let Some(orig) = obj.get("originalEstimate")
-                    && let Some(cf) =
-                        json_value_to_custom_field("Original Estimate".to_string(), orig, None)
-                {
-                    custom_fields.push(cf);
-                }
-                if let Some(rem) = obj.get("remainingEstimate")
-                    && let Some(cf) =
-                        json_value_to_custom_field("Remaining Estimate".to_string(), rem, None)
-                {
-                    custom_fields.push(cf);
-                }
-            }
+            // Already emitted above (authoritative estimate source); skip here
+            // so the object is never double-counted.
+            continue;
         } else if key == "timeoriginalestimate" {
-            if let Some(cf) =
-                json_value_to_custom_field("Original Estimate".to_string(), value, None)
+            if !emitted_estimates.contains("Original Estimate")
+                && let Some(cf) =
+                    json_value_to_custom_field("Original Estimate".to_string(), value, None)
             {
+                emitted_estimates.insert("Original Estimate");
                 custom_fields.push(cf);
             }
         } else if key == "timeestimate" {
-            if let Some(cf) =
-                json_value_to_custom_field("Remaining Estimate".to_string(), value, None)
+            if !emitted_estimates.contains("Remaining Estimate")
+                && let Some(cf) =
+                    json_value_to_custom_field("Remaining Estimate".to_string(), value, None)
             {
+                emitted_estimates.insert("Remaining Estimate");
                 custom_fields.push(cf);
             }
         } else if let Some(cf) = json_value_to_custom_field(name, value, schema) {
@@ -172,6 +204,28 @@ fn json_value_to_custom_field(
     value: &Value,
     schema: Option<&JiraFieldSchema>,
 ) -> Option<CustomField> {
+    // ADF rich-text documents ({"type":"doc","version":1,"content":[…]}) are
+    // gated before the schema match: rich-text custom fields report schema type
+    // "string" yet return an object value, so neither the (Some("string"), …)
+    // arm nor the schemaless heuristics would render them. Flatten to plain text
+    // the same way descriptions and comments already do; when the document
+    // flattens to nothing, preserve it raw rather than dropping it.
+    if let Value::Object(obj) = value
+        && obj.get("type").and_then(|t| t.as_str()) == Some("doc")
+    {
+        let txt = adf_document_to_text(value);
+        return if txt.is_empty() {
+            Some(CustomField::Unknown {
+                name,
+                value: Some(value.clone()),
+            })
+        } else {
+            Some(CustomField::Text {
+                name,
+                value: Some(txt),
+            })
+        };
+    }
     match (schema.map(|s| s.field_type.as_str()), value) {
         (_, Value::Null) => None,
 
@@ -240,12 +294,18 @@ fn json_value_to_custom_field(
                     value: Some(n.to_string()),
                 })
             } else {
-                Some(CustomField::Unknown { name })
+                Some(CustomField::Unknown {
+                    name,
+                    value: Some(value.clone()),
+                })
             }
         }
         (None, Value::Array(arr)) => convert_array_field(name, arr, None),
 
-        _ => Some(CustomField::Unknown { name }),
+        _ => Some(CustomField::Unknown {
+            name,
+            value: Some(value.clone()),
+        }),
     }
 }
 
@@ -260,6 +320,25 @@ fn convert_array_field(
     }
 
     let _items_type = schema.and_then(|s| s.items.as_deref());
+
+    // HEURISTIC: an array whose items are objects carrying sub-fields beyond a
+    // single display key (e.g. Sprint objects with id/state/goal/board) would
+    // lose data if collapsed to one display string per item. Preserve the whole
+    // array verbatim as Unknown in that case. Plain-string arrays and arrays of
+    // single-display-key option objects stay MultiEnum.
+    const DISPLAY_KEYS: &[&str] = &["value", "name", "displayName", "id", "self"];
+    let has_rich_object = arr.iter().any(|item| match item {
+        Value::Object(obj) => {
+            obj.len() > 1 || obj.keys().any(|k| !DISPLAY_KEYS.contains(&k.as_str()))
+        }
+        _ => false,
+    });
+    if has_rich_object {
+        return Some(CustomField::Unknown {
+            name,
+            value: Some(Value::Array(arr.to_vec())),
+        });
+    }
 
     let values: Vec<String> = arr
         .iter()
@@ -786,6 +865,29 @@ const RESERVED_FIELD_NAMES: &[&str] = &[
     "type",
     "issuetype",
     "labels",
+];
+
+/// System fields that arrive in the flattened `extra` map but carry no
+/// user-meaningful value worth surfacing as a custom field (progress rollups,
+/// worklog/vote/watch aggregates, internal bookkeeping). These are the only
+/// fields the read projection is allowed to silently drop; everything else the
+/// API returns is surfaced (typed when possible, `Unknown` otherwise).
+const JIRA_NOISE_FIELDS: &[&str] = &[
+    "aggregateprogress",
+    "progress",
+    "worklog",
+    "votes",
+    "watches",
+    "workratio",
+    "statuscategorychangedate",
+    "lastViewed",
+    "timespent",
+    "aggregatetimespent",
+    "aggregatetimeestimate",
+    "aggregatetimeoriginalestimate",
+    "statusCategory",
+    "issuerestriction",
+    "watchers",
 ];
 
 fn is_reserved_field(name: &str) -> bool {
@@ -1619,16 +1721,52 @@ mod tests {
     }
 
     #[test]
-    fn jira_issue_to_core_maps_array_field_sprint() {
+    fn jira_issue_to_core_maps_array_field_single_display_key() {
+        // An array of single-display-key option objects collapses to a
+        // MultiEnum of display strings (each item carries only one of the
+        // recognized display keys, so nothing is lost).
         let mut extra = std::collections::HashMap::new();
         extra.insert(
-            "customfield_10020".to_string(),
-            serde_json::json!([{"id": 1, "name": "Sprint 1"}, {"id": 2, "name": "Sprint 2"}]),
+            "customfield_10030".to_string(),
+            serde_json::json!([{"value": "Red"}, {"value": "Green"}]),
         );
 
         let fields = vec![JiraField {
-            id: "customfield_10020".to_string(),
-            name: "Sprint".to_string(),
+            id: "customfield_10030".to_string(),
+            name: "Colors".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "array".to_string(),
+                custom: None,
+                items: Some("option".to_string()),
+            }),
+        }];
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &fields);
+
+        let colors = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "Colors"))
+            .unwrap();
+        assert!(
+            matches!(colors, CustomField::MultiEnum { values, .. } if values == &["Red", "Green"])
+        );
+    }
+
+    #[test]
+    fn jira_issue_to_core_maps_plain_string_array() {
+        // Plain string arrays stay MultiEnum.
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "customfield_10031".to_string(),
+            serde_json::json!(["alpha", "beta"]),
+        );
+
+        let fields = vec![JiraField {
+            id: "customfield_10031".to_string(),
+            name: "Tags".to_string(),
             custom: true,
             schema: Some(JiraFieldSchema {
                 field_type: "array".to_string(),
@@ -1640,13 +1778,13 @@ mod tests {
         let issue = mock_jira_issue_for_conversion(extra);
         let core = jira_issue_to_core(issue, &fields);
 
-        let sprint = core
+        let tags = core
             .custom_fields
             .iter()
-            .find(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "Sprint"))
+            .find(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "Tags"))
             .unwrap();
         assert!(
-            matches!(sprint, CustomField::MultiEnum { values, .. } if values == &["Sprint 1", "Sprint 2"])
+            matches!(tags, CustomField::MultiEnum { values, .. } if values == &["alpha", "beta"])
         );
     }
 
@@ -1730,28 +1868,243 @@ mod tests {
     }
 
     #[test]
-    fn jira_issue_to_core_ignores_non_custom_extra_fields() {
+    fn jira_issue_to_core_surfaces_system_extra_fields() {
         let mut extra = std::collections::HashMap::new();
-        // System fields that end up in extra should be ignored
+        // A meaningful system field (not on the noise denylist) must now be
+        // surfaced rather than silently dropped.
         extra.insert("environment".to_string(), serde_json::json!("Production"));
+        // A denylisted noise field must NOT be surfaced.
+        extra.insert("workratio".to_string(), serde_json::json!(42));
         extra.insert("customfield_10016".to_string(), serde_json::json!(5.0));
 
         let issue = mock_jira_issue_for_conversion(extra);
         let core = jira_issue_to_core(issue, &[]);
 
-        // "environment" should NOT be in custom_fields
-        assert!(
-            !core
-                .custom_fields
-                .iter()
-                .any(|f| matches!(f, CustomField::Text { name, .. } if name == "environment"))
-        );
-        // customfield_ should be present
+        // "environment" IS surfaced as Text "Production".
+        assert!(core.custom_fields.iter().any(
+            |f| matches!(f, CustomField::Text { name, value: Some(v) } if name == "environment" && v == "Production")
+        ));
+        // "workratio" (noise) is NOT surfaced under any variant.
+        assert!(!core.custom_fields.iter().any(|f| matches!(
+            f,
+            CustomField::Text { name, .. }
+                | CustomField::SingleEnum { name, .. }
+                | CustomField::Unknown { name, .. }
+            if name == "workratio"
+        )));
+        // customfield_ should still be present.
         assert!(
             core.custom_fields.iter().any(
                 |f| matches!(f, CustomField::Text { name, .. } if name == "customfield_10016")
             )
         );
+    }
+
+    #[test]
+    fn jira_issue_to_core_renders_adf_custom_field_as_text() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "customfield_14000".to_string(),
+            serde_json::json!({
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            { "type": "text", "text": "Hello rich text" }
+                        ]
+                    }
+                ]
+            }),
+        );
+
+        let fields = vec![JiraField {
+            id: "customfield_14000".to_string(),
+            name: "Notes".to_string(),
+            custom: true,
+            schema: None,
+        }];
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &fields);
+
+        let notes = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::Text { name, .. } if name == "Notes"))
+            .expect("ADF rich-text field should be surfaced as Text");
+        assert!(
+            matches!(notes, CustomField::Text { value: Some(v), .. } if v.contains("Hello rich text"))
+        );
+    }
+
+    #[test]
+    fn jira_issue_to_core_renders_adf_field_with_string_schema_as_text() {
+        // Rich-text custom fields report schema type "string" but return an ADF
+        // object value. The ADF gate must fire regardless of the declared schema
+        // (regression for the schema-present path).
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "customfield_14001".to_string(),
+            serde_json::json!({
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    { "type": "paragraph", "content": [ { "type": "text", "text": "Repro steps here" } ] }
+                ]
+            }),
+        );
+
+        let fields = vec![JiraField {
+            id: "customfield_14001".to_string(),
+            name: "Repro Steps".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "string".to_string(),
+                custom: None,
+                items: None,
+            }),
+        }];
+
+        let core = jira_issue_to_core(mock_jira_issue_for_conversion(extra), &fields);
+        let repro = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::Text { name, .. } if name == "Repro Steps"))
+            .expect("ADF field with string schema should still render as Text");
+        assert!(
+            matches!(repro, CustomField::Text { value: Some(v), .. } if v.contains("Repro steps here"))
+        );
+    }
+
+    #[test]
+    fn jira_issue_to_core_preserves_object_array_losslessly() {
+        let raw = serde_json::json!([{"id": 1, "state": "active", "name": "Sprint 1"}]);
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("customfield_10020".to_string(), raw.clone());
+
+        let fields = vec![JiraField {
+            id: "customfield_10020".to_string(),
+            name: "Sprint".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "array".to_string(),
+                custom: None,
+                items: Some("json".to_string()),
+            }),
+        }];
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &fields);
+
+        // The array items carry sub-fields (state) beyond a single display key,
+        // so the whole array is preserved as Unknown rather than collapsed to a
+        // lossy MultiEnum of display strings.
+        let sprint = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::Unknown { name, .. } if name == "Sprint"))
+            .expect("object array should be preserved as Unknown");
+        assert!(matches!(sprint, CustomField::Unknown { value: Some(v), .. } if v == &raw));
+        // It must NOT have been collapsed to a MultiEnum.
+        assert!(
+            !core
+                .custom_fields
+                .iter()
+                .any(|f| matches!(f, CustomField::MultiEnum { name, .. } if name == "Sprint"))
+        );
+    }
+
+    #[test]
+    fn jira_issue_to_core_surfaces_reporter() {
+        let mut issue = mock_jira_issue_for_conversion(Default::default());
+        issue.fields.reporter = Some(JiraUser {
+            account_id: Some("rep-1".to_string()),
+            display_name: Some("Rita Reporter".to_string()),
+            email_address: None,
+            active: true,
+            self_url: None,
+        });
+
+        let core = jira_issue_to_core(issue, &[]);
+
+        let reporter = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::SingleUser { name, .. } if name == "Reporter"))
+            .expect("Reporter should be surfaced as SingleUser");
+        assert!(matches!(
+            reporter,
+            CustomField::SingleUser {
+                login: Some(l),
+                display_name: Some(dn),
+                ..
+            } if l == "rep-1" && dn == "Rita Reporter"
+        ));
+    }
+
+    #[test]
+    fn jira_issue_to_core_dedupes_time_estimates() {
+        // The timetracking object carries BOTH estimates, and the scalar keys
+        // also populate the same names. Each estimate name must be emitted
+        // exactly once, sourced from the authoritative timetracking object.
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "timetracking".to_string(),
+            serde_json::json!({
+                "originalEstimate": "4h",
+                "remainingEstimate": "2h"
+            }),
+        );
+        extra.insert("timeoriginalestimate".to_string(), serde_json::json!(14400));
+        extra.insert("timeestimate".to_string(), serde_json::json!(7200));
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &[]);
+
+        let original_count = core
+            .custom_fields
+            .iter()
+            .filter(|f| matches!(f, CustomField::Text { name, .. } if name == "Original Estimate"))
+            .count();
+        let remaining_count = core
+            .custom_fields
+            .iter()
+            .filter(|f| matches!(f, CustomField::Text { name, .. } if name == "Remaining Estimate"))
+            .count();
+        assert_eq!(original_count, 1, "Original Estimate must be emitted once");
+        assert_eq!(
+            remaining_count, 1,
+            "Remaining Estimate must be emitted once"
+        );
+
+        // The timetracking object is authoritative, so the textual "4h"/"2h"
+        // win over the raw scalar seconds.
+        let original = core
+            .custom_fields
+            .iter()
+            .find(|f| matches!(f, CustomField::Text { name, .. } if name == "Original Estimate"))
+            .unwrap();
+        assert!(matches!(original, CustomField::Text { value: Some(v), .. } if v == "4h"));
+    }
+
+    #[test]
+    fn jira_issue_to_core_emits_scalar_estimate_when_timetracking_absent() {
+        // A scalar estimate the timetracking object did NOT cover still emits
+        // exactly once.
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("timeoriginalestimate".to_string(), serde_json::json!("8h"));
+
+        let issue = mock_jira_issue_for_conversion(extra);
+        let core = jira_issue_to_core(issue, &[]);
+
+        let count = core
+            .custom_fields
+            .iter()
+            .filter(|f| matches!(f, CustomField::Text { name, .. } if name == "Original Estimate"))
+            .count();
+        assert_eq!(count, 1);
     }
 
     #[test]

--- a/crates/linear-backend/src/client.rs
+++ b/crates/linear-backend/src/client.rs
@@ -16,6 +16,8 @@ const ISSUE_FIELDS: &str = r#"
     description
     priority
     priorityLabel
+    estimate
+    dueDate
     url
     createdAt
     updatedAt
@@ -24,6 +26,8 @@ const ISSUE_FIELDS: &str = r#"
     team { id key name description }
     state { id name type position }
     assignee { id name displayName email }
+    creator { id name displayName email }
+    cycle { id number name }
     project { id name slugId description }
     parent { id identifier title }
     labels(first: 100) {

--- a/crates/linear-backend/src/convert.rs
+++ b/crates/linear-backend/src/convert.rs
@@ -63,6 +63,42 @@ pub fn linear_issue_to_core(issue: LinearIssue) -> Issue {
         });
     }
 
+    if let Some(estimate) = issue.estimate {
+        custom_fields.push(CustomField::Text {
+            name: "Estimate".to_string(),
+            value: Some(format_estimate(estimate)),
+        });
+    }
+
+    if let Some(due_date) = &issue.due_date {
+        custom_fields.push(CustomField::Text {
+            name: "Due Date".to_string(),
+            value: Some(due_date.clone()),
+        });
+    }
+
+    if let Some(cycle) = &issue.cycle {
+        let value = cycle.name.clone().unwrap_or_else(|| {
+            let label = cycle
+                .number
+                .map(format_estimate)
+                .unwrap_or_else(|| cycle.id.clone());
+            format!("Cycle {label}")
+        });
+        custom_fields.push(CustomField::SingleEnum {
+            name: "Cycle".to_string(),
+            value: Some(value),
+        });
+    }
+
+    if let Some(creator) = &issue.creator {
+        custom_fields.push(CustomField::SingleUser {
+            name: "Creator".to_string(),
+            login: Some(linear_user_login(creator)),
+            display_name: Some(linear_user_display_name(creator)),
+        });
+    }
+
     let tags = issue
         .labels
         .nodes
@@ -613,6 +649,17 @@ fn linear_user_display_name(user: &LinearUser) -> String {
         .unwrap_or_else(|| user.name.clone())
 }
 
+/// Render a Linear numeric estimate/cycle number, stripping a trailing `.0` so
+/// whole-number values read as `2` rather than `2.0` while fractional values
+/// (e.g. `1.5`) keep their decimal part.
+fn format_estimate(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{}", value as i64)
+    } else {
+        format!("{value}")
+    }
+}
+
 fn priority_label(priority: i64) -> &'static str {
     match priority {
         1 => "Urgent",
@@ -884,5 +931,119 @@ mod tests {
             parsed.state_type_nin,
             Some(vec!["completed".to_string(), "canceled".to_string()])
         );
+    }
+
+    fn issue_from_json(value: serde_json::Value) -> LinearIssue {
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn text_value<'a>(fields: &'a [CustomField], name: &str) -> Option<&'a str> {
+        fields.iter().find_map(|field| match field {
+            CustomField::Text { name: n, value } if n == name => value.as_deref(),
+            _ => None,
+        })
+    }
+
+    fn single_enum_value<'a>(fields: &'a [CustomField], name: &str) -> Option<&'a str> {
+        fields.iter().find_map(|field| match field {
+            CustomField::SingleEnum { name: n, value } if n == name => value.as_deref(),
+            _ => None,
+        })
+    }
+
+    fn single_user<'a>(
+        fields: &'a [CustomField],
+        name: &str,
+    ) -> Option<(Option<&'a str>, Option<&'a str>)> {
+        fields.iter().find_map(|field| match field {
+            CustomField::SingleUser {
+                name: n,
+                login,
+                display_name,
+            } if n == name => Some((login.as_deref(), display_name.as_deref())),
+            _ => None,
+        })
+    }
+
+    fn sample_issue_json() -> serde_json::Value {
+        serde_json::json!({
+            "id": "issue-1",
+            "identifier": "ENG-1",
+            "title": "Widen field projection",
+            "description": "body",
+            "priority": 2,
+            "priorityLabel": "High",
+            "estimate": 3.0,
+            "dueDate": "2026-07-01",
+            "url": "https://linear.app/x/issue/ENG-1",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-02T00:00:00Z",
+            "team": { "id": "team-1", "key": "ENG", "name": "Engineering", "description": null },
+            "state": { "id": "s-1", "name": "In Progress", "type": "started", "position": 1.0 },
+            "assignee": { "id": "u-1", "name": "alice", "displayName": "Alice", "email": "alice@example.com" },
+            "creator": { "id": "u-2", "name": "bob", "displayName": "Bob", "email": "bob@example.com" },
+            "cycle": { "id": "c-1", "number": 7.0, "name": "Sprint 7" },
+            "project": { "id": "p-1", "name": "Platform", "slugId": "plat", "description": null },
+            "parent": null,
+            "labels": { "nodes": [], "pageInfo": { "hasNextPage": false, "endCursor": null } }
+        })
+    }
+
+    #[test]
+    fn linear_issue_projects_widened_fields() {
+        let issue = issue_from_json(sample_issue_json());
+        let core = linear_issue_to_core(issue);
+        let fields = &core.custom_fields;
+
+        // Estimate is a Text field with the trailing `.0` stripped.
+        assert_eq!(text_value(fields, "Estimate"), Some("3"));
+        // Due Date passes through verbatim.
+        assert_eq!(text_value(fields, "Due Date"), Some("2026-07-01"));
+        // Cycle prefers the explicit name.
+        assert_eq!(single_enum_value(fields, "Cycle"), Some("Sprint 7"));
+        // Creator reuses the user helpers (login = email, display = displayName).
+        assert_eq!(
+            single_user(fields, "Creator"),
+            Some((Some("bob@example.com"), Some("Bob")))
+        );
+    }
+
+    #[test]
+    fn linear_issue_omits_absent_widened_fields() {
+        let mut json = sample_issue_json();
+        let obj = json.as_object_mut().unwrap();
+        obj.remove("estimate");
+        obj.remove("dueDate");
+        obj.remove("cycle");
+        obj.remove("creator");
+
+        let core = linear_issue_to_core(issue_from_json(json));
+        let fields = &core.custom_fields;
+
+        assert_eq!(text_value(fields, "Estimate"), None);
+        assert_eq!(text_value(fields, "Due Date"), None);
+        assert_eq!(single_enum_value(fields, "Cycle"), None);
+        assert!(single_user(fields, "Creator").is_none());
+    }
+
+    #[test]
+    fn linear_cycle_without_name_falls_back_to_number() {
+        let mut json = sample_issue_json();
+        json["cycle"] = serde_json::json!({ "id": "c-2", "number": 9.0, "name": null });
+
+        let core = linear_issue_to_core(issue_from_json(json));
+        assert_eq!(
+            single_enum_value(&core.custom_fields, "Cycle"),
+            Some("Cycle 9")
+        );
+    }
+
+    #[test]
+    fn linear_estimate_keeps_fractional_part() {
+        let mut json = sample_issue_json();
+        json["estimate"] = serde_json::json!(1.5);
+
+        let core = linear_issue_to_core(issue_from_json(json));
+        assert_eq!(text_value(&core.custom_fields, "Estimate"), Some("1.5"));
     }
 }

--- a/crates/linear-backend/src/models.rs
+++ b/crates/linear-backend/src/models.rs
@@ -96,6 +96,10 @@ pub struct LinearIssue {
     #[serde(default)]
     pub priority: i64,
     pub priority_label: Option<String>,
+    #[serde(default)]
+    pub estimate: Option<f64>,
+    #[serde(default)]
+    pub due_date: Option<String>,
     pub url: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -106,9 +110,20 @@ pub struct LinearIssue {
     pub team: LinearTeam,
     pub state: Option<LinearWorkflowState>,
     pub assignee: Option<LinearUser>,
+    #[serde(default)]
+    pub creator: Option<LinearUser>,
+    #[serde(default)]
+    pub cycle: Option<LinearCycle>,
     pub project: Option<LinearProject>,
     pub parent: Option<LinearIssueRef>,
     pub labels: LinearConnection<LinearIssueLabel>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LinearCycle {
+    pub id: String,
+    pub number: Option<f64>,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -1709,7 +1709,7 @@ fn verify_field_match(
         CustomField::SingleUser { name, .. } => unicode_eq_ignore_case(name, req_name),
         CustomField::Text { name, .. } => unicode_eq_ignore_case(name, req_name),
         CustomField::MultiEnum { name, .. } => unicode_eq_ignore_case(name, req_name),
-        CustomField::Unknown { name } => unicode_eq_ignore_case(name, req_name),
+        CustomField::Unknown { name, .. } => unicode_eq_ignore_case(name, req_name),
     });
 
     // A State update targets the tracker's workflow state field whatever the backend

--- a/crates/track/src/output.rs
+++ b/crates/track/src/output.rs
@@ -267,7 +267,10 @@ fn find_field_value(issue: &Issue, name: &str) -> Option<String> {
             CustomField::SingleUser { login, .. } => login.clone(),
             CustomField::Text { value, .. } => value.clone(),
             CustomField::MultiEnum { values, .. } => Some(values.join(", ")),
-            CustomField::Unknown { .. } => None,
+            CustomField::Unknown { value, .. } => value.as_ref().map(|v| match v {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            }),
         })
 }
 
@@ -441,8 +444,13 @@ impl Displayable for CustomField {
             CustomField::MultiEnum { name, values } => {
                 format!("{}: {}", name.dimmed(), values.join(", "))
             }
-            CustomField::Unknown { name } => {
-                format!("{}: {}", name.dimmed(), "Unknown field".dimmed())
+            CustomField::Unknown { name, value } => {
+                let rendered = match value {
+                    Some(serde_json::Value::String(s)) => s.clone(),
+                    Some(v) => v.to_string(),
+                    None => "Unknown field".dimmed().to_string(),
+                };
+                format!("{}: {}", name.dimmed(), rendered)
             }
         }
     }

--- a/crates/tracker-core/Cargo.toml
+++ b/crates/tracker-core/Cargo.toml
@@ -8,6 +8,4 @@ description = "Core traits and types for issue tracker backends"
 thiserror = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
-
-[dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/tracker-core/src/models.rs
+++ b/crates/tracker-core/src/models.rs
@@ -40,7 +40,24 @@ pub struct ProjectRef {
     pub short_name: Option<String>,
 }
 
-/// Custom field on an issue
+/// Custom field on an issue.
+///
+/// `custom_fields` is a best-effort-lossless projection of each backend's issue
+/// fields. Every backend converter follows one contract:
+///
+/// 1. Surface a field as the most specific variant it can prove (`State`,
+///    `SingleEnum`, `SingleUser`, `Text`, `MultiEnum`).
+/// 2. When a value is present but untypeable, emit
+///    [`CustomField::Unknown`] with `value: Some(<raw json>)` so the payload
+///    round-trips verbatim.
+/// 3. Use `Unknown { value: None }` only when a field is known to exist but its
+///    value is structurally unretrievable.
+/// 4. Never silently drop a field the API returned to the converter, except an
+///    enumerated, per-backend noise denylist.
+///
+/// There is exactly one fallback tag (`Unknown`) across all backends. The
+/// externally-tagged JSON encoding is stable and additive: existing variant
+/// encodings never change, and `Unknown` only gains an optional `value` key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CustomField {
     SingleEnum {
@@ -65,8 +82,14 @@ pub enum CustomField {
         name: String,
         values: Vec<String>,
     },
+    /// Fallback for a field present on the issue that the backend could not map
+    /// to a typed variant above. `value` carries the backend's raw JSON verbatim
+    /// (`None` only when the value is structurally unretrievable). See the
+    /// projection contract on [`CustomField`].
     Unknown {
         name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<serde_json::Value>,
     },
 }
 

--- a/crates/youtrack-backend/src/client.rs
+++ b/crates/youtrack-backend/src/client.rs
@@ -6,7 +6,7 @@ use tracker_core::{AttachmentUpload, unicode_eq_ignore_case};
 use ureq::Agent;
 use ureq::unversioned::multipart::{Form, Part};
 
-const DEFAULT_ISSUE_FIELDS: &str = "id,idReadable,summary,description,project(id,name,shortName),customFields(name,$type,value(name,login,isResolved,text)),tags(id,name),created,updated,resolved";
+const DEFAULT_ISSUE_FIELDS: &str = "id,idReadable,summary,description,project(id,name,shortName),customFields(name,$type,value(name,login,isResolved,text,minutes,presentation,color(id))),tags(id,name),created,updated,resolved";
 const DEFAULT_PROJECT_FIELDS: &str = "id,name,shortName,description";
 const DEFAULT_ARTICLE_FIELDS: &str = "id,idReadable,summary,content,project(id,name,shortName),parentArticle(id,idReadable,summary),hasChildren,tags(id,name),created,updated,reporter(login,name)";
 

--- a/crates/youtrack-backend/src/convert.rs
+++ b/crates/youtrack-backend/src/convert.rs
@@ -130,9 +130,7 @@ impl From<yt::CustomField> for core::CustomField {
                 name,
                 values: value.into_iter().map(|v| v.name).collect(),
             },
-            yt::CustomField::Unknown => core::CustomField::Unknown {
-                name: "Unknown".to_string(),
-            },
+            yt::CustomField::Unknown { name, value } => core::CustomField::Unknown { name, value },
         }
     }
 }
@@ -750,5 +748,29 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].field, "status");
         assert_eq!(events[0].to.as_deref(), Some("Done"));
+    }
+
+    #[test]
+    fn custom_field_unknown_passthrough_preserves_name_and_value() {
+        // yt Unknown { name, value } -> core Unknown { name, value } verbatim:
+        // the raw payload must survive the conversion untouched.
+        let raw = serde_json::json!({
+            "$type": "DateIssueCustomField",
+            "name": "Due Date",
+            "value": 1700000000000i64
+        });
+        let yt_field = yt::CustomField::Unknown {
+            name: "Due Date".to_string(),
+            value: Some(raw.clone()),
+        };
+
+        let core_field: core::CustomField = yt_field.into();
+        match core_field {
+            core::CustomField::Unknown { name, value } => {
+                assert_eq!(name, "Due Date");
+                assert_eq!(value, Some(raw));
+            }
+            other => panic!("expected core Unknown, got {other:?}"),
+        }
     }
 }

--- a/crates/youtrack-backend/src/models/issue.rs
+++ b/crates/youtrack-backend/src/models/issue.rs
@@ -66,33 +66,136 @@ pub struct ProjectRef {
     pub short_name: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(tag = "$type")]
+/// A custom field as projected from the YouTrack issue payload.
+///
+/// Deserialization is hand-written (not `#[serde(untagged)]`): we buffer each
+/// element into a [`serde_json::Value`], read its `$type`, and dispatch to the
+/// matching typed variant. A known `$type` whose body fails to parse propagates
+/// the error (it does NOT silently degrade to `Unknown`) -- that is the whole
+/// point of dispatching by tag rather than using `untagged`. An unrecognized
+/// `$type` (or a missing one) becomes `Unknown { name, value: Some(raw) }`,
+/// carrying the entire raw element verbatim so no API data is dropped.
+#[derive(Debug, Serialize, Clone)]
 pub enum CustomField {
-    #[serde(rename = "SingleEnumIssueCustomField")]
     SingleEnum {
         name: String,
         value: Option<EnumValue>,
     },
-    #[serde(rename = "StateIssueCustomField")]
     State {
         name: String,
         value: Option<StateValue>,
     },
-    #[serde(rename = "SingleUserIssueCustomField")]
     SingleUser {
         name: String,
         value: Option<UserValue>,
     },
-    #[serde(rename = "TextIssueCustomField")]
     Text {
         name: String,
         value: Option<TextValue>,
     },
-    #[serde(rename = "MultiEnumIssueCustomField")]
-    MultiEnum { name: String, value: Vec<EnumValue> },
-    #[serde(other)]
-    Unknown,
+    MultiEnum {
+        name: String,
+        value: Vec<EnumValue>,
+    },
+    Unknown {
+        name: String,
+        value: Option<serde_json::Value>,
+    },
+}
+
+#[derive(Deserialize)]
+struct SingleEnumData {
+    name: String,
+    #[serde(default)]
+    value: Option<EnumValue>,
+}
+
+#[derive(Deserialize)]
+struct StateData {
+    name: String,
+    #[serde(default)]
+    value: Option<StateValue>,
+}
+
+#[derive(Deserialize)]
+struct UserData {
+    name: String,
+    #[serde(default)]
+    value: Option<UserValue>,
+}
+
+#[derive(Deserialize)]
+struct TextData {
+    name: String,
+    #[serde(default)]
+    value: Option<TextValue>,
+}
+
+#[derive(Deserialize)]
+struct MultiEnumData {
+    name: String,
+    #[serde(default)]
+    value: Vec<EnumValue>,
+}
+
+impl<'de> Deserialize<'de> for CustomField {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+        use serde_json::Value;
+
+        let raw = Value::deserialize(d)?;
+        let ty = raw.get("$type").and_then(Value::as_str);
+        let field = match ty {
+            Some("SingleEnumIssueCustomField") => {
+                let d: SingleEnumData = serde_json::from_value(raw).map_err(D::Error::custom)?;
+                CustomField::SingleEnum {
+                    name: d.name,
+                    value: d.value,
+                }
+            }
+            Some("StateIssueCustomField") => {
+                let d: StateData = serde_json::from_value(raw).map_err(D::Error::custom)?;
+                CustomField::State {
+                    name: d.name,
+                    value: d.value,
+                }
+            }
+            Some("SingleUserIssueCustomField") => {
+                let d: UserData = serde_json::from_value(raw).map_err(D::Error::custom)?;
+                CustomField::SingleUser {
+                    name: d.name,
+                    value: d.value,
+                }
+            }
+            Some("TextIssueCustomField") => {
+                let d: TextData = serde_json::from_value(raw).map_err(D::Error::custom)?;
+                CustomField::Text {
+                    name: d.name,
+                    value: d.value,
+                }
+            }
+            Some("MultiEnumIssueCustomField") => {
+                let d: MultiEnumData = serde_json::from_value(raw).map_err(D::Error::custom)?;
+                CustomField::MultiEnum {
+                    name: d.name,
+                    value: d.value,
+                }
+            }
+            _ => {
+                let name = raw
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .or_else(|| ty.map(str::to_string))
+                    .unwrap_or_else(|| "custom field".to_string());
+                CustomField::Unknown {
+                    name,
+                    value: Some(raw),
+                }
+            }
+        };
+        Ok(field)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -416,5 +519,70 @@ mod tests {
         assert!(!json.contains("\"id\""));
         assert!(json.contains("\"name\":\"urgent\""));
         assert!(json.contains("\"$type\":\"IssueTag\""));
+    }
+
+    #[test]
+    fn custom_field_unknown_type_retains_raw_value() {
+        // A field type we don't model (Date) must be captured losslessly as
+        // Unknown, keeping the original name and the raw payload verbatim.
+        let json = serde_json::json!({
+            "$type": "DateIssueCustomField",
+            "name": "Due Date",
+            "value": 1700000000000i64
+        });
+
+        let field: CustomField = serde_json::from_value(json).unwrap();
+        match field {
+            CustomField::Unknown { name, value } => {
+                assert_eq!(name, "Due Date");
+                let value = value.expect("raw value must be retained");
+                // The whole element is buffered, so the payload is recoverable.
+                assert_eq!(
+                    value.get("value").and_then(|v| v.as_i64()),
+                    Some(1700000000000)
+                );
+                assert_eq!(
+                    value.get("$type").and_then(|v| v.as_str()),
+                    Some("DateIssueCustomField")
+                );
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_field_malformed_known_type_errors_not_unknown() {
+        // A KNOWN $type whose body is malformed (value.name should be a string)
+        // must propagate a deserialization error rather than degrading to
+        // Unknown -- this is the guarantee vs #[serde(untagged)].
+        let json = serde_json::json!({
+            "$type": "StateIssueCustomField",
+            "name": "State",
+            "value": { "name": 123 }
+        });
+
+        let result: Result<CustomField, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "malformed known type must error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn custom_field_known_single_enum_preserves_value() {
+        let json = serde_json::json!({
+            "$type": "SingleEnumIssueCustomField",
+            "name": "Priority",
+            "value": { "name": "Major" }
+        });
+
+        let field: CustomField = serde_json::from_value(json).unwrap();
+        match field {
+            CustomField::SingleEnum { name, value } => {
+                assert_eq!(name, "Priority");
+                assert_eq!(value.map(|v| v.name).as_deref(), Some("Major"));
+            }
+            other => panic!("expected SingleEnum, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #277. `track` fetched far more issue data than it surfaced — Jira pulled `fixVersions`, `reporter`, and ADF rich-text custom fields over the wire and then dropped them in the converter, and every backend's `CustomField::Unknown` fallback discarded its value.

This makes `custom_fields` a **best-effort-lossless projection** across all five backends with one rule: *never silently drop a field the API returned to the converter.*

### Core contract (one fallback tag, additive wire)
`CustomField::Unknown` now carries an optional raw JSON value:

```rust
Unknown {
    name: String,
    #[serde(default, skip_serializing_if = "Option::is_none")]
    value: Option<serde_json::Value>,
}
```

The externally-tagged JSON stays byte-identical when `value` is `None`, so existing consumers that read today's output keep working — `value` simply starts appearing on fields that used to be empty.

### Per backend
| Backend | Change | Ceiling |
|---|---|---|
| **Jira** | `extra` loop inverted from a `customfield_*` allow-list to a noise deny-list (system fields surface); ADF rich-text → rendered `Text` regardless of schema; object arrays (Sprint, fixVersions) preserved losslessly; time-estimate de-dup; `reporter` mapped; `get_issue` now sends `fields=*all` so single-issue reads match search | open response — near-total |
| **YouTrack** | hand-written `Deserialize` makes the `Unknown` fallback value-bearing **without** masking known-`$type` deserialize failures (no `#[serde(untagged)]`); widened value sub-selection | closed selection |
| **GitHub / GitLab** | `#[serde(flatten)]` catch-all + value-shape projection + per-backend noise deny-list; GitLab promotes `weight`/`due_date`/`confidential` to typed fields | open response |
| **Linear** | widened GraphQL selection (`estimate`, `dueDate`, `cycle`, `creator`) and projected them — a runtime catch-all isn't possible on GraphQL | closed selection |

Write path is unchanged: surfaced fields flow through the existing generic path; if a field isn't editable, the backend's error is surfaced (no read-only allow-list).

## Testing
- `cargo build --workspace` clean; `cargo test --workspace` — **786 pass, 0 fail**; `cargo fmt --all --check` clean.
- New unit tests per backend (deny-list, ADF→Text incl. the schema-present case, lossless object arrays, reporter, estimate de-dup, value-bearing `Unknown`, and a negative test that a malformed known YouTrack `$type` errors rather than degrading to `Unknown`).
- **Validated read-only against live Jira** — `i search` + `i get` only, no mutations:
  - `Reporter` / `Creator` recovered (previously dropped).
  - `Sprint` / `Platform` now preserved as full object arrays (were collapsed/empty).
  - `Rank` (`"0|i0pjkg:"`) and `Start date` (`"2026-06-10"`) now carry their raw values (were name-only `Unknown`).
  - Duplicate `Original`/`Remaining Estimate` entries collapsed to one each.
  - Across 173 live `Unknown` entries, zero unrendered ADF documents — the ADF gate catches them all.

## Compatibility
Additive JSON, no migration. Version bumped 1.13.0 → 1.14.0. Docs updated (README backend notes, agent skill JSON shapes).
