### PR TITLE
fix(github): use timeline-shaped label/milestone types for issue history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/github-backend/src/client_tests.rs
+++ b/crates/github-backend/src/client_tests.rs
@@ -521,7 +521,7 @@ mod tests {
                     "event": "labeled",
                     "created_at": created_at,
                     "actor": { "login": "alice", "id": 1 },
-                    "label": { "id": i, "name": format!("label-{i}"), "color": "ffffff", "description": null }
+                    "label": { "name": format!("label-{i}"), "color": "ffffff" }
                 })
             })
             .collect();

--- a/crates/github-backend/src/convert_tests.rs
+++ b/crates/github-backend/src/convert_tests.rs
@@ -71,7 +71,7 @@ mod tests {
                 "event": "labeled",
                 "created_at": "2024-01-02T10:00:00Z",
                 "actor": { "login": "alice", "id": 1 },
-                "label": { "id": 9, "name": "bug", "color": "fc2929", "description": null }
+                "label": { "name": "bug", "color": "fc2929" }
             })),
             event_from_json(serde_json::json!({
                 "event": "renamed",
@@ -99,6 +99,47 @@ mod tests {
         assert_eq!(assigned.field, "assignee");
         assert_eq!(assigned.from, None);
         assert_eq!(assigned.to.as_deref(), Some("dave"));
+    }
+
+    // ------------------------------------------------------------------
+    // Regression tests for issue #265: the timeline API's `labeled` and
+    // `milestoned` events send narrower objects than the full issue-API
+    // `label`/`milestone` (no `id`/`number`), which used to fail
+    // deserialization with "missing field `id`".
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn github_timeline_labeled_event_without_id_deserializes() {
+        let value = serde_json::json!({
+            "event": "labeled",
+            "created_at": "2024-01-02T10:00:00Z",
+            "actor": { "login": "alice", "id": 1 },
+            "label": { "name": "bug", "color": "fc2929" }
+        });
+
+        let event = GitHubTimelineEvent::from_value(value).unwrap();
+        let out = github_timeline_to_events(vec![event]);
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].field, "labels");
+        assert_eq!(out[0].to.as_deref(), Some("bug"));
+    }
+
+    #[test]
+    fn github_timeline_milestoned_event_without_id_deserializes() {
+        let value = serde_json::json!({
+            "event": "milestoned",
+            "created_at": "2024-01-02T10:00:00Z",
+            "actor": { "login": "alice", "id": 1 },
+            "milestone": { "title": "v1.0" }
+        });
+
+        let event = GitHubTimelineEvent::from_value(value).unwrap();
+        let out = github_timeline_to_events(vec![event]);
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].field, "milestone");
+        assert_eq!(out[0].to.as_deref(), Some("v1.0"));
     }
 
     #[test]

--- a/crates/github-backend/src/models/timeline.rs
+++ b/crates/github-backend/src/models/timeline.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::issue::{GitHubMilestone, GitHubUser};
-use super::label::GitHubLabel;
+use super::issue::GitHubUser;
 
 /// A single GitHub issue timeline event.
 ///
