### PR TITLE
test: avoid unwrap in tracker-mock evaluator assertions

### DIFF
--- a/crates/tracker-mock/src/evaluator.rs
+++ b/crates/tracker-mock/src/evaluator.rs
@@ -694,8 +694,11 @@ mod tests {
             .bonuses
             .iter()
             .find(|b| b.reason.contains("cache usage"));
-        assert!(cache_bonus.is_some(), "cache_use bonus should be awarded");
-        assert_eq!(cache_bonus.unwrap().points, 15);
+        assert_eq!(
+            cache_bonus.map(|b| b.points),
+            Some(15),
+            "cache_use bonus should be awarded"
+        );
     }
 
     #[test]
@@ -726,8 +729,11 @@ mod tests {
             .bonuses
             .iter()
             .find(|b| b.reason.contains("cache usage"));
-        assert!(cache_bonus.is_some(), "cache_show should trigger bonus");
-        assert_eq!(cache_bonus.unwrap().points, 10);
+        assert_eq!(
+            cache_bonus.map(|b| b.points),
+            Some(10),
+            "cache_show should trigger bonus"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace two guarded `unwrap()` calls in tracker-mock evaluator tests with direct `Option::map` assertions.
- The test semantics are unchanged: each assertion still verifies that the cache bonus exists and has the expected point value.

## Review note

This is an idiomatic test cleanup, not a production security or runtime hardening change. The changed code is in tests, and the previous unwraps were already guarded by `is_some()` assertions.

## Validation

- Existing PR CI is green across format, clippy, build, and tests.