### PR TITLE
Add native installers and OS-specific install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,41 @@ A command-line interface for issue tracking systems, built with Rust. Supports *
 
 ## Installation
 
-### Homebrew (macOS and Linux)
+### Native Install
+
+macOS and Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.ps1 | iex
+```
+
+The native installers download the latest GitHub release archive, verify it with
+`checksums-sha256.txt`, install `track` into a user-owned directory, and install
+shell completions where supported. Override the install directory with
+`TRACK_INSTALL_DIR`, or set `TRACK_SKIP_PATH=1` to skip shell startup file or
+user PATH changes. Pin a release with `TRACK_VERSION`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/v1.15.1/scripts/install.sh | TRACK_VERSION=1.15.1 bash
+```
+
+```powershell
+$env:TRACK_VERSION = "1.15.1"; irm https://raw.githubusercontent.com/OrekGames/track-cli/v1.15.1/scripts/install.ps1 | iex
+```
+
+Agent skills are optional and installed explicitly after the CLI is available:
+
+```bash
+track init --skills
+```
+
+### Homebrew (Package Manager)
 
 ```bash
 brew tap OrekGames/tap

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,236 @@
+# Install track from a GitHub release archive.
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.ps1 | iex
+#   $env:TRACK_VERSION = "1.15.1"; irm https://raw.githubusercontent.com/OrekGames/track-cli/v1.15.1/scripts/install.ps1 | iex
+#
+# Environment:
+#   TRACK_VERSION      Optional release version, with or without a leading "v".
+#   TRACK_INSTALL_DIR  Optional install directory. Defaults to $env:LOCALAPPDATA\Programs\track.
+#   TRACK_SKIP_PATH    Set to 1 to skip user PATH changes.
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+try {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {
+    # PowerShell Core on non-Windows platforms may not expose ServicePointManager.
+}
+
+$Repo = "OrekGames/track-cli"
+$GitHubApiUrl = "https://api.github.com/repos/$Repo"
+$GitHubReleaseUrl = "https://github.com/$Repo/releases/download"
+
+function Write-Step {
+    param([string] $Message)
+    Write-Host $Message
+}
+
+function Fail {
+    param([string] $Message)
+    throw "track installer: $Message"
+}
+
+function Normalize-TrackVersion {
+    param([string] $InputVersion)
+
+    if ([string]::IsNullOrWhiteSpace($InputVersion)) {
+        Fail "TRACK_VERSION cannot be empty"
+    }
+
+    $Version = $InputVersion.Trim()
+    if ($Version.StartsWith("v")) {
+        $Version = $Version.Substring(1)
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        Fail "TRACK_VERSION cannot be empty"
+    }
+
+    return $Version
+}
+
+function Get-LatestTrackVersion {
+    $Headers = @{ "User-Agent" = "track-installer" }
+    $Release = Invoke-RestMethod -Uri "$GitHubApiUrl/releases/latest" -Headers $Headers
+    if (-not $Release.tag_name) {
+        Fail "could not determine the latest release version"
+    }
+
+    $LatestVersion = Normalize-TrackVersion -InputVersion ([string] $Release.tag_name)
+    return $LatestVersion
+}
+
+function Get-TrackTarget {
+    $Arch = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrWhiteSpace($Arch)) {
+        $Arch = $env:PROCESSOR_ARCHITECTURE
+    }
+
+    switch -Regex ($Arch) {
+        "^(AMD64|x64)$" { return "x86_64-pc-windows-msvc" }
+        "^(ARM64|AARCH64)$" { return "aarch64-pc-windows-msvc" }
+        default { Fail "unsupported Windows architecture: $Arch" }
+    }
+}
+
+function Download-File {
+    param(
+        [string] $Url,
+        [string] $Destination
+    )
+
+    Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing
+}
+
+function Get-ExpectedChecksum {
+    param(
+        [string] $ChecksumsPath,
+        [string] $ArchiveName
+    )
+
+    $EscapedName = [regex]::Escape($ArchiveName)
+    foreach ($Line in Get-Content -Path $ChecksumsPath) {
+        if ($Line -match "^\s*([a-fA-F0-9]{64})\s+\*?$EscapedName\s*$") {
+            return $Matches[1].ToLowerInvariant()
+        }
+    }
+
+    Fail "checksum not found for $ArchiveName"
+}
+
+function Verify-Checksum {
+    param(
+        [string] $ChecksumsPath,
+        [string] $ArchivePath,
+        [string] $ArchiveName
+    )
+
+    $Expected = Get-ExpectedChecksum -ChecksumsPath $ChecksumsPath -ArchiveName $ArchiveName
+    $Actual = (Get-FileHash -Algorithm SHA256 -Path $ArchivePath).Hash.ToLowerInvariant()
+
+    if ($Expected -ne $Actual) {
+        Fail "checksum verification failed for $ArchiveName"
+    }
+}
+
+function Add-InstallDirToUserPath {
+    param([string] $Directory)
+
+    $CurrentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $Entries = @()
+    if (-not [string]::IsNullOrWhiteSpace($CurrentPath)) {
+        $Entries = $CurrentPath -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    }
+
+    $NormalizedDirectory = $Directory.TrimEnd("\")
+    $AlreadyPresent = $Entries | Where-Object { $_.TrimEnd("\") -ieq $NormalizedDirectory } | Select-Object -First 1
+    if ($AlreadyPresent) {
+        Write-Step "User PATH already contains $Directory"
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($CurrentPath)) {
+        $NewPath = $Directory
+    } else {
+        $NewPath = "$CurrentPath;$Directory"
+    }
+
+    [Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
+
+    $ProcessEntries = $env:Path -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $ProcessAlreadyPresent = $ProcessEntries | Where-Object { $_.TrimEnd("\") -ieq $NormalizedDirectory } | Select-Object -First 1
+    if (-not $ProcessAlreadyPresent) {
+        $env:Path = "$env:Path;$Directory"
+    }
+
+    Write-Step "Added $Directory to the user PATH."
+}
+
+if ($env:TRACK_VERSION) {
+    $Version = Normalize-TrackVersion -InputVersion $env:TRACK_VERSION
+} else {
+    $Version = Get-LatestTrackVersion
+}
+
+$Tag = "v$Version"
+$Target = Get-TrackTarget
+$ArchiveName = "track-$Version-$Target.zip"
+$PackageName = "track-$Version-$Target"
+
+if ($env:TRACK_INSTALL_DIR) {
+    $InstallDir = $env:TRACK_INSTALL_DIR
+} else {
+    $LocalAppData = $env:LOCALAPPDATA
+    if ([string]::IsNullOrWhiteSpace($LocalAppData)) {
+        $LocalAppData = Join-Path $HOME "AppData\Local"
+    }
+    $InstallDir = Join-Path $LocalAppData "Programs\track"
+}
+
+$InstallDir = [System.IO.Path]::GetFullPath($InstallDir)
+$CompletionsDir = Join-Path $InstallDir "completions"
+$TrackExe = Join-Path $InstallDir "track.exe"
+$CompletionFile = Join-Path $CompletionsDir "track.ps1"
+
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("track-install-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+
+try {
+    $ArchivePath = Join-Path $TempDir $ArchiveName
+    $ChecksumsPath = Join-Path $TempDir "checksums-sha256.txt"
+    $ArchiveUrl = "$GitHubReleaseUrl/$Tag/$ArchiveName"
+    $ChecksumsUrl = "$GitHubReleaseUrl/$Tag/checksums-sha256.txt"
+
+    Write-Step "Installing track $Version for $Target"
+    Write-Step "Download: $ArchiveUrl"
+
+    Download-File -Url $ArchiveUrl -Destination $ArchivePath
+    Download-File -Url $ChecksumsUrl -Destination $ChecksumsPath
+
+    Verify-Checksum -ChecksumsPath $ChecksumsPath -ArchivePath $ArchivePath -ArchiveName $ArchiveName
+    Write-Step "Checksum verified."
+
+    $ExtractDir = Join-Path $TempDir "extract"
+    New-Item -ItemType Directory -Path $ExtractDir -Force | Out-Null
+    Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+
+    $ExtractedBinary = Join-Path (Join-Path $ExtractDir $PackageName) "track.exe"
+    if (-not (Test-Path $ExtractedBinary)) {
+        $Candidate = Get-ChildItem -Path $ExtractDir -Filter "track.exe" -Recurse | Select-Object -First 1
+        if (-not $Candidate) {
+            Fail "release archive did not contain track.exe"
+        }
+        $ExtractedBinary = $Candidate.FullName
+    }
+
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    Copy-Item -Path $ExtractedBinary -Destination $TrackExe -Force
+
+    New-Item -ItemType Directory -Path $CompletionsDir -Force | Out-Null
+    & $TrackExe completions powershell | Set-Content -Path $CompletionFile -Encoding UTF8
+
+    if ($env:TRACK_SKIP_PATH -eq "1") {
+        Write-Step "Skipping user PATH changes because TRACK_SKIP_PATH=1."
+    } else {
+        Add-InstallDirToUserPath -Directory $InstallDir
+    }
+
+    Write-Step ""
+    Write-Step "Installation complete."
+    Write-Step "  Binary:      $TrackExe"
+    Write-Step "  Completion:  $CompletionFile"
+    Write-Step ""
+    Write-Step "PowerShell completion is installed but not added to your profile automatically."
+    Write-Step "Add this line to your PowerShell profile (`$PROFILE) to load it:"
+    Write-Step "  . '$CompletionFile'"
+    Write-Step ""
+    Write-Step "Verify installation:"
+    Write-Step "  track --version"
+    Write-Step ""
+    Write-Step "Optional agent skills:"
+    Write-Step "  track init --skills"
+} finally {
+    Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Install track from a GitHub release archive.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.sh | bash
+#   TRACK_VERSION=1.15.1 bash scripts/install.sh
+#
+# Environment:
+#   TRACK_VERSION      Optional release version, with or without a leading "v".
+#   TRACK_INSTALL_DIR  Optional install directory. Defaults to ~/.tracker-cli.
+#   TRACK_SKIP_PATH    Set to 1 to skip shell startup file changes.
+
+set -euo pipefail
+
+REPO="OrekGames/track-cli"
+GITHUB_API_URL="https://api.github.com/repos/${REPO}"
+GITHUB_RELEASE_URL="https://github.com/${REPO}/releases/download"
+BINARY_NAME="track"
+
+log() {
+    printf '%s\n' "$*"
+}
+
+fail() {
+    printf 'track installer: %s\n' "$*" >&2
+    exit 1
+}
+
+need_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+normalize_version() {
+    local version="$1"
+    version="${version#v}"
+    [[ -n "$version" ]] || fail "TRACK_VERSION cannot be empty"
+    printf '%s\n' "$version"
+}
+
+latest_version() {
+    local tag
+    tag="$(curl -fsSL -H "User-Agent: track-installer" "${GITHUB_API_URL}/releases/latest" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | sed -n '1p')"
+    [[ -n "$tag" ]] || fail "could not determine the latest release version"
+    normalize_version "$tag"
+}
+
+detect_target() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$arch" in
+        x86_64|amd64)
+            arch="x86_64"
+            ;;
+        arm64|aarch64)
+            arch="aarch64"
+            ;;
+        *)
+            fail "unsupported architecture: $arch"
+            ;;
+    esac
+
+    case "$os" in
+        Darwin)
+            printf '%s-apple-darwin\n' "$arch"
+            ;;
+        Linux)
+            printf '%s-unknown-linux-gnu\n' "$arch"
+            ;;
+        *)
+            fail "unsupported operating system: $os"
+            ;;
+    esac
+}
+
+sha256_file() {
+    local file="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | awk '{print $1}'
+    else
+        fail "required command not found: sha256sum or shasum"
+    fi
+}
+
+verify_checksum() {
+    local checksums_file="$1"
+    local archive_file="$2"
+    local archive_name="$3"
+    local expected actual
+
+    expected="$(awk -v name="$archive_name" '{ filename = $2; sub(/^\*/, "", filename); if (filename == name) print $1 }' "$checksums_file" | sed -n '1p')"
+    [[ -n "$expected" ]] || fail "checksum not found for ${archive_name}"
+
+    actual="$(sha256_file "$archive_file")"
+    expected="$(printf '%s\n' "$expected" | tr '[:upper:]' '[:lower:]')"
+    actual="$(printf '%s\n' "$actual" | tr '[:upper:]' '[:lower:]')"
+
+    [[ "$expected" == "$actual" ]] || fail "checksum verification failed for ${archive_name}"
+}
+
+append_shell_config() {
+    local config_file="$1"
+    local shell_type="$2"
+    local needs_path=1
+    local needs_completion=1
+
+    if grep -Fq "$INSTALL_DIR" "$config_file" 2>/dev/null; then
+        needs_path=0
+    elif [[ "$INSTALL_DIR" == "$HOME/.tracker-cli" ]] && grep -Fq ".tracker-cli" "$config_file" 2>/dev/null; then
+        needs_path=0
+    fi
+
+    if grep -Fq "$COMPLETIONS_DIR" "$config_file" 2>/dev/null; then
+        needs_completion=0
+    elif [[ "$COMPLETIONS_DIR" == "$HOME/.tracker-cli/completions" ]] && grep -Fq "tracker-cli/completions" "$config_file" 2>/dev/null; then
+        needs_completion=0
+    fi
+
+    if [[ "$needs_path" -eq 0 && "$needs_completion" -eq 0 ]]; then
+        log "  ${config_file}: already configured"
+        return
+    fi
+
+    {
+        printf '\n# Added by track CLI installer\n'
+        if [[ "$needs_path" -eq 1 ]]; then
+            printf 'export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+        fi
+
+        if [[ "$needs_completion" -eq 1 ]]; then
+            case "$shell_type" in
+                zsh)
+                    printf 'if [ -d "%s" ]; then\n' "$COMPLETIONS_DIR"
+                    printf '  fpath=("%s" $fpath)\n' "$COMPLETIONS_DIR"
+                    printf '  autoload -Uz compinit\n'
+                    printf '  compinit\n'
+                    printf 'fi\n'
+                    ;;
+                bash)
+                    printf 'if [ -f "%s/track.bash" ]; then\n' "$COMPLETIONS_DIR"
+                    printf '  source "%s/track.bash"\n' "$COMPLETIONS_DIR"
+                    printf 'fi\n'
+                    ;;
+            esac
+        fi
+    } >> "$config_file"
+
+    log "  ${config_file}: updated"
+}
+
+configure_shell() {
+    log ""
+    log "Configuring shell PATH and completions..."
+
+    if [[ -f "$HOME/.zshrc" || "${SHELL:-}" == *"zsh"* ]]; then
+        touch "$HOME/.zshrc"
+        append_shell_config "$HOME/.zshrc" "zsh"
+    fi
+
+    if [[ -f "$HOME/.bashrc" || ( "${SHELL:-}" == *"bash"* && ! -f "$HOME/.bash_profile" ) ]]; then
+        touch "$HOME/.bashrc"
+        append_shell_config "$HOME/.bashrc" "bash"
+    fi
+
+    if [[ -f "$HOME/.bash_profile" ]]; then
+        append_shell_config "$HOME/.bash_profile" "bash"
+    fi
+
+    if [[ -d "$HOME/.config/fish" ]]; then
+        local fish_completions_dir="$HOME/.config/fish/completions"
+        mkdir -p "$fish_completions_dir"
+        ln -sf "$COMPLETIONS_DIR/track.fish" "$fish_completions_dir/track.fish"
+        log "  fish: completions symlinked to ${fish_completions_dir}/track.fish"
+    fi
+}
+
+need_command curl
+need_command tar
+need_command awk
+need_command sed
+need_command tr
+
+if [[ -n "${TRACK_VERSION:-}" ]]; then
+    VERSION="$(normalize_version "$TRACK_VERSION")"
+else
+    VERSION="$(latest_version)"
+fi
+
+TAG="v${VERSION}"
+TARGET="$(detect_target)"
+ARCHIVE_NAME="track-${VERSION}-${TARGET}.tar.gz"
+PACKAGE_NAME="track-${VERSION}-${TARGET}"
+
+INSTALL_DIR="${TRACK_INSTALL_DIR:-$HOME/.tracker-cli}"
+INSTALL_DIR="${INSTALL_DIR/#\~/$HOME}"
+mkdir -p "$INSTALL_DIR"
+INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd)"
+COMPLETIONS_DIR="$INSTALL_DIR/completions"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ARCHIVE_PATH="$TMP_DIR/$ARCHIVE_NAME"
+CHECKSUMS_PATH="$TMP_DIR/checksums-sha256.txt"
+ARCHIVE_URL="${GITHUB_RELEASE_URL}/${TAG}/${ARCHIVE_NAME}"
+CHECKSUMS_URL="${GITHUB_RELEASE_URL}/${TAG}/checksums-sha256.txt"
+
+log "Installing track ${VERSION} for ${TARGET}"
+log "Download: ${ARCHIVE_URL}"
+
+curl -fL --retry 3 -o "$ARCHIVE_PATH" "$ARCHIVE_URL"
+curl -fL --retry 3 -o "$CHECKSUMS_PATH" "$CHECKSUMS_URL"
+
+verify_checksum "$CHECKSUMS_PATH" "$ARCHIVE_PATH" "$ARCHIVE_NAME"
+log "Checksum verified."
+
+tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR"
+
+EXTRACTED_DIR="$TMP_DIR/$PACKAGE_NAME"
+EXTRACTED_BINARY="$EXTRACTED_DIR/$BINARY_NAME"
+[[ -x "$EXTRACTED_BINARY" ]] || fail "release archive did not contain an executable ${BINARY_NAME}"
+
+cp "$EXTRACTED_BINARY" "$INSTALL_DIR/$BINARY_NAME"
+chmod +x "$INSTALL_DIR/$BINARY_NAME"
+
+mkdir -p "$COMPLETIONS_DIR"
+"$INSTALL_DIR/$BINARY_NAME" completions bash > "$COMPLETIONS_DIR/track.bash"
+"$INSTALL_DIR/$BINARY_NAME" completions zsh > "$COMPLETIONS_DIR/_track"
+"$INSTALL_DIR/$BINARY_NAME" completions fish > "$COMPLETIONS_DIR/track.fish"
+
+if [[ "${TRACK_SKIP_PATH:-}" == "1" ]]; then
+    log ""
+    log "Skipping shell startup file changes because TRACK_SKIP_PATH=1."
+else
+    configure_shell
+fi
+
+log ""
+log "Installation complete."
+log "  Binary:      $INSTALL_DIR/$BINARY_NAME"
+log "  Completions: $COMPLETIONS_DIR"
+log ""
+log "Verify installation:"
+log "  track --version"
+log ""
+log "Optional agent skills:"
+log "  track init --skills"

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -18,28 +18,192 @@ const repo = "https://github.com/OrekGames/track-cli";
       <a class="btn btn-secondary" href={repo}>View on GitHub</a>
     </div>
 