@@ -37,12 +36,12 @@ pub enum GitHubTimelineEvent {
     Labeled {
         created_at: Option<String>,
         actor: Option<GitHubUser>,
-        label: Option<GitHubLabel>,
+        label: Option<TimelineLabel>,
     },
     Unlabeled {
         created_at: Option<String>,
         actor: Option<GitHubUser>,
-        label: Option<GitHubLabel>,
+        label: Option<TimelineLabel>,
     },
     Renamed {
         created_at: Option<String>,
@@ -52,12 +51,12 @@ pub enum GitHubTimelineEvent {
     Milestoned {
         created_at: Option<String>,
         actor: Option<GitHubUser>,
-        milestone: Option<GitHubMilestone>,
+        milestone: Option<TimelineMilestone>,
     },
     Demilestoned {
         created_at: Option<String>,
         actor: Option<GitHubUser>,
-        milestone: Option<GitHubMilestone>,
+        milestone: Option<TimelineMilestone>,
     },
     /// Any event type we don't translate (commented, referenced, ...).
     Other,
@@ -68,6 +67,28 @@ pub enum GitHubTimelineEvent {
 pub struct GitHubRename {
     pub from: Option<String>,
     pub to: Option<String>,
+}
+
+/// The `label` payload on a `labeled`/`unlabeled` timeline event.
+///
+/// The timeline API sends a narrower object than the full issue-API label
+/// (no `id`/`description`), so this is a dedicated subset type rather than
+/// reusing [`super::label::GitHubLabel`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TimelineLabel {
+    pub name: String,
+    #[serde(default)]
+    pub color: Option<String>,
+}
+
+/// The `milestone` payload on a `milestoned`/`demilestoned` timeline event.
+///
+/// The timeline API sends a narrower object than the full issue-API
+/// milestone (no `id`/`number`), so this is a dedicated subset type rather
+/// than reusing [`super::issue::GitHubMilestone`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TimelineMilestone {
+    pub title: String,
 }
 
 /// Flattened representation of the raw timeline event JSON, used as a
@@ -81,9 +102,9 @@ struct RawTimelineEvent {
     created_at: Option<String>,
     actor: Option<GitHubUser>,
     assignee: Option<GitHubUser>,
-    label: Option<GitHubLabel>,
+    label: Option<TimelineLabel>,
     rename: Option<GitHubRename>,
-    milestone: Option<GitHubMilestone>,
+    milestone: Option<TimelineMilestone>,
 }
 
 impl GitHubTimelineEvent {

--- a/crates/github-backend/src/trait_impl.rs
+++ b/crates/github-backend/src/trait_impl.rs
@@ -735,7 +735,7 @@ mod slugify_tests {
         let hajimeni = slugify("はじめに");
         assert!(!hajimeni.is_empty(), "CJK slug should not be empty");
         assert!(
-            hajimeni.chars().all(|c| c.is_ascii()),
+            hajimeni.is_ascii(),
             "slug should be all ASCII: {hajimeni:?}"
         );
 

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.15.3"
+version = "1.15.4"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 


### PR DESCRIPTION
## What

Fixes #265 — `track issue history` against GitHub threw `missing field
'id'` for any issue whose timeline included a `labeled`, `unlabeled`,
`milestoned`, or `demilestoned` event.

## Root cause

`crates/github-backend/src/models/timeline.rs`'s internal
deserialization target (`RawTimelineEvent`) reused the full issue-API
types `GitHubLabel` (requires `id`/`color`) and `GitHubMilestone`
(requires `id`/`number`) for the nested `label`/`milestone` payloads on
timeline events.

But GitHub's "List timeline events" API sends much narrower objects for
these nested fields:
- `label`: `{ "name": "...", "color": "..." }` — no `id`, no `description`
- `milestone`: `{ "title": "..." }` — no `id`, no `number`

Deserializing that narrower JSON into the full issue-API struct failed
on the missing `id` field, which surfaced as a hard error the moment any
labeled/unlabeled/milestoned/demilestoned event showed up in an issue's
timeline.

## Fix

- Added `TimelineLabel { name, color: Option<String> }` and
  `TimelineMilestone { title }` — dedicated subset types scoped to the
  timeline payload shape, modeled on the existing `GitHubRename`
  precedent already in the same file.
- Changed `RawTimelineEvent` and the `Labeled`/`Unlabeled` /
  `Milestoned`/`Demilestoned` variants of `GitHubTimelineEvent` to use
  these new types instead of `GitHubLabel`/`GitHubMilestone`.
- Removed the now-unused `GitHubLabel` import and trimmed the
  `GitHubMilestone` import from `timeline.rs`. `GitHubLabel` and
  `GitHubMilestone` themselves are untouched — they're still correct and
  used elsewhere for full issue-API responses (`issue.labels`,
  `issue.milestone`).
- No changes needed in `convert.rs`: `github_timeline_to_events` only
  ever reads `label.map(|l| l.name)` and `milestone.map(|m| m.title)`,
  both of which exist identically on the new subset types.

## Tests

- Fixed `github_timeline_mixed_assign_label_rename` and
  `test_get_issue_history_paginates_and_derives_status`, whose
  `labeled` fixtures used issue-shaped JSON (`id`, `description`)
  instead of the real timeline API shape — which is exactly why the
  existing suite didn't catch this.
- Added two regression tests reproducing the original failing payloads
  verbatim (`labeled` and `milestoned` events with no `id`/`number`),
  asserting they deserialize via `GitHubTimelineEvent::from_value` and
  convert correctly via `github_timeline_to_events`.

Verified locally: `cargo test -p github-backend`, `cargo test
--workspace`, `cargo clippy -p github-backend --all-targets -- -D
warnings` — all pass.