### PR TITLE
Add track apply declarative bulk operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/agent-skills/SKILL.md
+++ b/agent-skills/SKILL.md
@@ -425,6 +425,60 @@ track i done PROJ-1,PROJ-2 --state Done
 track i del PROJ-1,PROJ-2,PROJ-3
 ```
 
+## Declarative Apply Plans
+
+Use `track apply <plan.json>` for multi-step issue workflows that need ordered, dependent operations against one selected backend. Plans are JSON-only and can create issues, update issues, add comments, link issues, and guarded-delete issues.
+
+```bash
+track apply plan.json --dry-run
+track apply plan.json --validate --resume /tmp/track-apply-state.json
+track -o json apply plan.json
+track apply delete-plan.json --allow-delete
+```
+
+Key rules:
+- The plan file lives wherever you pass it. Use `-` to read JSON from stdin.
+- `--dry-run` may read/search/validate, but must not create, update, comment, link, or delete.
+- `--validate` validates custom fields on create/update. `defaults.validate: true` in the plan has the same effect for those operations.
+- `--resume <path>` is the only place apply state is stored. There is no implicit `.tracker-cache/` write. The state file includes a checksum of the raw plan bytes, completed operation indexes, refs, and operation results.
+- Local refs are written as `$name`; create operations populate refs with the created or dedupe-reused readable issue ID, falling back to the backend ID.
+- Real `delete_issue` operations require `--allow-delete`; dry-run can inspect delete plans without it. GitHub cannot delete issues, so use close/update behavior there instead.
+
+Minimal plan:
+
+```json
+{
+  "version": 1,
+  "defaults": {"project": "PROJ", "validate": true},
+  "operations": [
+    {
+      "ref": "parent",
+      "op": "create_issue",
+      "summary": "Parent issue",
+      "description": "Created by an apply plan",
+      "fields": {"Priority": "Major", "Platform": ["macOS", "Linux"]},
+      "tags": ["agent-workflow"],
+      "dedupe": {
+        "query": "project: PROJ summary: {Parent issue}",
+        "on_match": "reuse"
+      }
+    },
+    {
+      "op": "update_issue",
+      "issue": "$parent",
+      "fields": {"State": "In Progress"}
+    },
+    {
+      "op": "comment",
+      "issue": "$parent",
+      "body": "Created from an apply plan."
+    }
+  ]
+}
+```
+
+JSON output includes `success`, `dry_run`, `resumed`, summary counts, `refs`, and per-operation results with `index`, `op`, `status`, `issue`, `ref`, `error`, and `warnings`. Stop on the first failed operation; resume skips completed operations when the checksum still matches.
+
 ---
 
 ## Pagination

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.14.0"
+version = "1.15.0"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/cli.rs
+++ b/crates/track/src/cli.rs
@@ -159,6 +159,23 @@ pub enum Commands {
         #[arg(long, default_value_t = 10)]
         issue_limit: usize,
     },
+    /// Execute a JSON issue-operation plan against the selected backend
+    Apply {
+        /// Path to a JSON apply plan, or "-" to read from stdin
+        plan: PathBuf,
+        /// Parse, resolve, validate, and dedupe-check without mutating
+        #[arg(long)]
+        dry_run: bool,
+        /// Validate custom fields against project schema before create/update writes
+        #[arg(long)]
+        validate: bool,
+        /// Explicit JSON resume state path
+        #[arg(long, value_name = "PATH")]
+        resume: Option<PathBuf>,
+        /// Allow real delete_issue operations
+        #[arg(long)]
+        allow_delete: bool,
+    },
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for
@@ -2730,6 +2747,59 @@ mod tests {
                 _ => panic!("expected issue update"),
             },
             _ => panic!("expected issue command"),
+        }
+    }
+
+    #[test]
+    fn parses_apply_command_with_plan_path() {
+        let cli = Cli::parse_from(["track", "apply", "plan.json"]);
+
+        match cli.command {
+            Commands::Apply {
+                plan,
+                dry_run,
+                validate,
+                resume,
+                allow_delete,
+            } => {
+                assert_eq!(plan, PathBuf::from("plan.json"));
+                assert!(!dry_run);
+                assert!(!validate);
+                assert!(resume.is_none());
+                assert!(!allow_delete);
+            }
+            _ => panic!("expected apply command"),
+        }
+    }
+
+    #[test]
+    fn parses_apply_command_with_stdin_and_flags() {
+        let cli = Cli::parse_from([
+            "track",
+            "apply",
+            "-",
+            "--dry-run",
+            "--validate",
+            "--resume",
+            "state.json",
+            "--allow-delete",
+        ]);
+
+        match cli.command {
+            Commands::Apply {
+                plan,
+                dry_run,
+                validate,
+                resume,
+                allow_delete,
+            } => {
+                assert_eq!(plan, PathBuf::from("-"));
+                assert!(dry_run);
+                assert!(validate);
+                assert_eq!(resume, Some(PathBuf::from("state.json")));
+                assert!(allow_delete);
+            }
+            _ => panic!("expected apply command"),
         }
     }
 }

--- a/crates/track/src/commands/apply.rs
+++ b/crates/track/src/commands/apply.rs
@@ -9,29 +9,30 @@ use std::io::Read;
 use std::path::Path;
 use tracker_core::{CreateIssue, CustomFieldUpdate, Issue, IssueTracker, UpdateIssue};
 
-pub fn handle_apply(
-    client: &dyn IssueTracker,
-    plan_path: &Path,
-    dry_run: bool,
-    validate: bool,
-    resume_path: Option<&Path>,
-    allow_delete: bool,
-    format: OutputFormat,
-    default_project: Option<&str>,
-) -> Result<()> {
-    let raw_plan = read_plan_bytes(plan_path)?;
+pub(crate) struct ApplyOptions<'a> {
+    pub(crate) plan_path: &'a Path,
+    pub(crate) dry_run: bool,
+    pub(crate) validate: bool,
+    pub(crate) resume_path: Option<&'a Path>,
+    pub(crate) allow_delete: bool,
+    pub(crate) format: OutputFormat,
+    pub(crate) default_project: Option<&'a str>,
+}
+
+pub fn handle_apply(client: &dyn IssueTracker, options: ApplyOptions<'_>) -> Result<()> {
+    let raw_plan = read_plan_bytes(options.plan_path)?;
     let checksum = plan_checksum(&raw_plan);
     let plan = parse_apply_plan(&raw_plan)?;
-    let (state, resumed) = load_resume_state(resume_path, &checksum)?;
+    let (state, resumed) = load_resume_state(options.resume_path, &checksum)?;
 
     if let Err(failure) = validate_reference_order(&plan) {
-        let output = failure_output(&plan, dry_run, resumed, state.refs, failure);
-        output_apply_result(&output, format)?;
+        let output = failure_output(&plan, options.dry_run, resumed, state.refs, failure);
+        output_apply_result(&output, options.format)?;
         return Err(anyhow!(first_error(&output)));
     }
 
-    if !dry_run
-        && !allow_delete
+    if !options.dry_run
+        && !options.allow_delete
         && let Some((index, op)) = plan
             .operations
             .iter()
@@ -40,7 +41,7 @@ pub fn handle_apply(
     {
         let output = failure_output(
             &plan,
-            dry_run,
+            options.dry_run,
             resumed,
             state.refs,
             PreflightFailure {
@@ -49,7 +50,7 @@ pub fn handle_apply(
                 message: "delete_issue operations require --allow-delete".to_string(),
             },
         );
-        output_apply_result(&output, format)?;
+        output_apply_result(&output, options.format)?;
         return Err(anyhow!(first_error(&output)));
     }
 
@@ -57,15 +58,15 @@ pub fn handle_apply(
         client,
         plan: &plan,
         checksum,
-        dry_run,
-        validate,
-        resume_path,
-        default_project,
+        dry_run: options.dry_run,
+        validate: options.validate,
+        resume_path: options.resume_path,
+        default_project: options.default_project,
         resumed,
         state,
     })?;
 
-    output_apply_result(&execution.output, format)?;
+    output_apply_result(&execution.output, options.format)?;
     if execution.output.success {
         Ok(())
     } else {
@@ -294,6 +295,15 @@ struct ApplyExecution<'a> {
     state: ApplyResumeState,
 }
 
+#[derive(Clone, Copy)]
+struct OperationContext<'a> {
+    client: &'a dyn IssueTracker,
+    plan: &'a ApplyPlan,
+    dry_run: bool,
+    validate: bool,
+    default_project: Option<&'a str>,
+}
+
 struct ExecutionResult {
     output: ApplyOutput,
     error: Option<String>,
@@ -316,6 +326,13 @@ fn execute_plan(execution: ApplyExecution<'_>) -> Result<ExecutionResult> {
         .map(|result| (result.index, result))
         .collect();
     let mut output_results = Vec::new();
+    let operation_context = OperationContext {
+        client: execution.client,
+        plan: execution.plan,
+        dry_run: execution.dry_run,
+        validate: execution.validate,
+        default_project: execution.default_project,
+    };
 
     for (index, operation) in execution.plan.operations.iter().enumerate() {
         if completed.contains(&index) {
@@ -327,16 +344,7 @@ fn execute_plan(execution: ApplyExecution<'_>) -> Result<ExecutionResult> {
             continue;
         }
 
-        match execute_operation(
-            execution.client,
-            execution.plan,
-            operation,
-            index,
-            execution.dry_run,
-            execution.validate,
-            execution.default_project,
-            &mut refs,
-        ) {
+        match execute_operation(operation_context, operation, index, &mut refs) {
             Ok(result) => {
                 if !execution.dry_run {
                     completed.insert(index);
@@ -390,13 +398,9 @@ fn execute_plan(execution: ApplyExecution<'_>) -> Result<ExecutionResult> {
 }
 
 fn execute_operation(
-    client: &dyn IssueTracker,
-    plan: &ApplyPlan,
+    context: OperationContext<'_>,
     operation: &ApplyOperation,
     index: usize,
-    dry_run: bool,
-    validate: bool,
-    default_project: Option<&str>,
     refs: &mut BTreeMap<String, String>,
 ) -> Result<ApplyOperationResult> {
     match operation {
@@ -414,12 +418,12 @@ fn execute_operation(
             parent,
             dedupe,
         } => execute_create_issue(
-            client,
-            plan,
+            context.client,
+            context.plan,
             index,
-            dry_run,
-            validate,
-            default_project,
+            context.dry_run,
+            context.validate,
+            context.default_project,
             refs,
             ref_name.as_deref(),
             project.as_deref(),
@@ -446,11 +450,11 @@ fn execute_operation(
             tags,
             parent,
         } => execute_update_issue(
-            client,
-            plan,
+            context.client,
+            context.plan,
             index,
-            dry_run,
-            validate,
+            context.dry_run,
+            context.validate,
             refs,
             issue,
             summary.as_deref(),
@@ -468,11 +472,16 @@ fn execute_operation(
             let mut result = ApplyOperationResult::success(
                 index,
                 operation.op_name(),
-                if dry_run { "dry_run" } else { "commented" },
+                if context.dry_run {
+                    "dry_run"
+                } else {
+                    "commented"
+                },
             );
             result.issue = Some(issue_id.clone());
-            if !dry_run {
-                client
+            if !context.dry_run {
+                context
+                    .client
                     .add_comment(&issue_id, body)
                     .with_context(|| format!("Failed to comment on '{}'", issue_id))?;
             }
@@ -488,11 +497,11 @@ fn execute_operation(
             let mut result = ApplyOperationResult::success(
                 index,
                 operation.op_name(),
-                if dry_run { "dry_run" } else { "linked" },
+                if context.dry_run { "dry_run" } else { "linked" },
             );
             result.issue = Some(source_id.clone());
-            if !dry_run {
-                issue::link_issues_with_type(client, &source_id, &target_id, link_type)?;
+            if !context.dry_run {
+                issue::link_issues_with_type(context.client, &source_id, &target_id, link_type)?;
             }
             Ok(result)
         }
@@ -501,11 +510,16 @@ fn execute_operation(
             let mut result = ApplyOperationResult::success(
                 index,
                 operation.op_name(),
-                if dry_run { "dry_run" } else { "deleted" },
+                if context.dry_run {
+                    "dry_run"
+                } else {
+                    "deleted"
+                },
             );
             result.issue = Some(issue_id.clone());
-            if !dry_run {
-                client
+            if !context.dry_run {
+                context
+                    .client
                     .delete_issue(&issue_id)
                     .with_context(|| format!("Failed to delete '{}'", issue_id))?;
             }

--- a/crates/track/src/commands/apply.rs
+++ b/crates/track/src/commands/apply.rs
@@ -1,0 +1,1249 @@
+use crate::cli::OutputFormat;
+use crate::commands::issue;
+use crate::output::output_json;
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
+use std::io::Read;
+use std::path::Path;
+use tracker_core::{CreateIssue, CustomFieldUpdate, Issue, IssueTracker, UpdateIssue};
+
+pub fn handle_apply(
+    client: &dyn IssueTracker,
+    plan_path: &Path,
+    dry_run: bool,
+    validate: bool,
+    resume_path: Option<&Path>,
+    allow_delete: bool,
+    format: OutputFormat,
+    default_project: Option<&str>,
+) -> Result<()> {
+    let raw_plan = read_plan_bytes(plan_path)?;
+    let checksum = plan_checksum(&raw_plan);
+    let plan = parse_apply_plan(&raw_plan)?;
+    let (state, resumed) = load_resume_state(resume_path, &checksum)?;
+
+    if let Err(failure) = validate_reference_order(&plan) {
+        let output = failure_output(&plan, dry_run, resumed, state.refs, failure);
+        output_apply_result(&output, format)?;
+        return Err(anyhow!(first_error(&output)));
+    }
+
+    if !dry_run
+        && !allow_delete
+        && let Some((index, op)) = plan
+            .operations
+            .iter()
+            .enumerate()
+            .find(|(_, op)| matches!(op, ApplyOperation::DeleteIssue { .. }))
+    {
+        let output = failure_output(
+            &plan,
+            dry_run,
+            resumed,
+            state.refs,
+            PreflightFailure {
+                index,
+                op: op.op_name().to_string(),
+                message: "delete_issue operations require --allow-delete".to_string(),
+            },
+        );
+        output_apply_result(&output, format)?;
+        return Err(anyhow!(first_error(&output)));
+    }
+
+    let execution = execute_plan(ApplyExecution {
+        client,
+        plan: &plan,
+        checksum,
+        dry_run,
+        validate,
+        resume_path,
+        default_project,
+        resumed,
+        state,
+    })?;
+
+    output_apply_result(&execution.output, format)?;
+    if execution.output.success {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            execution
+                .error
+                .unwrap_or_else(|| "apply failed".to_string())
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplyPlan {
+    version: u32,
+    #[serde(default)]
+    defaults: ApplyDefaults,
+    operations: Vec<ApplyOperation>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ApplyDefaults {
+    project: Option<String>,
+    validate: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+enum ApplyOperation {
+    CreateIssue {
+        #[serde(default, rename = "ref")]
+        ref_name: Option<String>,
+        #[serde(default)]
+        project: Option<String>,
+        summary: String,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default)]
+        fields: BTreeMap<String, PlanFieldValue>,
+        #[serde(default, rename = "customFields")]
+        custom_fields: Vec<serde_json::Value>,
+        #[serde(default)]
+        state: Option<String>,
+        #[serde(default)]
+        priority: Option<String>,
+        #[serde(default)]
+        assignee: Option<String>,
+        #[serde(default)]
+        tags: Vec<String>,
+        #[serde(default)]
+        parent: Option<String>,
+        #[serde(default)]
+        dedupe: Option<Dedupe>,
+    },
+    UpdateIssue {
+        issue: String,
+        #[serde(default)]
+        summary: Option<String>,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default)]
+        fields: BTreeMap<String, PlanFieldValue>,
+        #[serde(default, rename = "customFields")]
+        custom_fields: Vec<serde_json::Value>,
+        #[serde(default)]
+        state: Option<String>,
+        #[serde(default)]
+        priority: Option<String>,
+        #[serde(default)]
+        assignee: Option<String>,
+        #[serde(default)]
+        tags: Vec<String>,
+        #[serde(default)]
+        parent: Option<String>,
+    },
+    Comment {
+        issue: String,
+        body: String,
+    },
+    Link {
+        source: String,
+        target: String,
+        #[serde(default = "default_link_type", rename = "type")]
+        link_type: String,
+    },
+    DeleteIssue {
+        issue: String,
+    },
+}
+
+impl ApplyOperation {
+    fn op_name(&self) -> &'static str {
+        match self {
+            Self::CreateIssue { .. } => "create_issue",
+            Self::UpdateIssue { .. } => "update_issue",
+            Self::Comment { .. } => "comment",
+            Self::Link { .. } => "link",
+            Self::DeleteIssue { .. } => "delete_issue",
+        }
+    }
+
+    fn defined_ref(&self) -> Option<&str> {
+        match self {
+            Self::CreateIssue {
+                ref_name: Some(ref_name),
+                ..
+            } => Some(ref_name),
+            _ => None,
+        }
+    }
+
+    fn referenced_values(&self) -> Vec<&str> {
+        match self {
+            Self::CreateIssue { parent, .. } => parent.iter().map(String::as_str).collect(),
+            Self::UpdateIssue { issue, parent, .. } => {
+                let mut refs = vec![issue.as_str()];
+                if let Some(parent) = parent {
+                    refs.push(parent.as_str());
+                }
+                refs
+            }
+            Self::Comment { issue, .. } => vec![issue.as_str()],
+            Self::Link { source, target, .. } => vec![source.as_str(), target.as_str()],
+            Self::DeleteIssue { issue } => vec![issue.as_str()],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Dedupe {
+    query: String,
+    on_match: DedupeAction,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DedupeAction {
+    Reuse,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum PlanFieldValue {
+    Single(String),
+    Multi(Vec<String>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ApplyResumeState {
+    version: u32,
+    plan_checksum: String,
+    #[serde(default)]
+    completed: BTreeSet<usize>,
+    #[serde(default)]
+    refs: BTreeMap<String, String>,
+    #[serde(default)]
+    results: Vec<ApplyOperationResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ApplyOperationResult {
+    index: usize,
+    op: String,
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issue: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "ref")]
+    ref_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
+}
+
+impl ApplyOperationResult {
+    fn success(index: usize, op: &str, status: &str) -> Self {
+        Self {
+            index,
+            op: op.to_string(),
+            status: status.to_string(),
+            issue: None,
+            ref_name: None,
+            error: None,
+            warnings: Vec::new(),
+        }
+    }
+
+    fn failed(index: usize, op: &str, error: impl Into<String>) -> Self {
+        Self {
+            index,
+            op: op.to_string(),
+            status: "failed".to_string(),
+            issue: None,
+            ref_name: None,
+            error: Some(error.into()),
+            warnings: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ApplyOutput {
+    success: bool,
+    dry_run: bool,
+    resumed: bool,
+    summary: ApplySummary,
+    refs: BTreeMap<String, String>,
+    results: Vec<ApplyOperationResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct ApplySummary {
+    total: usize,
+    by_status: BTreeMap<String, usize>,
+    by_op: BTreeMap<String, usize>,
+}
+
+struct ApplyExecution<'a> {
+    client: &'a dyn IssueTracker,
+    plan: &'a ApplyPlan,
+    checksum: String,
+    dry_run: bool,
+    validate: bool,
+    resume_path: Option<&'a Path>,
+    default_project: Option<&'a str>,
+    resumed: bool,
+    state: ApplyResumeState,
+}
+
+struct ExecutionResult {
+    output: ApplyOutput,
+    error: Option<String>,
+}
+
+#[derive(Debug)]
+struct PreflightFailure {
+    index: usize,
+    op: String,
+    message: String,
+}
+
+fn execute_plan(execution: ApplyExecution<'_>) -> Result<ExecutionResult> {
+    let mut refs = execution.state.refs.clone();
+    let mut completed = execution.state.completed.clone();
+    let mut state_results: BTreeMap<usize, ApplyOperationResult> = execution
+        .state
+        .results
+        .into_iter()
+        .map(|result| (result.index, result))
+        .collect();
+    let mut output_results = Vec::new();
+
+    for (index, operation) in execution.plan.operations.iter().enumerate() {
+        if completed.contains(&index) {
+            let mut result = state_results.get(&index).cloned().unwrap_or_else(|| {
+                ApplyOperationResult::success(index, operation.op_name(), "skipped")
+            });
+            result.status = "skipped".to_string();
+            output_results.push(result);
+            continue;
+        }
+
+        match execute_operation(
+            execution.client,
+            execution.plan,
+            operation,
+            index,
+            execution.dry_run,
+            execution.validate,
+            execution.default_project,
+            &mut refs,
+        ) {
+            Ok(result) => {
+                if !execution.dry_run {
+                    completed.insert(index);
+                    state_results.insert(index, result.clone());
+                    write_resume_state(
+                        execution.resume_path,
+                        &execution.checksum,
+                        &completed,
+                        &refs,
+                        &state_results,
+                    )?;
+                }
+                output_results.push(result);
+            }
+            Err(error) => {
+                let message = error.to_string();
+                output_results.push(ApplyOperationResult::failed(
+                    index,
+                    operation.op_name(),
+                    message.clone(),
+                ));
+                let output = build_output(
+                    false,
+                    execution.dry_run,
+                    execution.resumed,
+                    execution.plan.operations.len(),
+                    refs,
+                    output_results,
+                );
+                return Ok(ExecutionResult {
+                    output,
+                    error: Some(message),
+                });
+            }
+        }
+    }
+
+    let output = build_output(
+        true,
+        execution.dry_run,
+        execution.resumed,
+        execution.plan.operations.len(),
+        refs,
+        output_results,
+    );
+
+    Ok(ExecutionResult {
+        output,
+        error: None,
+    })
+}
+
+fn execute_operation(
+    client: &dyn IssueTracker,
+    plan: &ApplyPlan,
+    operation: &ApplyOperation,
+    index: usize,
+    dry_run: bool,
+    validate: bool,
+    default_project: Option<&str>,
+    refs: &mut BTreeMap<String, String>,
+) -> Result<ApplyOperationResult> {
+    match operation {
+        ApplyOperation::CreateIssue {
+            ref_name,
+            project,
+            summary,
+            description,
+            fields,
+            custom_fields,
+            state,
+            priority,
+            assignee,
+            tags,
+            parent,
+            dedupe,
+        } => execute_create_issue(
+            client,
+            plan,
+            index,
+            dry_run,
+            validate,
+            default_project,
+            refs,
+            ref_name.as_deref(),
+            project.as_deref(),
+            summary,
+            description.as_deref(),
+            fields,
+            custom_fields,
+            state.as_deref(),
+            priority.as_deref(),
+            assignee.as_deref(),
+            tags,
+            parent.as_deref(),
+            dedupe.as_ref(),
+        ),
+        ApplyOperation::UpdateIssue {
+            issue,
+            summary,
+            description,
+            fields,
+            custom_fields,
+            state,
+            priority,
+            assignee,
+            tags,
+            parent,
+        } => execute_update_issue(
+            client,
+            plan,
+            index,
+            dry_run,
+            validate,
+            refs,
+            issue,
+            summary.as_deref(),
+            description.as_deref(),
+            fields,
+            custom_fields,
+            state.as_deref(),
+            priority.as_deref(),
+            assignee.as_deref(),
+            tags,
+            parent.as_deref(),
+        ),
+        ApplyOperation::Comment { issue, body } => {
+            let issue_id = resolve_issue_ref(issue, refs)?;
+            let mut result = ApplyOperationResult::success(
+                index,
+                operation.op_name(),
+                if dry_run { "dry_run" } else { "commented" },
+            );
+            result.issue = Some(issue_id.clone());
+            if !dry_run {
+                client
+                    .add_comment(&issue_id, body)
+                    .with_context(|| format!("Failed to comment on '{}'", issue_id))?;
+            }
+            Ok(result)
+        }
+        ApplyOperation::Link {
+            source,
+            target,
+            link_type,
+        } => {
+            let source_id = resolve_issue_ref(source, refs)?;
+            let target_id = resolve_issue_ref(target, refs)?;
+            let mut result = ApplyOperationResult::success(
+                index,
+                operation.op_name(),
+                if dry_run { "dry_run" } else { "linked" },
+            );
+            result.issue = Some(source_id.clone());
+            if !dry_run {
+                issue::link_issues_with_type(client, &source_id, &target_id, link_type)?;
+            }
+            Ok(result)
+        }
+        ApplyOperation::DeleteIssue { issue } => {
+            let issue_id = resolve_issue_ref(issue, refs)?;
+            let mut result = ApplyOperationResult::success(
+                index,
+                operation.op_name(),
+                if dry_run { "dry_run" } else { "deleted" },
+            );
+            result.issue = Some(issue_id.clone());
+            if !dry_run {
+                client
+                    .delete_issue(&issue_id)
+                    .with_context(|| format!("Failed to delete '{}'", issue_id))?;
+            }
+            Ok(result)
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_create_issue(
+    client: &dyn IssueTracker,
+    plan: &ApplyPlan,
+    index: usize,
+    dry_run: bool,
+    validate: bool,
+    default_project: Option<&str>,
+    refs: &mut BTreeMap<String, String>,
+    ref_name: Option<&str>,
+    project: Option<&str>,
+    summary: &str,
+    description: Option<&str>,
+    fields: &BTreeMap<String, PlanFieldValue>,
+    raw_custom_fields: &[serde_json::Value],
+    state: Option<&str>,
+    priority: Option<&str>,
+    assignee: Option<&str>,
+    tags: &[String],
+    parent: Option<&str>,
+    dedupe: Option<&Dedupe>,
+) -> Result<ApplyOperationResult> {
+    let project_input = project
+        .or(plan.defaults.project.as_deref())
+        .or(default_project)
+        .ok_or_else(|| {
+            anyhow!(
+                "Project is required for create_issue. Set operation.project, defaults.project, or config default_project."
+            )
+        })?;
+
+    let project_id = client
+        .resolve_project_id(project_input)
+        .with_context(|| format!("Failed to resolve project '{}'", project_input))?;
+    let schema = load_schema_for_detection(client, &project_id, !fields.is_empty());
+    let custom_fields = build_custom_field_updates(
+        fields,
+        raw_custom_fields,
+        state,
+        priority,
+        assignee,
+        schema.as_deref(),
+    )?;
+    let effective_validate = validate || plan.defaults.validate.unwrap_or(false);
+    if effective_validate {
+        issue::validate_custom_fields(client, &project_id, &custom_fields)?;
+    }
+
+    if let Some(dedupe) = dedupe {
+        let matches = dedupe_matches(client, dedupe)?;
+        match matches.as_slice() {
+            [] => {}
+            [existing] => {
+                let issue_id = issue_output_id(existing);
+                if let Some(ref_name) = ref_name {
+                    refs.insert(ref_name.to_string(), issue_id.clone());
+                }
+                let mut result = ApplyOperationResult::success(index, "create_issue", "reused");
+                result.issue = Some(issue_id);
+                result.ref_name = ref_name.map(String::from);
+                return Ok(result);
+            }
+            _ => {
+                let candidates = matches
+                    .iter()
+                    .map(issue_output_id)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                bail!(
+                    "Dedupe query matched multiple issues; refusing to create. Candidates: {}",
+                    candidates
+                );
+            }
+        }
+    }
+
+    let parent = parent
+        .map(|parent| resolve_issue_ref(parent, refs))
+        .transpose()?;
+    let create = CreateIssue {
+        project_id,
+        summary: summary.to_string(),
+        description: description.map(String::from),
+        custom_fields,
+        tags: tags.to_vec(),
+        parent,
+    };
+
+    if dry_run {
+        let issue_id = ref_name.map(planned_ref_value);
+        if let (Some(ref_name), Some(issue_id)) = (ref_name, issue_id.as_ref()) {
+            refs.insert(ref_name.to_string(), issue_id.clone());
+        }
+        let mut result = ApplyOperationResult::success(index, "create_issue", "dry_run");
+        result.issue = issue_id;
+        result.ref_name = ref_name.map(String::from);
+        return Ok(result);
+    }
+
+    let issue = client
+        .create_issue(&create)
+        .context("Failed to create issue")?;
+    let issue_id = issue_output_id(&issue);
+    if let Some(ref_name) = ref_name {
+        refs.insert(ref_name.to_string(), issue_id.clone());
+    }
+
+    let mut result = ApplyOperationResult::success(index, "create_issue", "created");
+    result.issue = Some(issue_id);
+    result.ref_name = ref_name.map(String::from);
+    result.warnings = issue::verify_issue_create(&create, &issue);
+    Ok(result)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_update_issue(
+    client: &dyn IssueTracker,
+    plan: &ApplyPlan,
+    index: usize,
+    dry_run: bool,
+    validate: bool,
+    refs: &BTreeMap<String, String>,
+    issue_ref: &str,
+    summary: Option<&str>,
+    description: Option<&str>,
+    fields: &BTreeMap<String, PlanFieldValue>,
+    raw_custom_fields: &[serde_json::Value],
+    state: Option<&str>,
+    priority: Option<&str>,
+    assignee: Option<&str>,
+    tags: &[String],
+    parent: Option<&str>,
+) -> Result<ApplyOperationResult> {
+    let issue_id = resolve_issue_ref(issue_ref, refs)?;
+    let effective_validate = validate || plan.defaults.validate.unwrap_or(false);
+    let existing = if !fields.is_empty()
+        || (effective_validate
+            && has_any_custom_field_input(fields, raw_custom_fields, state, priority, assignee))
+    {
+        Some(
+            client
+                .get_issue(&issue_id)
+                .with_context(|| format!("Failed to fetch issue '{}' for validation", issue_id))?,
+        )
+    } else {
+        None
+    };
+    let schema = existing.as_ref().and_then(|existing| {
+        load_schema_for_detection(client, &existing.project.id, !fields.is_empty())
+    });
+    let custom_fields = build_custom_field_updates(
+        fields,
+        raw_custom_fields,
+        state,
+        priority,
+        assignee,
+        schema.as_deref(),
+    )?;
+    let parent = parent
+        .map(|parent| resolve_issue_ref(parent, refs))
+        .transpose()?;
+
+    if summary.is_none()
+        && description.is_none()
+        && custom_fields.is_empty()
+        && tags.is_empty()
+        && parent.is_none()
+    {
+        bail!("update_issue operation must include at least one field to update");
+    }
+
+    if effective_validate && !custom_fields.is_empty() {
+        let existing = match existing {
+            Some(existing) => existing,
+            None => client
+                .get_issue(&issue_id)
+                .with_context(|| format!("Failed to fetch issue '{}' for validation", issue_id))?,
+        };
+        issue::validate_custom_fields(client, &existing.project.id, &custom_fields)?;
+    }
+
+    let update = UpdateIssue {
+        summary: summary.map(String::from),
+        description: description.map(String::from),
+        custom_fields,
+        tags: tags.to_vec(),
+        parent,
+    };
+
+    let mut result = ApplyOperationResult::success(
+        index,
+        "update_issue",
+        if dry_run { "dry_run" } else { "updated" },
+    );
+    result.issue = Some(issue_id.clone());
+
+    if dry_run {
+        return Ok(result);
+    }
+
+    let updated = client
+        .update_issue(&issue_id, &update)
+        .with_context(|| format!("Failed to update issue '{}'", issue_id))?;
+    result.issue = Some(issue_output_id(&updated));
+    result.warnings = issue::verify_issue_update(&update, &updated);
+    Ok(result)
+}
+
+fn build_custom_field_updates(
+    fields: &BTreeMap<String, PlanFieldValue>,
+    raw_custom_fields: &[serde_json::Value],
+    state: Option<&str>,
+    priority: Option<&str>,
+    assignee: Option<&str>,
+    schema: Option<&[tracker_core::ProjectCustomField]>,
+) -> Result<Vec<CustomFieldUpdate>> {
+    let mut updates = Vec::new();
+
+    for (name, value) in fields {
+        match value {
+            PlanFieldValue::Single(value) => updates.push(issue::build_custom_field_update(
+                name.clone(),
+                vec![value.clone()],
+                false,
+                schema,
+            )),
+            PlanFieldValue::Multi(values) => {
+                if values.is_empty() {
+                    bail!("Field '{}' array cannot be empty", name);
+                }
+                updates.push(issue::build_custom_field_update(
+                    name.clone(),
+                    values.clone(),
+                    true,
+                    schema,
+                ));
+            }
+        }
+    }
+
+    updates.extend(issue::parse_custom_fields_json(raw_custom_fields)?);
+
+    if let Some(state) = state {
+        updates.push(CustomFieldUpdate::State {
+            name: "State".to_string(),
+            value: state.to_string(),
+        });
+    }
+    if let Some(priority) = priority {
+        updates.push(CustomFieldUpdate::SingleEnum {
+            name: "Priority".to_string(),
+            value: priority.to_string(),
+        });
+    }
+    if let Some(assignee) = assignee {
+        updates.push(CustomFieldUpdate::SingleUser {
+            name: "Assignee".to_string(),
+            login: assignee.to_string(),
+        });
+    }
+
+    Ok(updates)
+}
+
+fn has_any_custom_field_input(
+    fields: &BTreeMap<String, PlanFieldValue>,
+    raw_custom_fields: &[serde_json::Value],
+    state: Option<&str>,
+    priority: Option<&str>,
+    assignee: Option<&str>,
+) -> bool {
+    !fields.is_empty()
+        || !raw_custom_fields.is_empty()
+        || state.is_some()
+        || priority.is_some()
+        || assignee.is_some()
+}
+
+fn dedupe_matches(client: &dyn IssueTracker, dedupe: &Dedupe) -> Result<Vec<Issue>> {
+    match dedupe.on_match {
+        DedupeAction::Reuse => {}
+    }
+    Ok(client
+        .search_issues(&dedupe.query, 2, 0)
+        .with_context(|| format!("Failed to run dedupe query '{}'", dedupe.query))?
+        .items)
+}
+
+fn load_schema_for_detection(
+    client: &dyn IssueTracker,
+    project_id: &str,
+    should_load: bool,
+) -> Option<Vec<tracker_core::ProjectCustomField>> {
+    if should_load {
+        client.get_project_custom_fields(project_id).ok()
+    } else {
+        None
+    }
+}
+
+fn parse_apply_plan(raw_plan: &[u8]) -> Result<ApplyPlan> {
+    let plan: ApplyPlan = serde_json::from_slice(raw_plan).context("Invalid JSON apply plan")?;
+    if plan.version != 1 {
+        bail!(
+            "Unsupported apply plan version {}. Expected version 1.",
+            plan.version
+        );
+    }
+    Ok(plan)
+}
+
+fn read_plan_bytes(path: &Path) -> Result<Vec<u8>> {
+    if path.as_os_str() == OsStr::new("-") {
+        let mut bytes = Vec::new();
+        std::io::stdin()
+            .lock()
+            .read_to_end(&mut bytes)
+            .context("Failed to read apply plan from stdin")?;
+        Ok(bytes)
+    } else {
+        std::fs::read(path)
+            .with_context(|| format!("Failed to read apply plan '{}'", path.display()))
+    }
+}
+
+fn resolve_issue_ref(value: &str, refs: &BTreeMap<String, String>) -> Result<String> {
+    if let Some(ref_name) = local_ref_name(value) {
+        refs.get(ref_name)
+            .cloned()
+            .ok_or_else(|| anyhow!("Unknown local ref '${}'", ref_name))
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+fn local_ref_name(value: &str) -> Option<&str> {
+    value.strip_prefix('$').filter(|name| !name.is_empty())
+}
+
+fn validate_reference_order(plan: &ApplyPlan) -> std::result::Result<(), PreflightFailure> {
+    let mut defined_refs = BTreeSet::new();
+    let mut duplicate_refs = BTreeSet::new();
+    for operation in &plan.operations {
+        if let Some(ref_name) = operation.defined_ref()
+            && !defined_refs.insert(ref_name.to_string())
+        {
+            duplicate_refs.insert(ref_name.to_string());
+        }
+    }
+
+    if let Some(duplicate) = duplicate_refs.into_iter().next() {
+        let index = plan
+            .operations
+            .iter()
+            .position(|op| op.defined_ref() == Some(duplicate.as_str()))
+            .unwrap_or(0);
+        return Err(PreflightFailure {
+            index,
+            op: plan.operations[index].op_name().to_string(),
+            message: format!("Duplicate local ref '${}'", duplicate),
+        });
+    }
+
+    let mut seen_refs = BTreeSet::new();
+    for (index, operation) in plan.operations.iter().enumerate() {
+        for value in operation.referenced_values() {
+            if let Some(ref_name) = local_ref_name(value)
+                && !seen_refs.contains(ref_name)
+            {
+                return Err(PreflightFailure {
+                    index,
+                    op: operation.op_name().to_string(),
+                    message: format!("Operation references '${}' before it is defined", ref_name),
+                });
+            }
+        }
+        if let Some(ref_name) = operation.defined_ref() {
+            seen_refs.insert(ref_name.to_string());
+        }
+    }
+
+    Ok(())
+}
+
+fn load_resume_state(
+    resume_path: Option<&Path>,
+    checksum: &str,
+) -> Result<(ApplyResumeState, bool)> {
+    let Some(path) = resume_path else {
+        return Ok((new_resume_state(checksum), false));
+    };
+
+    if !path.exists() {
+        return Ok((new_resume_state(checksum), false));
+    }
+
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read resume state '{}'", path.display()))?;
+    let state: ApplyResumeState = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse resume state '{}'", path.display()))?;
+    if state.plan_checksum != checksum {
+        bail!("Resume state checksum does not match apply plan");
+    }
+    Ok((state, true))
+}
+
+fn new_resume_state(checksum: &str) -> ApplyResumeState {
+    ApplyResumeState {
+        version: 1,
+        plan_checksum: checksum.to_string(),
+        completed: BTreeSet::new(),
+        refs: BTreeMap::new(),
+        results: Vec::new(),
+    }
+}
+
+fn write_resume_state(
+    resume_path: Option<&Path>,
+    checksum: &str,
+    completed: &BTreeSet<usize>,
+    refs: &BTreeMap<String, String>,
+    state_results: &BTreeMap<usize, ApplyOperationResult>,
+) -> Result<()> {
+    let Some(path) = resume_path else {
+        return Ok(());
+    };
+
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create resume state directory '{}'",
+                parent.display()
+            )
+        })?;
+    }
+
+    let state = ApplyResumeState {
+        version: 1,
+        plan_checksum: checksum.to_string(),
+        completed: completed.clone(),
+        refs: refs.clone(),
+        results: state_results.values().cloned().collect(),
+    };
+    let json = serde_json::to_vec_pretty(&state).context("Failed to serialize resume state")?;
+    std::fs::write(path, json)
+        .with_context(|| format!("Failed to write resume state '{}'", path.display()))?;
+    Ok(())
+}
+
+fn build_output(
+    success: bool,
+    dry_run: bool,
+    resumed: bool,
+    total: usize,
+    refs: BTreeMap<String, String>,
+    results: Vec<ApplyOperationResult>,
+) -> ApplyOutput {
+    ApplyOutput {
+        success,
+        dry_run,
+        resumed,
+        summary: summarize_results(total, &results),
+        refs,
+        results,
+    }
+}
+
+fn summarize_results(total: usize, results: &[ApplyOperationResult]) -> ApplySummary {
+    let mut by_status = BTreeMap::new();
+    let mut by_op = BTreeMap::new();
+    for result in results {
+        *by_status.entry(result.status.clone()).or_insert(0) += 1;
+        *by_op.entry(result.op.clone()).or_insert(0) += 1;
+    }
+    ApplySummary {
+        total,
+        by_status,
+        by_op,
+    }
+}
+
+fn failure_output(
+    plan: &ApplyPlan,
+    dry_run: bool,
+    resumed: bool,
+    refs: BTreeMap<String, String>,
+    failure: PreflightFailure,
+) -> ApplyOutput {
+    build_output(
+        false,
+        dry_run,
+        resumed,
+        plan.operations.len(),
+        refs,
+        vec![ApplyOperationResult::failed(
+            failure.index,
+            &failure.op,
+            failure.message,
+        )],
+    )
+}
+
+fn output_apply_result(output: &ApplyOutput, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => output_json(output),
+        OutputFormat::Text => {
+            output_apply_text(output);
+            Ok(())
+        }
+    }
+}
+
+fn output_apply_text(output: &ApplyOutput) {
+    let status = if output.success {
+        "Apply completed"
+    } else {
+        "Apply failed"
+    };
+    let dry_run = if output.dry_run { " (dry run)" } else { "" };
+    let resumed = if output.resumed { " resumed" } else { "" };
+    println!("{status}{dry_run}{resumed}");
+    println!("{} operation(s)", output.summary.total);
+
+    for result in &output.results {
+        let issue = result.issue.as_deref().unwrap_or("-");
+        let ref_name = result
+            .ref_name
+            .as_deref()
+            .map(|name| format!(" ${name}"))
+            .unwrap_or_default();
+        if let Some(error) = &result.error {
+            println!(
+                "[{}] {} {}{}: {}",
+                result.index, result.op, result.status, ref_name, error
+            );
+        } else {
+            println!(
+                "[{}] {} {} {}{}",
+                result.index, result.op, result.status, issue, ref_name
+            );
+        }
+        for warning in &result.warnings {
+            println!("  warning: {warning}");
+        }
+    }
+
+    if !output.refs.is_empty() {
+        println!("refs:");
+        for (name, value) in &output.refs {
+            println!("  ${name} = {value}");
+        }
+    }
+}
+
+fn first_error(output: &ApplyOutput) -> String {
+    output
+        .results
+        .iter()
+        .find_map(|result| result.error.clone())
+        .unwrap_or_else(|| "apply failed".to_string())
+}
+
+fn issue_output_id(issue: &Issue) -> String {
+    if issue.id_readable.is_empty() {
+        issue.id.clone()
+    } else {
+        issue.id_readable.clone()
+    }
+}
+
+fn planned_ref_value(ref_name: &str) -> String {
+    format!("planned:{ref_name}")
+}
+
+fn default_link_type() -> String {
+    "relates".to_string()
+}
+
+fn plan_checksum(bytes: &[u8]) -> String {
+    // Stable FNV-1a checksum. This is not intended for cryptographic use; it
+    // only guards explicit resume files against being paired with a different plan.
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracker_core::CustomFieldUpdate;
+
+    #[test]
+    fn plan_deserializes_supported_operations() {
+        let plan = parse_apply_plan(
+            br#"{
+                "version": 1,
+                "defaults": {"project": "DEMO", "validate": true},
+                "operations": [
+                    {"ref": "epic", "op": "create_issue", "summary": "Parent"},
+                    {"op": "update_issue", "issue": "$epic", "summary": "Updated"},
+                    {"op": "comment", "issue": "$epic", "body": "hello"},
+                    {"op": "link", "source": "$epic", "target": "DEMO-2", "type": "relates"},
+                    {"op": "delete_issue", "issue": "DEMO-9"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(plan.version, 1);
+        assert_eq!(plan.operations.len(), 5);
+        assert_eq!(plan.defaults.project.as_deref(), Some("DEMO"));
+        assert_eq!(plan.defaults.validate, Some(true));
+    }
+
+    #[test]
+    fn field_object_conversion_preserves_string_and_array_values() {
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "Priority".to_string(),
+            PlanFieldValue::Single("Major".to_string()),
+        );
+        fields.insert(
+            "Platform".to_string(),
+            PlanFieldValue::Multi(vec!["macOS".to_string(), "Linux".to_string()]),
+        );
+
+        let updates = build_custom_field_updates(&fields, &[], None, None, None, None).unwrap();
+
+        assert!(matches!(
+            &updates[0],
+            CustomFieldUpdate::MultiEnum { name, values }
+                if name == "Platform" && values == &vec!["macOS".to_string(), "Linux".to_string()]
+        ));
+        assert!(matches!(
+            &updates[1],
+            CustomFieldUpdate::SingleEnum { name, value }
+                if name == "Priority" && value == "Major"
+        ));
+    }
+
+    #[test]
+    fn raw_custom_fields_conversion_supports_multi_enum_shape() {
+        let raw = vec![serde_json::json!({
+            "$type": "MultiEnumIssueCustomField",
+            "name": "Platform",
+            "value": [{"name": "macOS"}, {"name": "Linux"}]
+        })];
+
+        let updates = issue::parse_custom_fields_json(&raw).unwrap();
+
+        assert!(matches!(
+            &updates[0],
+            CustomFieldUpdate::MultiEnum { name, values }
+                if name == "Platform" && values == &vec!["macOS".to_string(), "Linux".to_string()]
+        ));
+    }
+
+    #[test]
+    fn ref_resolution_uses_existing_refs() {
+        let refs = BTreeMap::from([("epic".to_string(), "DEMO-1".to_string())]);
+        assert_eq!(resolve_issue_ref("$epic", &refs).unwrap(), "DEMO-1");
+        assert_eq!(resolve_issue_ref("DEMO-2", &refs).unwrap(), "DEMO-2");
+        assert!(resolve_issue_ref("$missing", &refs).is_err());
+    }
+
+    #[test]
+    fn reference_validation_rejects_forward_refs() {
+        let plan = parse_apply_plan(
+            br#"{
+                "version": 1,
+                "operations": [
+                    {"op": "comment", "issue": "$epic", "body": "too soon"},
+                    {"ref": "epic", "op": "create_issue", "project": "DEMO", "summary": "Parent"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let failure = validate_reference_order(&plan).unwrap_err();
+        assert_eq!(failure.index, 0);
+        assert!(failure.message.contains("before it is defined"));
+    }
+
+    #[test]
+    fn resume_checksum_mismatch_is_rejected() {
+        let dir =
+            std::env::temp_dir().join(format!("track-apply-resume-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let state_path = dir.join("state.json");
+        std::fs::write(
+            &state_path,
+            r#"{"version":1,"plan_checksum":"old","completed":[],"refs":{},"results":[]}"#,
+        )
+        .unwrap();
+
+        let err = load_resume_state(Some(&state_path), "new").unwrap_err();
+        assert!(err.to_string().contains("checksum"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn delete_guard_failure_output_points_at_delete_operation() {
+        let plan = parse_apply_plan(
+            br#"{
+                "version": 1,
+                "operations": [{"op": "delete_issue", "issue": "DEMO-1"}]
+            }"#,
+        )
+        .unwrap();
+
+        let output = failure_output(
+            &plan,
+            false,
+            false,
+            BTreeMap::new(),
+            PreflightFailure {
+                index: 0,
+                op: "delete_issue".to_string(),
+                message: "delete_issue operations require --allow-delete".to_string(),
+            },
+        );
+
+        assert!(!output.success);
+        assert_eq!(output.results[0].status, "failed");
+        assert_eq!(output.results[0].op, "delete_issue");
+    }
+}

--- a/crates/track/src/commands/issue.rs
+++ b/crates/track/src/commands/issue.rs
@@ -491,7 +491,11 @@ fn build_update(client: &dyn IssueTracker, id: &str, args: &IssueFieldArgs) -> R
     Ok(update)
 }
 
-fn validate_update(client: &dyn IssueTracker, id: &str, update: &UpdateIssue) -> Result<usize> {
+pub(crate) fn validate_update(
+    client: &dyn IssueTracker,
+    id: &str,
+    update: &UpdateIssue,
+) -> Result<usize> {
     if !update.custom_fields.is_empty() {
         let existing_issue = client
             .get_issue(id)
@@ -528,7 +532,7 @@ fn output_update_dry_run(id: &str, fields_validated: usize, format: OutputFormat
 /// When `project_fields` is provided, the field type is detected from the project schema
 /// so that state fields, user fields, and enum fields get the correct `$type` discriminator.
 /// Without schema info, generic `--field` arguments default to SingleEnum.
-fn build_custom_fields(
+pub(crate) fn build_custom_fields(
     fields: &[String],
     state: Option<&str>,
     priority: Option<&str>,
@@ -554,20 +558,12 @@ fn build_custom_fields(
             );
         }
 
-        let detected_type = matched_field.map(|f| f.field_type.as_str());
-
-        let update = match detected_type {
-            Some(ft) if ft.contains("state") => CustomFieldUpdate::State { name, value },
-            Some(ft) if ft.contains("user") => CustomFieldUpdate::SingleUser { name, login: value },
-            // enum[*] = multi-enum, supports comma-separated values
-            Some(ft) if ft.contains("enum[*]") || ft.contains("multi-enum") => {
-                let values = value.split(',').map(|v| v.trim().to_string()).collect();
-                CustomFieldUpdate::MultiEnum { name, values }
-            }
-            _ => CustomFieldUpdate::SingleEnum { name, value },
-        };
-
-        custom_fields.push(update);
+        custom_fields.push(build_custom_field_update(
+            name,
+            vec![value],
+            false,
+            project_fields,
+        ));
     }
 
     // Add state if provided
@@ -597,8 +593,35 @@ fn build_custom_fields(
     Ok(custom_fields)
 }
 
+pub(crate) fn build_custom_field_update(
+    name: String,
+    values: Vec<String>,
+    force_multi: bool,
+    project_fields: Option<&[ProjectCustomField]>,
+) -> CustomFieldUpdate {
+    if force_multi {
+        return CustomFieldUpdate::MultiEnum { name, values };
+    }
+
+    let value = values.into_iter().next().unwrap_or_default();
+    let detected_type = project_fields
+        .and_then(|pf| pf.iter().find(|f| unicode_eq_ignore_case(&f.name, &name)))
+        .map(|f| f.field_type.as_str());
+
+    match detected_type {
+        Some(ft) if ft.contains("state") => CustomFieldUpdate::State { name, value },
+        Some(ft) if ft.contains("user") => CustomFieldUpdate::SingleUser { name, login: value },
+        // enum[*] = multi-enum, supports comma-separated values for CLI parity.
+        Some(ft) if ft.contains("enum[*]") || ft.contains("multi-enum") => {
+            let values = value.split(',').map(|v| v.trim().to_string()).collect();
+            CustomFieldUpdate::MultiEnum { name, values }
+        }
+        _ => CustomFieldUpdate::SingleEnum { name, value },
+    }
+}
+
 /// Validate custom fields against project schema
-fn validate_custom_fields(
+pub(crate) fn validate_custom_fields(
     client: &dyn IssueTracker,
     project_id: &str,
     custom_fields: &[CustomFieldUpdate],
@@ -781,7 +804,9 @@ fn parse_update_payload(payload: &str) -> Result<UpdateIssue> {
 }
 
 /// Parse custom fields from raw JSON values
-fn parse_custom_fields_json(fields: &[serde_json::Value]) -> Result<Vec<CustomFieldUpdate>> {
+pub(crate) fn parse_custom_fields_json(
+    fields: &[serde_json::Value],
+) -> Result<Vec<CustomFieldUpdate>> {
     let mut result = Vec::new();
 
     for field in fields {
@@ -814,6 +839,23 @@ fn parse_custom_fields_json(fields: &[serde_json::Value]) -> Result<Vec<CustomFi
                     .unwrap_or("")
                     .to_string();
                 CustomFieldUpdate::SingleUser { name, login }
+            }
+            "MultiEnumIssueCustomField" => {
+                let values = field
+                    .get("value")
+                    .and_then(|v| v.as_array())
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(|item| {
+                                item.get("name")
+                                    .and_then(|name| name.as_str())
+                                    .map(String::from)
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                CustomFieldUpdate::MultiEnum { name, values }
             }
             _ => {
                 // Default to SingleEnum for unknown types
@@ -1191,95 +1233,105 @@ fn handle_link(
     link_type: &str,
     format: OutputFormat,
 ) -> Result<()> {
-    // Parent-child relationships use link_subtask() — each backend implements this natively
-    match link_type.to_lowercase().as_str() {
-        "subtask" | "subtask-of" => {
-            client
-                .link_subtask(source, target)
-                .with_context(|| format!("Failed to set {} as subtask of {}", source, target))?;
-            let description = "is subtask of";
-            match format {
-                OutputFormat::Json => {
-                    println!(
-                        r#"{{"success":true,"source":"{}","target":"{}","linkType":"{}","description":"{}"}}"#,
-                        source, target, link_type, description
-                    );
-                }
-                OutputFormat::Text => {
-                    use colored::Colorize;
-                    println!(
-                        "{} {} {}",
-                        source.cyan().bold(),
-                        description.dimmed(),
-                        target.cyan().bold()
-                    );
-                }
-            }
-            return Ok(());
-        }
-        "parent" | "parent-of" => {
-            client
-                .link_subtask(target, source)
-                .with_context(|| format!("Failed to set {} as parent of {}", source, target))?;
-            let description = "is parent of";
-            match format {
-                OutputFormat::Json => {
-                    println!(
-                        r#"{{"success":true,"source":"{}","target":"{}","linkType":"{}","description":"{}"}}"#,
-                        source, target, link_type, description
-                    );
-                }
-                OutputFormat::Text => {
-                    use colored::Colorize;
-                    println!(
-                        "{} {} {}",
-                        source.cyan().bold(),
-                        description.dimmed(),
-                        target.cyan().bold()
-                    );
-                }
-            }
-            return Ok(());
-        }
-        _ => {}
-    }
-
-    // All other link types use link_issues()
-    let lowered = link_type.to_lowercase();
-    let (canonical_type, direction, description) = match lowered.as_str() {
-        "relates" => ("relates", "BOTH", "relates to"),
-        "depends" => ("depends", "OUTWARD", "depends on"),
-        "required" | "required-for" => ("required", "INWARD", "is required for"),
-        "duplicates" | "duplicate" => ("duplicates", "OUTWARD", "duplicates"),
-        "duplicated-by" => ("duplicated-by", "INWARD", "is duplicated by"),
-        // Pass through unrecognized types to the backend as-is (bidirectional default).
-        // This supports custom link types defined by backend admins, either directly
-        // by native name or via link_mappings config.
-        _ => (lowered.as_str(), "BOTH", lowered.as_str()),
-    };
-
-    client
-        .link_issues(source, target, canonical_type, direction)
-        .with_context(|| format!("Failed to link {} to {}", source, target))?;
+    let outcome = link_issues_with_type(client, source, target, link_type)?;
 
     match format {
         OutputFormat::Json => {
             println!(
                 r#"{{"success":true,"source":"{}","target":"{}","linkType":"{}","description":"{}"}}"#,
-                source, target, link_type, description
+                outcome.source, outcome.target, outcome.link_type, outcome.description
             );
         }
         OutputFormat::Text => {
             use colored::Colorize;
             println!(
                 "{} {} {}",
-                source.cyan().bold(),
-                description.dimmed(),
-                target.cyan().bold()
+                outcome.source.cyan().bold(),
+                outcome.description.dimmed(),
+                outcome.target.cyan().bold()
             );
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LinkOutcome {
+    pub source: String,
+    pub target: String,
+    pub link_type: String,
+    pub description: String,
+}
+
+pub(crate) fn link_issues_with_type(
+    client: &dyn IssueTracker,
+    source: &str,
+    target: &str,
+    link_type: &str,
+) -> Result<LinkOutcome> {
+    // Parent-child relationships use link_subtask() — each backend implements this natively.
+    match link_type.to_lowercase().as_str() {
+        "subtask" | "subtask-of" => {
+            client
+                .link_subtask(source, target)
+                .with_context(|| format!("Failed to set {} as subtask of {}", source, target))?;
+            return Ok(LinkOutcome {
+                source: source.to_string(),
+                target: target.to_string(),
+                link_type: link_type.to_string(),
+                description: "is subtask of".to_string(),
+            });
+        }
+        "parent" | "parent-of" => {
+            client
+                .link_subtask(target, source)
+                .with_context(|| format!("Failed to set {} as parent of {}", source, target))?;
+            return Ok(LinkOutcome {
+                source: source.to_string(),
+                target: target.to_string(),
+                link_type: link_type.to_string(),
+                description: "is parent of".to_string(),
+            });
+        }
+        _ => {}
+    }
+
+    // All other link types use link_issues().
+    let lowered = link_type.to_lowercase();
+    let (canonical_type, direction, description) = match lowered.as_str() {
+        "relates" => ("relates".to_string(), "BOTH", "relates to".to_string()),
+        "depends" => ("depends".to_string(), "OUTWARD", "depends on".to_string()),
+        "required" | "required-for" => (
+            "required".to_string(),
+            "INWARD",
+            "is required for".to_string(),
+        ),
+        "duplicates" | "duplicate" => (
+            "duplicates".to_string(),
+            "OUTWARD",
+            "duplicates".to_string(),
+        ),
+        "duplicated-by" => (
+            "duplicated-by".to_string(),
+            "INWARD",
+            "is duplicated by".to_string(),
+        ),
+        // Pass through unrecognized types to the backend as-is (bidirectional default).
+        // This supports custom link types defined by backend admins, either directly
+        // by native name or via link_mappings config.
+        _ => (lowered.clone(), "BOTH", lowered),
+    };
+
+    client
+        .link_issues(source, target, &canonical_type, direction)
+        .with_context(|| format!("Failed to link {} to {}", source, target))?;
+
+    Ok(LinkOutcome {
+        source: source.to_string(),
+        target: target.to_string(),
+        link_type: link_type.to_string(),
+        description,
+    })
 }
 
 fn handle_unlink(
@@ -1634,7 +1686,7 @@ fn output_batch_results(results: &[BatchResult], action: &str, format: OutputFor
 
 /// Verify that an issue update was correctly applied by the backend.
 /// Returns a list of warning messages for fields that do not match the request.
-fn verify_issue_update(requested: &UpdateIssue, result: &Issue) -> Vec<String> {
+pub(crate) fn verify_issue_update(requested: &UpdateIssue, result: &Issue) -> Vec<String> {
     let mut warnings = Vec::new();
 
     if let Some(req_summary) = &requested.summary
@@ -1662,7 +1714,7 @@ fn verify_issue_update(requested: &UpdateIssue, result: &Issue) -> Vec<String> {
 }
 
 /// Verify that an issue creation correctly applied all requested fields.
-fn verify_issue_create(requested: &CreateIssue, result: &Issue) -> Vec<String> {
+pub(crate) fn verify_issue_create(requested: &CreateIssue, result: &Issue) -> Vec<String> {
     let mut warnings = Vec::new();
 
     if result.summary != requested.summary {

--- a/crates/track/src/commands/mod.rs
+++ b/crates/track/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod apply;
 pub mod article;
 pub(crate) mod attachments;
 pub mod bundle;

--- a/crates/track/src/main.rs
+++ b/crates/track/src/main.rs
@@ -262,13 +262,15 @@ fn run_with_client(
             allow_delete,
         } => commands::apply::handle_apply(
             issue_client,
-            plan,
-            *dry_run,
-            *validate,
-            resume.as_deref(),
-            *allow_delete,
-            cli.format,
-            config.default_project.as_deref(),
+            commands::apply::ApplyOptions {
+                plan_path: plan,
+                dry_run: *dry_run,
+                validate: *validate,
+                resume_path: resume.as_deref(),
+                allow_delete: *allow_delete,
+                format: cli.format,
+                default_project: config.default_project.as_deref(),
+            },
         ),
         Commands::Completions { .. } => {
             unreachable!("Completions command should be handled before API validation")

--- a/crates/track/src/main.rs
+++ b/crates/track/src/main.rs
@@ -254,6 +254,22 @@ fn run_with_client(
                 config.default_project.as_deref(),
             )
         }
+        Commands::Apply {
+            plan,
+            dry_run,
+            validate,
+            resume,
+            allow_delete,
+        } => commands::apply::handle_apply(
+            issue_client,
+            plan,
+            *dry_run,
+            *validate,
+            resume.as_deref(),
+            *allow_delete,
+            cli.format,
+            config.default_project.as_deref(),
+        ),
         Commands::Completions { .. } => {
             unreachable!("Completions command should be handled before API validation")
         }

--- a/crates/track/tests/apply_integration_tests.rs
+++ b/crates/track/tests/apply_integration_tests.rs
@@ -1,0 +1,780 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn temp_dir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "track-apply-test-{}-{}-{}",
+        std::process::id(),
+        nanos,
+        n
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn track_in(dir: &Path, scenario: &Path) -> assert_cmd::Command {
+    let mut cmd = cargo_bin_cmd!("track");
+    cmd.current_dir(dir)
+        .env("HOME", dir)
+        .env("USERPROFILE", dir)
+        .env("TRACK_MOCK_DIR", scenario)
+        .env_remove("TRACKER_BACKEND")
+        .env_remove("TRACKER_CONFIG")
+        .env_remove("YOUTRACK_URL")
+        .env_remove("YOUTRACK_TOKEN")
+        .env_remove("JIRA_URL")
+        .env_remove("JIRA_EMAIL")
+        .env_remove("JIRA_TOKEN")
+        .env_remove("GITHUB_TOKEN")
+        .env_remove("GITHUB_OWNER")
+        .env_remove("GITHUB_REPO")
+        .env_remove("GITHUB_API_URL")
+        .env_remove("GITLAB_TOKEN")
+        .env_remove("GITLAB_URL")
+        .env_remove("GITLAB_PROJECT_ID")
+        .env_remove("GITLAB_NAMESPACE")
+        .env_remove("LINEAR_TOKEN")
+        .env_remove("LINEAR_API_URL")
+        .env_remove("LINEAR_URL")
+        .env_remove("LINEAR_DEFAULT_TEAM")
+        .env_remove("LINEAR_DEFAULT_PROJECT")
+        .args(["--url", "https://mock.test", "--token", "mock-token"]);
+    cmd
+}
+
+fn write_scenario(dir: &Path, manifest: &str, responses: &[(&str, Value)]) -> PathBuf {
+    let scenario = dir.join("scenario");
+    let responses_dir = scenario.join("responses");
+    fs::create_dir_all(&responses_dir).unwrap();
+    fs::write(scenario.join("manifest.toml"), manifest).unwrap();
+    fs::write(scenario.join("call_log.jsonl"), "").unwrap();
+    for (name, value) in responses {
+        fs::write(
+            responses_dir.join(name),
+            serde_json::to_string(value).unwrap(),
+        )
+        .unwrap();
+    }
+    scenario
+}
+
+fn base_manifest(extra: &str) -> String {
+    format!(
+        r#"
+[[responses]]
+method = "resolve_project_id"
+file = "resolve_project_id_DEMO.json"
+[responses.args]
+identifier = "DEMO"
+
+[[responses]]
+method = "get_project_custom_fields"
+file = "project_custom_fields.json"
+[responses.args]
+project_id = "*"
+
+{extra}
+"#
+    )
+}
+
+fn project_fields() -> Value {
+    json!([
+        {
+            "id": "field-state",
+            "name": "State",
+            "field_type": "state[1]",
+            "required": false,
+            "values": ["Open", "In Progress", "Done"]
+        },
+        {
+            "id": "field-priority",
+            "name": "Priority",
+            "field_type": "enum[1]",
+            "required": false,
+            "values": ["Major", "Minor", "Normal"]
+        },
+        {
+            "id": "field-platform",
+            "name": "Platform",
+            "field_type": "enum[*]",
+            "required": false,
+            "values": ["macOS", "Linux"]
+        }
+    ])
+}
+
+fn issue_json(id: &str, summary: &str, state: &str, priority: &str) -> Value {
+    json!({
+        "id": format!("internal-{id}"),
+        "id_readable": id,
+        "summary": summary,
+        "description": "Issue description",
+        "project": {
+            "id": "0-1",
+            "name": "Demo Project",
+            "short_name": "DEMO"
+        },
+        "custom_fields": [
+            {
+                "State": {
+                    "name": "State",
+                    "value": state,
+                    "is_resolved": state == "Done"
+                }
+            },
+            {
+                "SingleEnum": {
+                    "name": "Priority",
+                    "value": priority
+                }
+            }
+        ],
+        "tags": [],
+        "created": "2024-01-10T09:00:00Z",
+        "updated": "2024-01-15T14:30:00Z",
+        "resolved": null
+    })
+}
+
+fn comment_json(id: &str, text: &str) -> Value {
+    json!({
+        "id": id,
+        "text": text,
+        "author": null,
+        "created": null
+    })
+}
+
+fn standard_responses() -> Vec<(&'static str, Value)> {
+    vec![
+        ("resolve_project_id_DEMO.json", json!("0-1")),
+        ("project_custom_fields.json", project_fields()),
+    ]
+}
+
+fn write_plan(dir: &Path, name: &str, plan: Value) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, serde_json::to_string_pretty(&plan).unwrap()).unwrap();
+    path
+}
+
+fn parse_stdout_json(output: &[u8]) -> Value {
+    serde_json::from_slice(output).unwrap()
+}
+
+fn mock_call_methods(scenario: &Path) -> Vec<String> {
+    let log = fs::read_to_string(scenario.join("call_log.jsonl")).unwrap_or_default();
+    log.lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .map(|entry| entry["method"].as_str().unwrap().to_string())
+        .collect()
+}
+
+fn method_count(methods: &[String], method: &str) -> usize {
+    methods
+        .iter()
+        .filter(|actual| actual.as_str() == method)
+        .count()
+}
+
+#[test]
+fn apply_runs_create_update_comment_and_link_plan() {
+    let dir = temp_dir();
+    let manifest = base_manifest(
+        r#"
+[[responses]]
+method = "create_issue"
+file = "create_parent.json"
+[responses.args]
+project = "0-1"
+summary = "Parent issue"
+
+[[responses]]
+method = "create_issue"
+file = "create_child.json"
+[responses.args]
+project = "0-1"
+summary = "Child issue"
+
+[[responses]]
+method = "get_issue"
+file = "get_parent.json"
+[responses.args]
+id = "DEMO-100"
+
+[[responses]]
+method = "update_issue"
+file = "update_parent.json"
+[responses.args]
+id = "DEMO-100"
+
+[[responses]]
+method = "add_comment"
+file = "comment_parent.json"
+[responses.args]
+issue_id = "DEMO-100"
+
+[[responses]]
+method = "link_subtask"
+file = "ok.json"
+[responses.args]
+child = "DEMO-101"
+parent = "DEMO-100"
+"#,
+    );
+    let mut responses = standard_responses();
+    responses.extend([
+        (
+            "create_parent.json",
+            issue_json("DEMO-100", "Parent issue", "Open", "Major"),
+        ),
+        (
+            "create_child.json",
+            issue_json("DEMO-101", "Child issue", "Open", "Normal"),
+        ),
+        (
+            "get_parent.json",
+            issue_json("DEMO-100", "Parent issue", "Open", "Major"),
+        ),
+        (
+            "update_parent.json",
+            issue_json("DEMO-100", "Parent issue", "In Progress", "Major"),
+        ),
+        (
+            "comment_parent.json",
+            comment_json("comment-1", "Created from apply"),
+        ),
+        ("ok.json", Value::Null),
+    ]);
+    let scenario = write_scenario(&dir, &manifest, &responses);
+    let plan = write_plan(
+        &dir,
+        "plan.json",
+        json!({
+            "version": 1,
+            "defaults": {"project": "DEMO", "validate": true},
+            "operations": [
+                {
+                    "ref": "parent",
+                    "op": "create_issue",
+                    "summary": "Parent issue",
+                    "fields": {"Priority": "Major"}
+                },
+                {
+                    "ref": "child",
+                    "op": "create_issue",
+                    "summary": "Child issue",
+                    "parent": "$parent"
+                },
+                {
+                    "op": "update_issue",
+                    "issue": "$parent",
+                    "fields": {"State": "In Progress"}
+                },
+                {
+                    "op": "comment",
+                    "issue": "$parent",
+                    "body": "Created from apply"
+                },
+                {
+                    "op": "link",
+                    "source": "$child",
+                    "target": "$parent",
+                    "type": "subtask"
+                }
+            ]
+        }),
+    );
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+
+    assert_eq!(json["success"], true);
+    assert_eq!(json["refs"]["parent"], "DEMO-100");
+    assert_eq!(json["refs"]["child"], "DEMO-101");
+    assert_eq!(json["summary"]["total"], 5);
+    assert_eq!(json["results"][0]["status"], "created");
+    assert_eq!(json["results"][4]["status"], "linked");
+
+    let methods = mock_call_methods(&scenario);
+    assert_eq!(method_count(&methods, "create_issue"), 2);
+    assert_eq!(method_count(&methods, "update_issue"), 1);
+    assert_eq!(method_count(&methods, "add_comment"), 1);
+    assert_eq!(method_count(&methods, "link_subtask"), 1);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_dry_run_does_not_call_mutating_methods() {
+    let dir = temp_dir();
+    let scenario = write_scenario(&dir, &base_manifest(""), &standard_responses());
+    let plan = write_plan(
+        &dir,
+        "plan.json",
+        json!({
+            "version": 1,
+            "defaults": {"project": "DEMO", "validate": true},
+            "operations": [
+                {
+                    "ref": "parent",
+                    "op": "create_issue",
+                    "summary": "Parent issue",
+                    "fields": {"Priority": "Major"}
+                }
+            ]
+        }),
+    );
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+
+    assert_eq!(json["success"], true);
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["results"][0]["status"], "dry_run");
+
+    let methods = mock_call_methods(&scenario);
+    assert_eq!(method_count(&methods, "create_issue"), 0);
+    assert_eq!(method_count(&methods, "update_issue"), 0);
+    assert_eq!(method_count(&methods, "add_comment"), 0);
+    assert_eq!(method_count(&methods, "link_subtask"), 0);
+    assert_eq!(method_count(&methods, "delete_issue"), 0);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_reads_plan_from_stdin() {
+    let dir = temp_dir();
+    let scenario = write_scenario(&dir, &base_manifest(""), &standard_responses());
+    let plan = json!({
+        "version": 1,
+        "defaults": {"project": "DEMO"},
+        "operations": [
+            {
+                "ref": "parent",
+                "op": "create_issue",
+                "summary": "Parent from stdin"
+            }
+        ]
+    });
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply", "-", "--dry-run"])
+        .write_stdin(serde_json::to_string(&plan).unwrap())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+
+    assert_eq!(json["success"], true);
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["refs"]["parent"], "planned:parent");
+
+    let methods = mock_call_methods(&scenario);
+    assert_eq!(method_count(&methods, "create_issue"), 0);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_validation_failure_stops_before_mutation() {
+    let dir = temp_dir();
+    let scenario = write_scenario(&dir, &base_manifest(""), &standard_responses());
+    let plan = write_plan(
+        &dir,
+        "plan.json",
+        json!({
+            "version": 1,
+            "defaults": {"project": "DEMO", "validate": true},
+            "operations": [
+                {
+                    "op": "create_issue",
+                    "summary": "Invalid priority",
+                    "fields": {"Priority": "Impossible"}
+                }
+            ]
+        }),
+    );
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+
+    assert_eq!(json["success"], false);
+    assert_eq!(json["results"][0]["status"], "failed");
+    assert!(
+        json["results"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid value")
+    );
+
+    let methods = mock_call_methods(&scenario);
+    assert_eq!(method_count(&methods, "create_issue"), 0);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_dedupe_reuse_skips_create_and_populates_refs() {
+    let dir = temp_dir();
+    let manifest = base_manifest(
+        r#"
+[[responses]]
+method = "search_issues"
+file = "search_existing.json"
+[responses.args]
+query = "project: DEMO summary: {Existing}"
+limit = "2"
+skip = "0"
+
+[[responses]]
+method = "add_comment"
+file = "comment_existing.json"
+[responses.args]
+issue_id = "DEMO-9"
+"#,
+    );
+    let mut responses = standard_responses();
+    responses.extend([
+        (
+            "search_existing.json",
+            json!([issue_json("DEMO-9", "Existing", "Open", "Normal")]),
+        ),
+        (
+            "comment_existing.json",
+            comment_json("comment-9", "Reused issue"),
+        ),
+    ]);
+    let scenario = write_scenario(&dir, &manifest, &responses);
+    let plan = write_plan(
+        &dir,
+        "plan.json",
+        json!({
+            "version": 1,
+            "defaults": {"project": "DEMO"},
+            "operations": [
+                {
+                    "ref": "existing",
+                    "op": "create_issue",
+                    "summary": "Existing",
+                    "dedupe": {
+                        "query": "project: DEMO summary: {Existing}",
+                        "on_match": "reuse"
+                    }
+                },
+                {
+                    "op": "comment",
+                    "issue": "$existing",
+                    "body": "Reused issue"
+                }
+            ]
+        }),
+    );
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+
+    assert_eq!(json["success"], true);
+    assert_eq!(json["refs"]["existing"], "DEMO-9");
+    assert_eq!(json["results"][0]["status"], "reused");
+
+    let methods = mock_call_methods(&scenario);
+    assert_eq!(method_count(&methods, "create_issue"), 0);
+    assert_eq!(method_count(&methods, "add_comment"), 1);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_multiple_dedupe_matches_fails_without_mutation() {
+    let dir = temp_dir();
+    let manifest = base_manifest(
+        r#"
+[[responses]]
+method = "search_issues"
+file = "search_multiple.json"
+[responses.args]
+query = "project: DEMO summary: {Duplicate}"
+limit = "2"
+skip = "0"
+"#,
+    );
+    let mut responses = standard_responses();
+    responses.push((
+        "search_multiple.json",
+        json!([
+            issue_json("DEMO-9", "Duplicate", "Open", "Normal"),
+            issue_json("DEMO-10", "Duplicate", "Open", "Normal")
+        ]),
+    ));
+    let scenario = write_scenario(&dir, &manifest, &responses);
+    let plan = write_plan(
+        &dir,
+        "plan.json",
+        json!({
+            "version": 1,
+            "defaults": {"project": "DEMO"},
+            "operations": [
+                {
+                    "ref": "duplicate",
+                    "op": "create_issue",
+                    "summary": "Duplicate",
+                    "dedupe": {
+                        "query": "project: DEMO summary: {Duplicate}",
+                        "on_match": "reuse"
+                    }
+                }
+            ]
+        }),
+    );
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+
+    assert_eq!(json["success"], false);
+    assert!(
+        json["results"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("multiple issues")
+    );
+
+    let methods = mock_call_methods(&scenario);
+    assert_eq!(method_count(&methods, "create_issue"), 0);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_resume_skips_completed_operations() {
+    let dir = temp_dir();
+    let failing_manifest = base_manifest(
+        r#"
+[[responses]]
+method = "create_issue"
+file = "create_resume.json"
+[responses.args]
+project = "0-1"
+summary = "Resume parent"
+
+[[responses]]
+method = "update_issue"
+file = "update_error.json"
+status = 500
+[responses.args]
+id = "DEMO-200"
+"#,
+    );
+    let mut responses = standard_responses();
+    responses.extend([
+        (
+            "create_resume.json",
+            issue_json("DEMO-200", "Resume parent", "Open", "Normal"),
+        ),
+        ("update_error.json", json!({"message": "temporary failure"})),
+    ]);
+    let scenario = write_scenario(&dir, &failing_manifest, &responses);
+    let plan = write_plan(
+        &dir,
+        "plan.json",
+        json!({
+            "version": 1,
+            "defaults": {"project": "DEMO"},
+            "operations": [
+                {
+                    "ref": "parent",
+                    "op": "create_issue",
+                    "summary": "Resume parent"
+                },
+                {
+                    "op": "update_issue",
+                    "issue": "$parent",
+                    "summary": "Resume parent updated"
+                }
+            ]
+        }),
+    );
+    let resume = dir.join("state.json");
+
+    track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .arg("--resume")
+        .arg(&resume)
+        .assert()
+        .failure();
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&resume).unwrap()).unwrap();
+    assert_eq!(state["completed"][0], 0);
+    assert_eq!(state["refs"]["parent"], "DEMO-200");
+
+    let passing_manifest = base_manifest(
+        r#"
+[[responses]]
+method = "create_issue"
+file = "create_resume.json"
+[responses.args]
+project = "0-1"
+summary = "Resume parent"
+
+[[responses]]
+method = "update_issue"
+file = "update_resume.json"
+[responses.args]
+id = "DEMO-200"
+"#,
+    );
+    fs::write(scenario.join("manifest.toml"), passing_manifest).unwrap();
+    fs::write(
+        scenario.join("responses/update_resume.json"),
+        serde_json::to_string(&issue_json(
+            "DEMO-200",
+            "Resume parent updated",
+            "Open",
+            "Normal",
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .arg("--resume")
+        .arg(&resume)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+
+    assert_eq!(json["success"], true);
+    assert_eq!(json["resumed"], true);
+    assert_eq!(json["results"][0]["status"], "skipped");
+    assert_eq!(json["results"][1]["status"], "updated");
+
+    let methods = mock_call_methods(&scenario);
+    assert_eq!(method_count(&methods, "create_issue"), 1);
+    assert_eq!(method_count(&methods, "update_issue"), 2);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_delete_requires_allow_delete_for_real_execution() {
+    let dir = temp_dir();
+    let manifest = base_manifest(
+        r#"
+[[responses]]
+method = "delete_issue"
+file = "ok.json"
+[responses.args]
+id = "DEMO-1"
+"#,
+    );
+    let mut responses = standard_responses();
+    responses.push(("ok.json", Value::Null));
+    let scenario = write_scenario(&dir, &manifest, &responses);
+    let plan = write_plan(
+        &dir,
+        "plan.json",
+        json!({
+            "version": 1,
+            "operations": [
+                {"op": "delete_issue", "issue": "DEMO-1"}
+            ]
+        }),
+    );
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["success"], false);
+    assert!(
+        json["results"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("--allow-delete")
+    );
+    assert_eq!(
+        method_count(&mock_call_methods(&scenario), "delete_issue"),
+        0
+    );
+
+    let output = track_in(&dir, &scenario)
+        .args(["-o", "json", "apply"])
+        .arg(&plan)
+        .arg("--allow-delete")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["success"], true);
+    assert_eq!(json["results"][0]["status"], "deleted");
+    assert_eq!(
+        method_count(&mock_call_methods(&scenario), "delete_issue"),
+        1
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -359,6 +359,39 @@ track i done PROJ-1,PROJ-2 --state Done
 track i del PROJ-1,PROJ-2,PROJ-3
 ```
 
