### PR TITLE
fix(jira): serialize multi-group-picker custom fields as group objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -832,6 +832,16 @@ fn custom_field_to_json(
                         .collect();
                     serde_json::Value::Array(items)
                 }
+                // Multi-group pickers (schema items == "group") must be written as
+                // an array of group objects keyed by `name`. Jira rejects bare
+                // strings with: "Operation value must be an array of group objects".
+                Some("group") => {
+                    let items: Vec<serde_json::Value> = values
+                        .iter()
+                        .map(|v| serde_json::json!({ "name": *v }))
+                        .collect();
+                    serde_json::Value::Array(items)
+                }
                 _ => {
                     let items: Vec<serde_json::Value> = values
                         .iter()
@@ -1171,6 +1181,49 @@ mod tests {
         let jira = update_issue_to_jira(&update, &fields).unwrap();
         let json = serde_json::to_value(&jira).unwrap();
         assert_eq!(json["fields"]["customfield_10016"], 8.0);
+    }
+
+    #[test]
+    fn custom_field_to_json_wraps_group_items_as_name_objects() {
+        let schema = JiraFieldSchema {
+            field_type: "array".to_string(),
+            custom: None,
+            items: Some("group".to_string()),
+        };
+        // Single group value.
+        assert_eq!(
+            custom_field_to_json("customfield_12954", "Group A", Some(&schema)),
+            serde_json::json!([{ "name": "Group A" }])
+        );
+        // Comma-separated multi-group value (trimmed).
+        assert_eq!(
+            custom_field_to_json("customfield_12954", "Group A, Group B", Some(&schema)),
+            serde_json::json!([{ "name": "Group A" }, { "name": "Group B" }])
+        );
+    }
+
+    #[test]
+    fn resolve_extra_fields_serializes_multi_group_picker_as_name_objects() {
+        let custom_fields = vec![CustomFieldUpdate::MultiEnum {
+            name: "Partner".to_string(),
+            values: vec!["Group A".to_string(), "Group B".to_string()],
+        }];
+        let jira_fields = vec![JiraField {
+            id: "customfield_12954".to_string(),
+            name: "Partner".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "array".to_string(),
+                custom: None,
+                items: Some("group".to_string()),
+            }),
+        }];
+
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields, &[]).unwrap();
+        assert_eq!(
+            extra["customfield_12954"],
+            serde_json::json!([{ "name": "Group A" }, { "name": "Group B" }])
+        );
     }
 
     #[test]

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.15.0"
+version = "1.15.1"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 


### PR DESCRIPTION
## What

Fixes #298 — the Jira backend serialized multi-group-picker custom fields (schema `type: array`, `items: group`) as an array of **bare strings**, which Jira rejects with `400: Operation value must be an array of group objects`. Affected `track issue update --field`, `track apply`, and create (all routes through the same serializer).

## Change

`custom_field_to_json` (`crates/jira-backend/src/convert.rs`) gains a `Some("group")` arm in the `array` branch that wraps each value as `{"name": v}`, mirroring the existing `option` → `{"value": v}` handling:

```rust
Some("group") => {
    let items: Vec<serde_json::Value> =
        values.iter().map(|v| serde_json::json!({ "name": *v })).collect();
    serde_json::Value::Array(items)
}
```

The field's `JiraFieldSchema` (`items == "group"`) is already threaded to the serializer via `resolve_extra_fields`, so this is the only change needed — no plan/enum changes. A group value is supplied as a string or array-of-string and routed through `MultiEnum`, exactly like a multi-enum field.

Also bumps `track` `1.15.0` → `1.15.1` (patch).

## Backend scope & cross-backend safety

The change is confined to one **private** function in `crates/jira-backend/src/convert.rs`. `custom_field_to_json` is not `pub` and is never re-exported or called outside the Jira backend, and no shared (`tracker-core`) or other-backend code is touched. Group-picker serialization is inherently Jira-specific (it keys on the Jira REST `schema.items == "group"`); YouTrack/GitHub/GitLab/Linear have their own field models and are unaffected by construction. Within the Jira backend it is purely additive: `items == "group"` previously fell through to the bare-string `_` arm (which always 400'd for a group picker), so no field that worked before changes behavior.

Verified locally (matching CI):
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test --workspace --all-features` — all crates/backends green (jira-backend 131; youtrack/github/gitlab/linear/tracker-core/track suites all pass; 0 failures)

## Tests

- `custom_field_to_json_wraps_group_items_as_name_objects` — unit: single + comma-separated values → `[{"name": …}]`.
- `resolve_extra_fields_serializes_multi_group_picker_as_name_objects` — end-to-end through the field-resolution path.

## Scope / follow-ups (intentionally out of this PR — unverified)

Scoped tightly to the verified **multi-group** case. Related gaps that likely need the same treatment but were not tested here:
- **Single group picker** (`schema.type == "group"`, not `array`) — would need a top-level `Some("group") => {"name": value}` arm, symmetric with the existing `option` scalar handling.
- **Other object-array item types** (`version`, `component`, `user`) also fall through to bare strings and likely need object wrappers (`{"name"|"id"|"accountId": …}`), but the exact key differs per type, so they warrant separate, individually-verified changes.
- `--validate` / `--dry-run` do not catch this class of error (they don't construct the write payload); a real pre-flight would be needed to surface it before a live apply.
