### PR TITLE
🔒 Fix insecure HTTP usage in init command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
  "toml 1.0.3+spec-1.1.0",
  "tracker-core",
  "tracker-mock",
+ "ureq",
  "youtrack-backend",
 ]
 

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -27,6 +27,7 @@ directories = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
 open = { workspace = true }
+ureq = { workspace = true }
 
 
 [dev-dependencies]

--- a/crates/track/src/commands/init.rs
+++ b/crates/track/src/commands/init.rs
@@ -149,6 +149,24 @@ pub fn handle_init(
         ));
     }
 
+    // Security: Enforce HTTPS for remote URLs to prevent token interception
+    if url.starts_with("http://") {
+        let is_local = url.starts_with("http://127.0.0.1:")
+            || url == "http://127.0.0.1"
+            || url.starts_with("http://127.0.0.1/")
+            || url.starts_with("http://localhost:")
+            || url == "http://localhost"
+            || url.starts_with("http://localhost/")
+            || url.starts_with("http://[::1]:")
+            || url == "http://[::1]"
+            || url.starts_with("http://[::1]/");
+        if !is_local {
+            return Err(anyhow::anyhow!(
+                "Insecure URL: http:// is only allowed for local addresses (127.0.0.1, localhost, [::1]). Use https:// for remote servers to protect your API token."
+            ));
+        }
+    }
+
     let config_path = if global {
         config::global_config_path_ensure()?
     } else {

--- a/crates/track/src/commands/init.rs
+++ b/crates/track/src/commands/init.rs
@@ -8,6 +8,7 @@ use gitlab_backend::GitLabClient;
 use jira_backend::JiraClient;
 use linear_backend::LinearClient;
 use tracker_core::IssueTracker;
+use ureq::http::Uri;
 use youtrack_backend::YouTrackClient;
 
 /// Embedded agent guide content - written to project directory during `track init`
@@ -64,6 +65,46 @@ fn parse_github_project(project: &str) -> Result<(String, String)> {
     }
 
     Ok((owner.to_string(), repo.to_string()))
+}
+
+fn validate_init_url(url: &str) -> Result<()> {
+    let parsed = url.parse::<Uri>().map_err(|_| {
+        anyhow::anyhow!("Invalid URL: must be a valid absolute http:// or https:// URL")
+    })?;
+
+    let scheme = parsed
+        .scheme_str()
+        .ok_or_else(|| anyhow::anyhow!("Invalid URL: must start with http:// or https://"))?;
+    if scheme != "http" && scheme != "https" {
+        return Err(anyhow::anyhow!(
+            "Invalid URL: must start with http:// or https://"
+        ));
+    }
+
+    let authority = parsed
+        .authority()
+        .ok_or_else(|| anyhow::anyhow!("Invalid URL: must include a host"))?;
+    if authority.as_str().contains('@') {
+        return Err(anyhow::anyhow!(
+            "Invalid URL: userinfo is not allowed in server URLs"
+        ));
+    }
+
+    let host = parsed
+        .host()
+        .ok_or_else(|| anyhow::anyhow!("Invalid URL: must include a host"))?;
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+
+    if scheme == "http" && !matches!(host, "127.0.0.1" | "localhost" | "::1") {
+        return Err(anyhow::anyhow!(
+            "Insecure URL: http:// is only allowed for local addresses (127.0.0.1, localhost, [::1]). Use https:// for remote servers to protect your API token."
+        ));
+    }
+
+    Ok(())
 }
 
 fn install_agent_skills(format: cli::OutputFormat) -> Result<()> {
@@ -142,30 +183,7 @@ pub fn handle_init(
     let url = url.expect("url required when not using --skills alone");
     let token = token.expect("token required when not using --skills alone");
 
-    // Validate URL format
-    if !url.starts_with("http://") && !url.starts_with("https://") {
-        return Err(anyhow::anyhow!(
-            "Invalid URL: must start with http:// or https://"
-        ));
-    }
-
-    // Security: Enforce HTTPS for remote URLs to prevent token interception
-    if url.starts_with("http://") {
-        let is_local = url.starts_with("http://127.0.0.1:")
-            || url == "http://127.0.0.1"
-            || url.starts_with("http://127.0.0.1/")
-            || url.starts_with("http://localhost:")
-            || url == "http://localhost"
-            || url.starts_with("http://localhost/")
-            || url.starts_with("http://[::1]:")
-            || url == "http://[::1]"
-            || url.starts_with("http://[::1]/");
-        if !is_local {
-            return Err(anyhow::anyhow!(
-                "Insecure URL: http:// is only allowed for local addresses (127.0.0.1, localhost, [::1]). Use https:// for remote servers to protect your API token."
-            ));
-        }
-    }
+    validate_init_url(url)?;
 
     let config_path = if global {
         config::global_config_path_ensure()?

--- a/crates/track/tests/cli_tests.rs
+++ b/crates/track/tests/cli_tests.rs
@@ -137,6 +137,85 @@ fn test_version() {
 }
 
 #[test]
+fn test_init_enforces_https_for_remote_urls() {
+    let temp_dir = create_temp_dir();
+
+    // 1. http:// on non-local domain should fail
+    cargo_bin_cmd!("track")
+        .args([
+            "init",
+            "--url",
+            "http://example.com",
+            "--token",
+            "test",
+            "-b",
+            "youtrack",
+            "--global",
+        ])
+        .env("HOME", &temp_dir)
+        .env("USERPROFILE", &temp_dir)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Insecure URL"));
+
+    // 2. http:// on spoofed local domain should fail
+    cargo_bin_cmd!("track")
+        .args(["init", "--url", "http://localhost.evil.com", "--token", "test", "-b", "youtrack", "--global"])
+        .env("HOME", &temp_dir)
+        .env("USERPROFILE", &temp_dir)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Insecure URL"));
+
+    // 3. http:// on local domain should NOT fail with "Insecure URL"
+    // It might fail connection/auth, but it should pass the security check.
+    let out = cargo_bin_cmd!("track")
+        .args([
+            "init",
+            "--url",
+            "http://127.0.0.1:1",
+            "--token",
+            "test",
+            "-b",
+            "youtrack",
+            "--global",
+        ])
+        .env("HOME", &temp_dir)
+        .env("USERPROFILE", &temp_dir)
+        .output()
+        .expect("failed to execute process");
+    let stderr_str = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr_str.contains("Insecure URL"),
+        "127.0.0.1 should not be insecure"
+    );
+
+    // 4. https:// on remote should NOT fail with "Insecure URL"
+    let out = cargo_bin_cmd!("track")
+        .args([
+            "init",
+            "--url",
+            "https://example.com",
+            "--token",
+            "test",
+            "-b",
+            "youtrack",
+            "--global",
+        ])
+        .env("HOME", &temp_dir)
+        .env("USERPROFILE", &temp_dir)
+        .output()
+        .expect("failed to execute process");
+    let stderr_str = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr_str.contains("Insecure URL"),
+        "https:// should not be insecure"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
 fn test_config_file_is_used_for_defaults() {
     let temp_dir = create_temp_dir();
     let config_path = temp_dir.join("config.toml");

--- a/crates/track/tests/cli_tests.rs
+++ b/crates/track/tests/cli_tests.rs
@@ -2,6 +2,7 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use serde_json::json;
 
+use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -42,7 +43,7 @@ fn start_mock_server(response_body: String) -> (u16, thread::JoinHandle<()>) {
     (port, handle)
 }
 
-fn create_temp_dir() -> std::path::PathBuf {
+fn create_temp_dir() -> PathBuf {
     let mut dir = std::env::temp_dir();
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -53,12 +54,11 @@ fn create_temp_dir() -> std::path::PathBuf {
     dir
 }
 
-#[test]
-fn test_missing_config() {
-    let temp_home = create_temp_dir();
-
-    cargo_bin_cmd!("track")
-        .args(["issue", "get", "PROJ-1"])
+fn track_with_home(temp_home: &Path) -> assert_cmd::Command {
+    let mut cmd = cargo_bin_cmd!("track");
+    cmd.current_dir(temp_home)
+        .env("HOME", temp_home)
+        .env("USERPROFILE", temp_home)
         .env_remove("TRACKER_URL")
         .env_remove("TRACKER_TOKEN")
         .env_remove("TRACKER_BACKEND")
@@ -81,9 +81,69 @@ fn test_missing_config() {
         .env_remove("LINEAR_URL")
         .env_remove("LINEAR_DEFAULT_TEAM")
         .env_remove("LINEAR_DEFAULT_PROJECT")
-        .env_remove("TRACK_MOCK_DIR")
-        .env("HOME", &temp_home)
-        .env("USERPROFILE", &temp_home)
+        .env_remove("TRACK_MOCK_DIR");
+    cmd
+}
+
+fn global_config_path(temp_home: &Path) -> PathBuf {
+    temp_home.join(".tracker-cli").join(".track.toml")
+}
+
+fn assert_init_rejects_url(url: &str, expected_message: &str) {
+    let temp_dir = create_temp_dir();
+    let config_path = global_config_path(&temp_dir);
+
+    track_with_home(&temp_dir)
+        .args([
+            "--format", "json", "init", "--url", url, "--token", "test", "-b", "youtrack",
+            "--global",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(expected_message));
+
+    assert!(
+        !config_path.exists(),
+        "rejected init URL should not create config: {}",
+        config_path.display()
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+fn assert_init_allows_url(url: &str) {
+    let temp_dir = create_temp_dir();
+    let config_path = global_config_path(&temp_dir);
+
+    let output = track_with_home(&temp_dir)
+        .args([
+            "--format", "json", "init", "--url", url, "--token", "test", "-b", "youtrack",
+            "--global",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["success"], true);
+    assert_eq!(json["config_path"], config_path.display().to_string());
+
+    let config = std::fs::read_to_string(&config_path).unwrap();
+    assert!(config.contains("backend = \"youtrack\""));
+    assert!(config.contains(&format!("url = \"{url}\"")));
+    assert!(config.contains("token = \"test\""));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn test_missing_config() {
+    let temp_home = create_temp_dir();
+
+    track_with_home(&temp_home)
+        .args(["issue", "get", "PROJ-1"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("URL not configured"));
@@ -129,90 +189,31 @@ fn test_version() {
 
 #[test]
 fn test_init_enforces_https_for_remote_urls() {
-    let temp_dir = create_temp_dir();
+    for url in [
+        "http://example.com",
+        "http://localhost.evil.com",
+        "http://127.0.0.1.example.com",
+    ] {
+        assert_init_rejects_url(url, "Insecure URL");
+    }
 
-    // 1. http:// on non-local domain should fail
-    cargo_bin_cmd!("track")
-        .args([
-            "init",
-            "--url",
-            "http://example.com",
-            "--token",
-            "test",
-            "-b",
-            "youtrack",
-            "--global",
-        ])
-        .env("HOME", &temp_dir)
-        .env("USERPROFILE", &temp_dir)
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("Insecure URL"));
+    for url in [
+        "http://localhost:token@example.com",
+        "http://127.0.0.1:token@example.com",
+    ] {
+        assert_init_rejects_url(url, "userinfo is not allowed");
+    }
 
-    // 2. http:// on spoofed local domain should fail
-    cargo_bin_cmd!("track")
-        .args([
-            "init",
-            "--url",
-            "http://localhost.evil.com",
-            "--token",
-            "test",
-            "-b",
-            "youtrack",
-            "--global",
-        ])
-        .env("HOME", &temp_dir)
-        .env("USERPROFILE", &temp_dir)
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("Insecure URL"));
-
-    // 3. http:// on local domain should NOT fail with "Insecure URL"
-    // It might fail connection/auth, but it should pass the security check.
-    let out = cargo_bin_cmd!("track")
-        .args([
-            "init",
-            "--url",
-            "http://127.0.0.1:1",
-            "--token",
-            "test",
-            "-b",
-            "youtrack",
-            "--global",
-        ])
-        .env("HOME", &temp_dir)
-        .env("USERPROFILE", &temp_dir)
-        .output()
-        .expect("failed to execute process");
-    let stderr_str = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr_str.contains("Insecure URL"),
-        "127.0.0.1 should not be insecure"
-    );
-
-    // 4. https:// on remote should NOT fail with "Insecure URL"
-    let out = cargo_bin_cmd!("track")
-        .args([
-            "init",
-            "--url",
-            "https://example.com",
-            "--token",
-            "test",
-            "-b",
-            "youtrack",
-            "--global",
-        ])
-        .env("HOME", &temp_dir)
-        .env("USERPROFILE", &temp_dir)
-        .output()
-        .expect("failed to execute process");
-    let stderr_str = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr_str.contains("Insecure URL"),
-        "https:// should not be insecure"
-    );
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
+    for url in [
+        "http://127.0.0.1",
+        "http://127.0.0.1:8080",
+        "http://localhost",
+        "http://[::1]",
+        "http://[::1]:8080",
+        "https://example.com",
+    ] {
+        assert_init_allows_url(url);
+    }
 }
 
 #[test]

--- a/crates/track/tests/cli_tests.rs
+++ b/crates/track/tests/cli_tests.rs
@@ -5,26 +5,15 @@ use serde_json::json;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-// Helper function to get an available port with atomic counter to avoid conflicts
-
-fn get_available_port() -> u16 {
-    use std::net::TcpListener;
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.local_addr().unwrap().port()
-}
-
 // Helper to create a simple mock server
-fn start_mock_server(port: u16, response_body: String) -> thread::JoinHandle<()> {
-    thread::spawn(move || {
-        use std::io::{Read, Write};
-        use std::net::TcpListener;
+fn start_mock_server(response_body: String) -> (u16, thread::JoinHandle<()>) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
 
-        let bind_addr = format!("127.0.0.1:{}", port);
-        let listener = match TcpListener::bind(&bind_addr) {
-            Ok(l) => l,
-            Err(_) => return, // Port already in use, exit gracefully
-        };
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
 
+    let handle = thread::spawn(move || {
         if let Some(mut stream) = listener.incoming().flatten().next() {
             let mut buffer = [0; 4096];
             // Read headers
@@ -48,7 +37,9 @@ fn start_mock_server(port: u16, response_body: String) -> thread::JoinHandle<()>
                 }
             }
         }
-    })
+    });
+
+    (port, handle)
 }
 
 fn create_temp_dir() -> std::path::PathBuf {
@@ -160,7 +151,16 @@ fn test_init_enforces_https_for_remote_urls() {
 
     // 2. http:// on spoofed local domain should fail
     cargo_bin_cmd!("track")
-        .args(["init", "--url", "http://localhost.evil.com", "--token", "test", "-b", "youtrack", "--global"])
+        .args([
+            "init",
+            "--url",
+            "http://localhost.evil.com",
+            "--token",
+            "test",
+            "-b",
+            "youtrack",
+            "--global",
+        ])
         .env("HOME", &temp_dir)
         .env("USERPROFILE", &temp_dir)
         .assert()
@@ -220,12 +220,6 @@ fn test_config_file_is_used_for_defaults() {
     let temp_dir = create_temp_dir();
     let config_path = temp_dir.join("config.toml");
 
-    let port = get_available_port();
-    let url = format!("http://127.0.0.1:{}", port);
-
-    let config_contents = format!("url = \"{}\"\ntoken = \"test-token\"\n", url);
-    std::fs::write(&config_path, config_contents).unwrap();
-
     let mock_response = json!([{
         "id": "0-1",
         "name": "Test Project",
@@ -233,8 +227,11 @@ fn test_config_file_is_used_for_defaults() {
         "description": "A test project"
     }]);
 
-    let _server = start_mock_server(port, mock_response.to_string());
-    thread::sleep(Duration::from_millis(200));
+    let (port, _server) = start_mock_server(mock_response.to_string());
+
+    let url = format!("http://127.0.0.1:{}", port);
+    let config_contents = format!("url = \"{}\"\ntoken = \"test-token\"\n", url);
+    std::fs::write(&config_path, config_contents).unwrap();
 
     let output = cargo_bin_cmd!("track")
         .args(["--config"])


### PR DESCRIPTION
## Summary

- Validate `track init` URLs with a parsed URI instead of string-prefix checks.
- Reject remote `http://` URLs so tokens are not sent over plaintext transport.
- Allow plaintext HTTP only for parsed loopback hosts: `127.0.0.1`, `localhost`, and `::1`.
- Reject URL userinfo so local-looking URLs such as `http://localhost:token@example.com` cannot bypass the guard.
- Strengthen CLI tests to assert rejected URLs create no config and allowed URLs succeed in isolated temp homes.

## Validation

- `cargo fmt --all --check`
- `cargo test -p track --test cli_tests test_init_enforces_https_for_remote_urls`
- `cargo test -p track --test cli_tests`