### PR TITLE
refactor: make Linear user fallback cloning explicit

### DIFF
--- a/crates/linear-backend/src/convert.rs
+++ b/crates/linear-backend/src/convert.rs
@@ -640,13 +640,11 @@ fn linked_issue(issue: LinearIssueRef) -> LinkedIssue {
 }
 
 fn linear_user_login(user: &LinearUser) -> String {
-    user.email.clone().unwrap_or_else(|| user.name.clone())
+    user.email.as_ref().unwrap_or(&user.name).clone()
 }
 
 fn linear_user_display_name(user: &LinearUser) -> String {
-    user.display_name
-        .clone()
-        .unwrap_or_else(|| user.name.clone())
+    user.display_name.as_ref().unwrap_or(&user.name).clone()
 }
 
 /// Render a Linear numeric estimate/cycle number, stripping a trailing `.0` so


### PR DESCRIPTION
## Summary

- Make Linear user login/display-name fallback cloning explicit by borrowing the selected value before cloning it.
- Behavior is unchanged: email/display name are still preferred, and `name` remains the fallback.

## Review note

This should be treated as a small readability/style cleanup, not a material performance optimization. Both the previous and current forms clone one selected `String` for the returned owned value.

## Validation

- Existing PR CI is green across format, clippy, build, and tests.