+### Declarative Apply Plans
+
+Use `track apply <plan.json>` when a workflow needs several dependent issue operations in one backend-scoped run. Plans are JSON-only and support `create_issue`, `update_issue`, `comment`, `link`, and guarded `delete_issue` operations.
+
+```bash
+track apply plan.json --dry-run
+track apply plan.json --validate --resume /tmp/track-apply-state.json
+track -o json apply plan.json
+track apply delete-plan.json --allow-delete
+```
+
+Local refs from create operations are written as `$name` and resolve to the created or dedupe-reused issue ID in later operations. `--resume` uses only the explicit JSON state path you pass; it does not write hidden project state. Real `delete_issue` operations require `--allow-delete`; dry-runs can inspect delete plans without it.
+
+```json
+{
+  "version": 1,
+  "defaults": {"project": "PROJ", "validate": true},
+  "operations": [
+    {
+      "ref": "parent",
+      "op": "create_issue",
+      "summary": "Parent issue",
+      "fields": {"Priority": "Major"}
+    },
+    {
+      "op": "comment",
+      "issue": "$parent",
+      "body": "Created from an apply plan."
+    }
+  ]
+}
+```
+
 ### Batch Output Format
 
 Text output shows success/failure summary:


### PR DESCRIPTION
## Summary