-    <div class="install-pill">
-      <span class="prompt">$</span>
-      <span id="install-cmd">brew install OrekGames/tap/track</span>
-      <button id="copy-install" type="button" aria-label="Copy install command"
-        >Copy</button
-      >
+    <div class="install-picker" data-install-picker>
+      <div class="install-picker-header">
+        <span class="install-platform" data-install-platform>Install for your OS</span>
+        <a class="install-docs-link" href={`${base}installation/`}>All install options</a>
+      </div>
+
+      <div class="install-options" aria-label="Install commands">
+        <article class="install-option" data-install-option="primary">
+          <div class="install-option-top">
+            <div>
+              <h3 data-install-title="primary">Homebrew</h3>
+              <p data-install-note="primary">Package-manager install</p>
+            </div>
+            <button
+              class="install-copy"
+              type="button"
+              data-install-copy="primary"
+              aria-label="Copy Homebrew install command">Copy</button
+            >
+          </div>
+          <pre class="install-command"><span class="prompt" data-install-prompt="primary">$</span><code data-install-command="primary">brew install OrekGames/tap/track</code></pre>
+        </article>
+
+        <article class="install-option" data-install-option="secondary">
+          <div class="install-option-top">
+            <div>
+              <h3 data-install-title="secondary">Native install</h3>
+              <p data-install-note="secondary">Verified release script</p>
+            </div>
+            <button
+              class="install-copy"
+              type="button"
+              data-install-copy="secondary"
+              aria-label="Copy native install command">Copy</button
+            >
+          </div>
+          <pre class="install-command"><span class="prompt" data-install-prompt="secondary">$</span><code data-install-command="secondary">curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.sh | bash</code></pre>
+        </article>
+      </div>
     </div>
   </div>
 </section>
 
 <script>
