### PR TITLE
Fix docs config path and GitLab search examples

### DIFF
--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -10,12 +10,12 @@ Configuration is resolved from highest to lowest priority:
 1. **CLI flags** — `--url`, `--token`, `--backend`, etc.
 2. **Environment variables** — backend-specific (see below)
 3. **Project config** — `.track.toml` in the current directory
-4. **Global config** — `~/.config/track/config.toml`
+4. **Global config** — `~/.tracker-cli/.track.toml`
 
 ## Config file format
 
 Create `.track.toml` in your project directory or
-`~/.config/track/config.toml`.
+`~/.tracker-cli/.track.toml` for global defaults.
 
 ### YouTrack
 

--- a/website/src/content/docs/query-syntax.md
+++ b/website/src/content/docs/query-syntax.md
@@ -34,8 +34,8 @@ GitHub uses GitHub's search query syntax (not traditional issue queries).
 ## GitLab
 
 ```bash
-track -b gitlab i s "bug fix" --state opened
-track -b gitlab i s "performance" --labels "priority::high"
+track -b gitlab i s "state=opened&search=bug fix"
+track -b gitlab i s "labels=priority::high&search=performance"
 ```
 
 GitLab uses project-scoped search with filter parameters.

--- a/website/src/content/docs/quick-start.md
+++ b/website/src/content/docs/quick-start.md
@@ -6,7 +6,7 @@ description: Configure a backend and run your first track commands.
 ## 1. Initialize configuration
 
 Create a `.track.toml` in your project directory (or
-`~/.config/track/config.toml` for global config):
+`~/.tracker-cli/.track.toml` for global config):
 
 ```bash
 # YouTrack (default)


### PR DESCRIPTION
## Summary

- Fix the website docs global config path to match `track init --global` and runtime config loading.
- Replace unsupported GitLab `issue search` flag examples with supported query-string filters.

## Root Cause

The original docs-site PR was merged before these review fixes were pushed, so `main` still contained copy-paste examples that do not match the CLI behavior.

## Validation

- `npm ci`
- `npm run build`
- `git diff --cached --check`