Closes #290.

Adds top-level `track apply <plan>` support for JSON declarative issue-operation plans. The first version supports create, update, comment, link, guarded delete, dry-run validation, explicit resume state, local refs, create dedupe reuse, and structured text/JSON results.

## What changed

- Added `track apply <plan>` with `--dry-run`, `--validate`, `--resume <path>`, and `--allow-delete`.
- Added a JSON plan executor for `create_issue`, `update_issue`, `comment`, `link`, and `delete_issue`.
- Added local `$ref` resolution for created or reused issues.
- Added dedupe support for `create_issue` with `on_match: "reuse"`.
- Added explicit resume state keyed by a checksum over the raw plan bytes.
- Reused existing issue command behavior for custom-field conversion, project field validation, post-action verification warnings, and link type canonicalization.
- Documented apply plans in `docs/agent_guide.md` and `agent-skills/SKILL.md`.
- Bumped the `track` crate version to `1.15.0`.

## Automated validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test -p track apply`
- `cargo test --workspace`
- Follow-up after skill/version update: `cargo check -p track`
- Follow-up after skill/version update: `cargo test -p track apply`

## Live validation

Validated `track apply` against every backend configured in the local test config. Project names, repository names, numeric project IDs, and temporary issue keys are intentionally omitted.

| Backend | Live result |
| --- | --- |
| YouTrack | Passed create, update, comment, delete. Final deleted issue lookup returned not found. |
| Jira | Passed create, update, comment, delete. Final deleted issue lookup returned not found. |
| GitHub | Passed create, update, comment, close. The temporary validation issue remains closed because GitHub issue deletion is unsupported. |
| GitLab | Passed create, update, comment, delete. Final deleted issue lookup returned not found. |
| Linear | Passed create, update, comment, delete. The backend performs a soft delete, so direct ID reads may still resolve while normal search no longer surfaces the issue. |

One configured backend still has insufficient token scope for config/project-list discovery, but issue-scoped apply operations passed with the configured project token.

## Cleanup notes

- One initial live attempt had a shell quoting mistake that created a temporary issue; it was immediately deleted successfully.
- The intentional GitHub live validation issue is closed, not deleted, due to backend capability limits.