-  const btn = document.getElementById("copy-install");
-  const cmd = document.getElementById("install-cmd");
-  if (btn && cmd) {
-    btn.addEventListener("click", async () => {
+  const commands = {
+    mac: {
+      platform: "Detected macOS",
+      primary: {
+        title: "Homebrew",
+        note: "Package-manager install",
+        prompt: "$",
+        command: "brew install OrekGames/tap/track",
+        label: "Copy Homebrew install command",
+      },
+      secondary: {
+        title: "Native install",
+        note: "Verified release script",
+        prompt: "$",
+        command:
+          "curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.sh | bash",
+        label: "Copy native install command",
+      },
+    },
+    linux: {
+      platform: "Detected Linux",
+      primary: {
+        title: "Homebrew",
+        note: "Linuxbrew package-manager install",
+        prompt: "$",
+        command: "brew install OrekGames/tap/track",
+        label: "Copy Homebrew install command",
+      },
+      secondary: {
+        title: "Native install",
+        note: "Verified release script",
+        prompt: "$",
+        command:
+          "curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.sh | bash",
+        label: "Copy native install command",
+      },
+    },
+    windows: {
+      platform: "Detected Windows",
+      primary: {
+        title: "Homebrew (WSL)",
+        note: "For a Linux shell inside WSL",
+        prompt: "$",
+        command: "brew install OrekGames/tap/track",
+        label: "Copy WSL Homebrew install command",
+      },
+      secondary: {
+        title: "PowerShell",
+        note: "Native Windows install",
+        prompt: "PS>",
+        command:
+          "irm https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.ps1 | iex",
+        label: "Copy PowerShell install command",
+      },
+    },
+    other: {
+      platform: "Choose your install path",
+      primary: {
+        title: "Homebrew",
+        note: "macOS, Linux, or WSL",
+        prompt: "$",
+        command: "brew install OrekGames/tap/track",
+        label: "Copy Homebrew install command",
+      },
+      secondary: {
+        title: "Native install",
+        note: "macOS or Linux release script",
+        prompt: "$",
+        command:
+          "curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.sh | bash",
+        label: "Copy native install command",
+      },
+    },
+  };
+
+  function platformKey() {
+    const nav = window.navigator;
+    const platform = `${nav.userAgentData?.platform ?? nav.platform ?? ""} ${nav.userAgent ?? ""}`;
+
+    if (/windows|win32|win64/i.test(platform)) return "windows";
+    if (/macintosh|macintel|mac os x|darwin/i.test(platform)) return "mac";
+    if (/linux|x11/i.test(platform)) return "linux";
+
+    return "other";
+  }
+
+  function setText(selector, text) {
+    const element = document.querySelector(selector);
+    if (element) element.textContent = text;
+  }
+
+  function applyInstallCommands() {
+    const config = commands[platformKey()] ?? commands.other;
+
+    setText("[data-install-platform]", config.platform);
+
+    for (const key of ["primary", "secondary"]) {
+      const option = config[key];
+      setText(`[data-install-title="${key}"]`, option.title);
+      setText(`[data-install-note="${key}"]`, option.note);
+      setText(`[data-install-prompt="${key}"]`, option.prompt);
+      setText(`[data-install-command="${key}"]`, option.command);
+
+      const button = document.querySelector(`[data-install-copy="${key}"]`);
+      if (button) {
+        button.setAttribute("aria-label", option.label);
+        button.dataset.command = option.command;
+      }
+    }
+  }
+
+  async function copyCommand(text) {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    textarea.remove();
+  }
+
+  applyInstallCommands();
+
+  for (const button of document.querySelectorAll("[data-install-copy]")) {
+    button.addEventListener("click", async () => {
+      const command = button.dataset.command ?? "";
+      if (!command) return;
+
       try {
-        await navigator.clipboard.writeText(cmd.textContent?.trim() ?? "");
-        const original = btn.textContent;
-        btn.textContent = "Copied!";
-        setTimeout(() => (btn.textContent = original), 1500);
+        await copyCommand(command);
+        const original = button.textContent;
+        button.textContent = "Copied";
+        setTimeout(() => (button.textContent = original), 1500);
       } catch {
-        /* clipboard unavailable — no-op */
+        /* clipboard unavailable - no-op */
       }
     });
   }

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -1,9 +1,9 @@
 ---
 title: Installation
-description: Install the track CLI via Homebrew, Cargo, or a prebuilt binary.
+description: Install the track CLI with Homebrew, the native installer, Cargo, or a prebuilt binary.
 ---
 
-## Homebrew (macOS and Linux)
+## Homebrew (Package Manager)
 
 ```bash
 brew tap OrekGames/tap
@@ -11,6 +11,43 @@ brew install track
 ```
 
 Shell completions for bash, zsh, and fish are installed automatically.
+
+## Native Install
+
+macOS and Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/OrekGames/track-cli/main/scripts/install.ps1 | iex
+```
+
+The native installers download the latest GitHub release archive, verify it with
+`checksums-sha256.txt`, install `track` into a user-owned directory, and install
+shell completions where supported.
+
+Override the install directory with `TRACK_INSTALL_DIR`, or set
+`TRACK_SKIP_PATH=1` to skip shell startup file or user PATH changes.
+
+Pin a release with `TRACK_VERSION`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/OrekGames/track-cli/v1.15.1/scripts/install.sh | TRACK_VERSION=1.15.1 bash
+```
+
+```powershell
+$env:TRACK_VERSION = "1.15.1"; irm https://raw.githubusercontent.com/OrekGames/track-cli/v1.15.1/scripts/install.ps1 | iex
+```
+
+Agent skills are optional and installed explicitly after the CLI is available:
+
+```bash
+track init --skills
+```
 
 ## From Source
 

--- a/website/src/content/docs/overview.md
+++ b/website/src/content/docs/overview.md
@@ -27,8 +27,8 @@ and update issues is the same no matter which backend your team uses.
 
 ## Next steps
 
-- [Installation](/track-cli/installation/) — install via Homebrew, Cargo, or a
-  prebuilt binary.
+- [Installation](/track-cli/installation/) — install with the native installer,
+  Homebrew, Cargo, or a prebuilt binary.
 - [Quick Start](/track-cli/quick-start/) — configure a backend and run your
   first commands.
 - [Configuration](/track-cli/configuration/) — config files, environment

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -152,39 +152,116 @@ a:hover {
   border-color: var(--text-muted);
 }
 
-/* ---- Install command pill ---- */
-.install-pill {
-  display: inline-flex;
+/* ---- Install commands ---- */
+.install-picker {
+  width: min(100%, 860px);
+  margin: 0 auto;
+  text-align: left;
+}
+
+.install-picker-header {
+  display: flex;
   align-items: center;
-  gap: 0.75rem;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.install-platform {
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.install-docs-link {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.install-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.install-option {
+  min-width: 0;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 0.6rem 0.6rem 0.6rem 1rem;
-  font-family: var(--font-mono);
-  font-size: 0.95rem;
+  padding: 1rem;
+}
+
+.install-option-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+}
+
+.install-option h3 {
+  margin: 0;
   color: var(--text);
-  margin: 0 auto;
+  font-size: 1rem;
+  line-height: 1.2;
+  letter-spacing: 0;
 }
 
-.install-pill .prompt {
-  color: var(--accent);
+.install-option p {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+  line-height: 1.35;
 }
 
-.install-pill button {
+.install-copy {
+  flex: 0 0 auto;
+  min-width: 4.25rem;
   background: var(--border);
   border: none;
   color: var(--text);
   border-radius: 6px;
   padding: 0.35rem 0.6rem;
+  font-family: var(--font-sans);
   font-size: 0.8rem;
   cursor: pointer;
-  font-family: var(--font-sans);
   transition: background 0.15s ease;
 }
 
-.install-pill button:hover {
+.install-copy:hover {
   background: #3d444d;
+}
+
+.install-command {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  min-height: 3.1rem;
+  margin: 0;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  background: #0b0f14;
+  color: var(--text);
+  padding: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
+.install-command .prompt {
+  flex: 0 0 auto;
+  color: var(--accent);
+}
+
+.install-command code {
+  min-width: 0;
+  font: inherit;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 /* ---- Section scaffolding ---- */
@@ -366,5 +443,16 @@ a:hover {
   }
   .hero {
     padding: 3rem 0 2rem;
+  }
+  .install-picker-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .install-options {
+    grid-template-columns: 1fr;
+  }
+  .install-command {
+    font-size: 0.8rem;
   }
 }


### PR DESCRIPTION
## Summary

- Add first-party release installers for Unix and Windows.
- Update README and website install docs with Homebrew, native installer, pinned version, PATH override, and optional agent skills guidance.
- Replace the landing page single install pill with OS-aware install command panels for macOS, Linux, Windows, and fallback platforms.

## Impact

Users can install `track` directly from GitHub release assets without requiring Cargo or Homebrew. The installers verify release archives against `checksums-sha256.txt`, install into user-owned directories, and provide shell completions where supported.

The landing page now presents copyable commands specific to the visitor's browser platform:

- macOS/Linux: Homebrew and native Unix installer.
- Windows: Homebrew for WSL and native PowerShell installer.
- Other platforms: Homebrew and Unix installer fallback with a link to all install options.

## Validation

- `bash -n scripts/install.sh`
- `TRACK_VERSION=1.15.1 TRACK_INSTALL_DIR=/private/tmp/track-installer-test-1.15.1 TRACK_SKIP_PATH=1 scripts/install.sh`
- `/private/tmp/track-installer-test-1.15.1/track --version`
- Verified generated bash, zsh, fish, and PowerShell completion output.
- `npm run build` in `website/`
- Verified the served landing HTML and client script include the OS-specific install panel variants.

PowerShell parse/runtime validation was not run because PowerShell is not installed in the local environment.
