### PR TITLE
refactor: make Linear cycle-name fallback cloning explicit

### DIFF
--- a/crates/linear-backend/src/convert.rs
+++ b/crates/linear-backend/src/convert.rs
@@ -78,7 +78,7 @@ pub fn linear_issue_to_core(issue: LinearIssue) -> Issue {
     }
 
     if let Some(cycle) = &issue.cycle {
-        let value = cycle.name.clone().unwrap_or_else(|| {
+        let value = cycle.name.as_ref().cloned().unwrap_or_else(|| {
             let label = cycle
                 .number
                 .map(format_estimate)


### PR DESCRIPTION
## Summary

- Make the Linear cycle-name fallback path explicit by borrowing the optional cycle name before producing the owned output string.
- Behavior is unchanged: named cycles use the name, and unnamed cycles still fall back to `Cycle {number-or-id}`.

## Review note

This is a tiny readability cleanup, not a meaningful performance optimization. The previous `Option<String>::clone()` did not clone an inner string on `None`, and the new form still clones the selected name when present.

## Validation

- Existing PR CI is green across format, clippy, build, and tests.