### PR TITLE
fix(jira): clear a custom field when its plan value is an empty array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.15.1"
+version = "1.15.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/agent-skills/SKILL.md
+++ b/agent-skills/SKILL.md
@@ -477,6 +477,8 @@ Minimal plan:
 }
 ```
 
+**Field values** in `fields`: a string sets one value (`"Priority": "Major"`), an array sets multiple (`"Platform": ["macOS", "Linux"]`), and an **empty array clears the field** (`"Platform": []`).
+
 JSON output includes `success`, `dry_run`, `resumed`, summary counts, `refs`, and per-operation results with `index`, `op`, `status`, `issue`, `ref`, `error`, and `warnings`. Stop on the first failed operation; resume skips completed operations when the checksum still matches.
 
 ---

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -1014,7 +1014,6 @@ pub fn resolve_extra_fields(
                 }
             }
             CustomFieldUpdate::MultiEnum { name, values } => {
-                let joined = values.join(",");
                 if is_reserved_field(name) {
                     if let Some(msg) = dropped_reserved_field_warning(name, silently_handled) {
                         eprintln!("Warning: {}", msg);
@@ -1023,7 +1022,19 @@ pub fn resolve_extra_fields(
                 }
                 if let Some(field_id) = field_id_map.get(&name.to_lowercase()) {
                     let schema = schema_map.get(field_id.as_str()).copied();
-                    insert_resolved_field(&mut extra, field_id, &joined, schema)?;
+                    if values.is_empty() {
+                        // An empty array clears the field. Jira needs [] for an
+                        // array/multi field and null for a scalar; detect it here,
+                        // before the lossy join(",") below (which would otherwise
+                        // collapse [] and [""] to the same single-element value).
+                        let cleared = match schema.map(|s| s.field_type.as_str()) {
+                            Some("array") => serde_json::Value::Array(vec![]),
+                            _ => serde_json::Value::Null,
+                        };
+                        extra.insert(field_id.clone(), cleared);
+                    } else {
+                        insert_resolved_field(&mut extra, field_id, &values.join(","), schema)?;
+                    }
                 }
             }
         }
@@ -1224,6 +1235,52 @@ mod tests {
             extra["customfield_12954"],
             serde_json::json!([{ "name": "Group A" }, { "name": "Group B" }])
         );
+    }
+
+    #[test]
+    fn resolve_extra_fields_clears_array_field_with_empty_values() {
+        // An empty MultiEnum on an array field (e.g. a multi-group picker) must
+        // serialize to [] so Jira clears it — not [{"name":""}].
+        let custom_fields = vec![CustomFieldUpdate::MultiEnum {
+            name: "Partner".to_string(),
+            values: vec![],
+        }];
+        let jira_fields = vec![JiraField {
+            id: "customfield_12954".to_string(),
+            name: "Partner".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "array".to_string(),
+                custom: None,
+                items: Some("group".to_string()),
+            }),
+        }];
+
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields, &[]).unwrap();
+        assert_eq!(extra["customfield_12954"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn resolve_extra_fields_clears_scalar_field_with_empty_values_as_null() {
+        // An empty MultiEnum on a non-array (scalar) field clears via null,
+        // which is how Jira empties a scalar custom field.
+        let custom_fields = vec![CustomFieldUpdate::MultiEnum {
+            name: "Single Select".to_string(),
+            values: vec![],
+        }];
+        let jira_fields = vec![JiraField {
+            id: "customfield_20001".to_string(),
+            name: "Single Select".to_string(),
+            custom: true,
+            schema: Some(JiraFieldSchema {
+                field_type: "option".to_string(),
+                custom: None,
+                items: None,
+            }),
+        }];
+
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields, &[]).unwrap();
+        assert_eq!(extra["customfield_20001"], serde_json::Value::Null);
     }
 
     #[test]

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.15.1"
+version = "1.15.2"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/track/src/commands/apply.rs
+++ b/crates/track/src/commands/apply.rs
@@ -755,9 +755,10 @@ fn build_custom_field_updates(
                 schema,
             )),
             PlanFieldValue::Multi(values) => {
-                if values.is_empty() {
-                    bail!("Field '{}' array cannot be empty", name);
-                }
+                // An empty array is an intentional "clear this field" request:
+                // forward it as an empty MultiEnum and let each backend serialize
+                // the clear (Jira -> [] / null; YouTrack -> value: []; Linear
+                // labels -> labelIds: []). A non-empty array sets those values.
                 updates.push(issue::build_custom_field_update(
                     name.clone(),
                     values.clone(),
@@ -1170,6 +1171,23 @@ mod tests {
             &updates[1],
             CustomFieldUpdate::SingleEnum { name, value }
                 if name == "Priority" && value == "Major"
+        ));
+    }
+
+    #[test]
+    fn empty_array_field_forwards_as_clear_not_error() {
+        // An empty array means "clear this field": it must no longer error, and
+        // should forward as an empty MultiEnum for the backend to serialize.
+        let mut fields = BTreeMap::new();
+        fields.insert("Platform".to_string(), PlanFieldValue::Multi(vec![]));
+
+        let updates = build_custom_field_updates(&fields, &[], None, None, None, None).unwrap();
+
+        assert_eq!(updates.len(), 1);
+        assert!(matches!(
+            &updates[0],
+            CustomFieldUpdate::MultiEnum { name, values }
+                if name == "Platform" && values.is_empty()
         ));
     }
 

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -392,6 +392,8 @@ Local refs from create operations are written as `$name` and resolve to the crea
 }
 ```
 
+**Field values** in `fields`: a string sets one value, an array sets multiple, and an **empty array (`[]`) clears the field**.
+
 ### Batch Output Format
 
 Text output shows success/failure summary:


### PR DESCRIPTION
## What

Fixes #300 — there was no way to **clear/empty a custom field** via `track apply` (the inverse of #299's set). An empty array `[]` in a plan's `fields` map now clears the field.

## Why it didn't work

- The shared builder `build_custom_field_updates` (`crates/track/src/commands/apply.rs`) **`bail!`ed** on an empty `Multi` array (`"Field '…' array cannot be empty"`).
- `null` can't be expressed — `PlanFieldValue` (`Single(String) | Multi(Vec<String>)`) fails to deserialize JSON null.
- `""` means "set the empty string", not clear.
- Even if `[]` got through, the Jira serializer joined values to a string then split on `,`, so `[]` was indistinguishable from `[""]` → `[{"name":""}]` instead of the `[]` Jira needs.

## Change (chosen design: empty array = clear)

I deliberately did **not** add a `CustomFieldUpdate::Clear` variant: it would compile-break the Jira/YouTrack/Linear backends (exhaustive matches, no wildcard) *and* silently no-op on GitHub/GitLab — so it delivers neither safety nor uniformity, and duplicates an intent two backends already serialize from an empty `MultiEnum`. I also left `Single("")` ("set empty string") untouched.

- **`apply.rs`** — stop rejecting an empty `Multi`; forward it as an empty `MultiEnum` so each backend serializes the clear in its own idiom.
- **`jira-backend/convert.rs`** — in `resolve_extra_fields`, detect an empty `MultiEnum` **before** the lossy join and emit `[]` for `array` schema types, `null` otherwise (what Jira requires to empty an array vs scalar field).
- Bumps `track` `1.15.1` → `1.15.2`, and documents the convention in `agent-skills/SKILL.md` and `docs/agent_guide.md`.

## Backend scope & cross-backend safety

The only shared-code change is removing a `bail!` — **purely additive** (a previously-erroring input now works), so no existing valid plan changes behavior on any backend. The serialization change is confined to `jira-backend`. Per-backend behavior of an empty `MultiEnum` (verified against source):

| Backend | Empty `MultiEnum` → | Result |
|---|---|---|
| **Jira** | `[]` (array) / `null` (scalar) — this PR | clears the field |
| **YouTrack** | `value: []` (already, `convert.rs` `From`) | clears — no change needed |
| **Linear** | `labelIds: []` for labels/tags; other names error as today | clears labels; non-label unknown field errors identically to a non-empty unknown field |
| **GitHub** | ignored (`find_map`/`filter_map` `_ => None`) | no-op (no custom-field plumbing) |
| **GitLab** | ignored (`find_map _ => None`; `has_rest_fields` guard) | no-op |

Verified locally (matching CI): `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features -- -D warnings`, `cargo test --workspace --all-features` — **all crates/backends green, 0 failures**.

## Tests

- `jira-backend`: empty `MultiEnum` on an `array`/group field → `[]`; on a scalar (`option`) field → `null`; plus the existing non-empty group test still asserts `[{"name":…}]`.
- `track` (shared apply): an empty array no longer errors and forwards as an empty `MultiEnum`.

## Verified live (net-zero, real Jira multi-group picker)

Built `target/debug/track` (1.15.2) and round-tripped one issue whose Partner (multi-group picker) was empty:

| Step | Field |
|---|---|
| baseline | empty |
| set `["<group>"]` → `updated` | `[{groupId…, name:"<group>"}]` |
| clear `[]` → `updated` (this fix) | empty |

End state == start state.

## Out of scope (follow-ups)

- `issue update --field NAME=` stays gated against empty values; a CLI clear would need a distinct affordance (e.g. `--clear-field`).
- Typed scalar clear via `"field": null` still isn't expressible (`PlanFieldValue` has no null arm); `[]` covers the multi-value case and is sufficient here.
