### PR TITLE
fix(gitlab): stop silently dropping GitLab issue-list filters

### DIFF
--- a/crates/gitlab-backend/src/client.rs
+++ b/crates/gitlab-backend/src/client.rs
@@ -5,7 +5,18 @@ use ureq::Agent;
 use ureq::unversioned::multipart::{Form, Part};
 
 use crate::error::{GitLabError, Result};
+use crate::filters::GitLabIssueFilters;
 use crate::models::*;
+
+/// Append `&key=value` (URL-encoded) to `url` if `value` is `Some`.
+fn push_opt(url: &mut String, key: &str, value: Option<&str>) {
+    if let Some(v) = value {
+        url.push('&');
+        url.push_str(key);
+        url.push('=');
+        url.push_str(&urlencoding::encode(v));
+    }
+}
 
 /// GitLab REST API client
 pub struct GitLabClient {
@@ -152,29 +163,68 @@ impl GitLabClient {
         Ok(issue)
     }
 
+    /// Build the `/issues?...` query string for a page of issues matching
+    /// `filters`. All filter dimensions are applied here so list/search and
+    /// count can never diverge in which filters they honor.
+    fn issues_url(
+        &self,
+        filters: &GitLabIssueFilters,
+        per_page: usize,
+        page: usize,
+    ) -> Result<String> {
+        let mut url = self.project_url(&format!("/issues?per_page={}&page={}", per_page, page))?;
+        if !filters.search.is_empty() {
+            url.push_str(&format!("&search={}", urlencoding::encode(&filters.search)));
+        }
+        push_opt(&mut url, "state", filters.state.as_deref());
+        push_opt(&mut url, "labels", filters.labels.as_deref());
+        push_opt(
+            &mut url,
+            "assignee_username",
+            filters.assignee_username.as_deref(),
+        );
+        push_opt(
+            &mut url,
+            "author_username",
+            filters.author_username.as_deref(),
+        );
+        push_opt(&mut url, "milestone", filters.milestone.as_deref());
+        push_opt(&mut url, "order_by", filters.order_by.as_deref());
+        push_opt(&mut url, "sort", filters.sort.as_deref());
+        Ok(url)
+    }
+
+    /// Read the `X-Total` header GitLab returns on list/search/count
+    /// responses, if present.
+    fn read_total_header(response: &ureq::http::Response<ureq::Body>) -> Option<u64> {
+        response
+            .headers()
+            .get("x-total")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+    }
+
     /// List issues for the project
     pub fn list_issues(
         &self,
-        state: Option<&str>,
+        filters: &GitLabIssueFilters,
         per_page: usize,
         page: usize,
     ) -> Result<Vec<GitLabIssue>> {
-        let (issues, _total) = self.list_issues_with_total(state, per_page, page)?;
+        let (issues, _total) = self.list_issues_with_total(filters, per_page, page)?;
         Ok(issues)
     }
 
-    /// List issues and also return the X-Total header count (if present).
-    /// This avoids a separate count API call.
+    /// List/search issues (all `GitLabIssueFilters` dimensions applied) and
+    /// also return the X-Total header count (if present). This avoids a
+    /// separate count API call.
     pub fn list_issues_with_total(
         &self,
-        state: Option<&str>,
+        filters: &GitLabIssueFilters,
         per_page: usize,
         page: usize,
     ) -> Result<(Vec<GitLabIssue>, Option<u64>)> {
-        let mut url = self.project_url(&format!("/issues?per_page={}&page={}", per_page, page))?;
-        if let Some(s) = state {
-            url.push_str(&format!("&state={}", urlencoding::encode(s)));
-        }
+        let url = self.issues_url(filters, per_page, page)?;
 
         let response = self
             .agent
@@ -184,67 +234,7 @@ impl GitLabClient {
             .call()
             .map_err(|e| self.handle_error(e))?;
 
-        let total = response
-            .headers()
-            .get("x-total")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<u64>().ok());
-
-        let mut response = self.check_response(response)?;
-        let issues: Vec<GitLabIssue> = response.body_mut().read_json()?;
-        Ok((issues, total))
-    }
-
-    /// Search issues with query text, state, and labels
-    pub fn search_issues(
-        &self,
-        search: &str,
-        state: Option<&str>,
-        labels: Option<&str>,
-        per_page: usize,
-        page: usize,
-    ) -> Result<Vec<GitLabIssue>> {
-        let (issues, _total) =
-            self.search_issues_with_total(search, state, labels, per_page, page)?;
-        Ok(issues)
-    }
-
-    /// Search issues and also return the X-Total header count (if present).
-    /// This avoids a separate count API call.
-    pub fn search_issues_with_total(
-        &self,
-        search: &str,
-        state: Option<&str>,
-        labels: Option<&str>,
-        per_page: usize,
-        page: usize,
-    ) -> Result<(Vec<GitLabIssue>, Option<u64>)> {
-        let mut url = self.project_url(&format!(
-            "/issues?search={}&per_page={}&page={}",
-            urlencoding::encode(search),
-            per_page,
-            page
-        ))?;
-        if let Some(s) = state {
-            url.push_str(&format!("&state={}", urlencoding::encode(s)));
-        }
-        if let Some(l) = labels {
-            url.push_str(&format!("&labels={}", urlencoding::encode(l)));
-        }
-
-        let response = self
-            .agent
-            .get(&url)
-            .header("PRIVATE-TOKEN", &self.token)
-            .header("Accept", "application/json")
-            .call()
-            .map_err(|e| self.handle_error(e))?;
-
-        let total = response
-            .headers()
-            .get("x-total")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<u64>().ok());
+        let total = Self::read_total_header(&response);
 
         let mut response = self.check_response(response)?;
         let issues: Vec<GitLabIssue> = response.body_mut().read_json()?;
@@ -656,17 +646,13 @@ impl GitLabClient {
 
     // ==================== Count Operations ====================
 
-    /// Count issues matching search criteria by reading the X-Total header.
-    /// Makes a minimal request with per_page=1 to get the count without
-    /// transferring significant data.
-    pub fn count_issues_by_query(&self, search: &str, state: Option<&str>) -> Result<Option<u64>> {
-        let mut url = format!("{}?per_page=1&page=1", self.project_url("/issues")?);
-        if !search.is_empty() {
-            url.push_str(&format!("&search={}", urlencoding::encode(search)));
-        }
-        if let Some(s) = state {
-            url.push_str(&format!("&state={}", urlencoding::encode(s)));
-        }
+    /// Count issues matching `filters` by reading the X-Total header. Makes a
+    /// minimal request with per_page=1 to get the count without transferring
+    /// significant data. Uses the same `issues_url` builder as
+    /// `list_issues_with_total`, so a count is guaranteed to apply identical
+    /// filters to what a matching search would apply.
+    pub fn count_issues_by_query(&self, filters: &GitLabIssueFilters) -> Result<Option<u64>> {
+        let url = self.issues_url(filters, 1, 1)?;
 
         let response = self
             .agent
@@ -677,11 +663,7 @@ impl GitLabClient {
             .map_err(|e| self.handle_error(e))?;
 
         // Read X-Total header before check_response takes ownership
-        let total = response
-            .headers()
-            .get("x-total")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<u64>().ok());
+        let total = Self::read_total_header(&response);
 
         // Validate the response status
         let _response = self.check_response(response)?;

--- a/crates/gitlab-backend/src/client_tests.rs
+++ b/crates/gitlab-backend/src/client_tests.rs
@@ -3,6 +3,7 @@
 #[cfg(test)]
 mod tests {
     use crate::client::GitLabClient;
+    use crate::filters::GitLabIssueFilters;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tracker_core::{AttachmentUpload, AttachmentUploadFile, IssueTracker, KnowledgeBase};
@@ -118,7 +119,8 @@ mod tests {
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let issues = client.list_issues(None, 20, 1).unwrap();
+        let filters = GitLabIssueFilters::default();
+        let issues = client.list_issues(&filters, 20, 1).unwrap();
 
         assert_eq!(issues.len(), 2);
         assert_eq!(issues[0].iid, 1);
@@ -128,7 +130,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_search_issues() {
+    async fn test_list_issues_with_search_text() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -142,9 +144,12 @@ mod tests {
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let issues = client
-            .search_issues("login", Some("opened"), None, 20, 1)
-            .unwrap();
+        let filters = GitLabIssueFilters {
+            search: "login".to_string(),
+            state: Some("opened".to_string()),
+            ..Default::default()
+        };
+        let issues = client.list_issues(&filters, 20, 1).unwrap();
 
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].title, "Bug in login");
@@ -665,13 +670,18 @@ mod tests {
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let result = client.count_issues_by_query("bug", Some("opened")).unwrap();
+        let filters = GitLabIssueFilters {
+            search: "bug".to_string(),
+            state: Some("opened".to_string()),
+            ..Default::default()
+        };
+        let result = client.count_issues_by_query(&filters).unwrap();
 
         assert_eq!(result, Some(847));
     }
 
     #[tokio::test]
-    async fn test_search_issues_with_total_reads_header() {
+    async fn test_list_issues_with_total_reads_header_with_search_text() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -690,16 +700,18 @@ mod tests {
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let (issues, total) = client
-            .search_issues_with_total("bug", None, None, 20, 1)
-            .unwrap();
+        let filters = GitLabIssueFilters {
+            search: "bug".to_string(),
+            ..Default::default()
+        };
+        let (issues, total) = client.list_issues_with_total(&filters, 20, 1).unwrap();
 
         assert_eq!(issues.len(), 2);
         assert_eq!(total, Some(42));
     }
 
     #[tokio::test]
-    async fn test_search_issues_with_total_without_header() {
+    async fn test_list_issues_with_total_with_search_text_without_header() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -714,9 +726,11 @@ mod tests {
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let (issues, total) = client
-            .search_issues_with_total("bug", None, None, 20, 1)
-            .unwrap();
+        let filters = GitLabIssueFilters {
+            search: "bug".to_string(),
+            ..Default::default()
+        };
+        let (issues, total) = client.list_issues_with_total(&filters, 20, 1).unwrap();
 
         assert_eq!(issues.len(), 1);
         assert_eq!(total, None);
@@ -741,9 +755,11 @@ mod tests {
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let (issues, total) = client
-            .list_issues_with_total(Some("opened"), 20, 1)
-            .unwrap();
+        let filters = GitLabIssueFilters {
+            state: Some("opened".to_string()),
+            ..Default::default()
+        };
+        let (issues, total) = client.list_issues_with_total(&filters, 20, 1).unwrap();
 
         assert_eq!(issues.len(), 2);
         assert_eq!(total, Some(100));
@@ -762,9 +778,114 @@ mod tests {
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let result = client.count_issues_by_query("", None).unwrap();
+        let filters = GitLabIssueFilters::default();
+        let result = client.count_issues_by_query(&filters).unwrap();
 
         assert_eq!(result, None);
+    }
+
+    /// This is the critical regression test for issue #255: the outgoing
+    /// request built without free-text search (exactly the `my_issues`
+    /// cache-template shape) must still carry `state`/`assignee_username`.
+    /// Before the fix, this branch (`list_issues_with_total`) could not
+    /// express those filters at all, so they were silently dropped.
+    #[tokio::test]
+    async fn test_list_issues_with_total_carries_filters_without_search_text() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/projects/123/issues"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("state", "opened"))
+            .and(query_param("assignee_username", "@me"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!([mock_gitlab_issue(7, "My issue")])),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let filters = GitLabIssueFilters {
+            state: Some("opened".to_string()),
+            assignee_username: Some("@me".to_string()),
+            ..Default::default()
+        };
+        let (issues, _total) = client.list_issues_with_total(&filters, 20, 1).unwrap();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].title, "My issue");
+    }
+
+    /// Proves every `GitLabIssueFilters` dimension reaches the outgoing HTTP
+    /// request when free-text search is also present.
+    #[tokio::test]
+    async fn test_list_issues_with_total_carries_all_filters_with_search_text() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/projects/123/issues"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("search", "login"))
+            .and(query_param("state", "opened"))
+            .and(query_param("labels", "bug"))
+            .and(query_param("assignee_username", "@me"))
+            .and(query_param("order_by", "updated_at"))
+            .and(query_param("sort", "desc"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!([mock_gitlab_issue(9, "Login bug")])),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let filters = GitLabIssueFilters {
+            search: "login".to_string(),
+            state: Some("opened".to_string()),
+            labels: Some("bug".to_string()),
+            assignee_username: Some("@me".to_string()),
+            order_by: Some("updated_at".to_string()),
+            sort: Some("desc".to_string()),
+            ..Default::default()
+        };
+        let (issues, _total) = client.list_issues_with_total(&filters, 20, 1).unwrap();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].title, "Login bug");
+    }
+
+    /// Proves `count_issues_by_query` applies the same filters (via the
+    /// shared `issues_url` builder) as a matching search would, so a count
+    /// can never silently disagree with its search.
+    #[tokio::test]
+    async fn test_count_issues_by_query_carries_labels_and_assignee() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/projects/123/issues"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("per_page", "1"))
+            .and(query_param("page", "1"))
+            .and(query_param("labels", "bug"))
+            .and(query_param("assignee_username", "@me"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("x-total", "3")
+                    .set_body_json(serde_json::json!([])),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let filters = GitLabIssueFilters {
+            labels: Some("bug".to_string()),
+            assignee_username: Some("@me".to_string()),
+            ..Default::default()
+        };
+        let result = client.count_issues_by_query(&filters).unwrap();
+
+        assert_eq!(result, Some(3));
     }
 
     // ==================== Work Item Parent Operations ====================

--- a/crates/gitlab-backend/src/convert.rs
+++ b/crates/gitlab-backend/src/convert.rs
@@ -7,6 +7,7 @@ use tracker_core::{
     canonical_field_name,
 };
 
+use crate::filters::GitLabIssueFilters;
 use crate::models::*;
 
 /// Convert a GitLab issue to a tracker-core Issue.
@@ -581,11 +582,15 @@ pub fn gitlab_events_to_history_events(
 /// URL-param format is detected when the query contains `=` with no whitespace
 /// before the first `=`.
 ///
-/// Returns `(search_text, state, labels)`.
-pub fn convert_query_to_gitlab_params(query: &str) -> (String, Option<String>, Option<String>) {
+/// Returns `(filters, unsupported)`, where `unsupported` lists the URL-param
+/// keys that were present but not recognized (in the order encountered).
+/// Token-based queries can never produce unsupported keys, since a token
+/// query's "no match" case is intentional free-text handling, not filter-key
+/// rejection.
+pub fn convert_query_to_gitlab_params(query: &str) -> (GitLabIssueFilters, Vec<String>) {
     let trimmed = query.trim();
     if trimmed.is_empty() {
-        return (String::new(), None, None);
+        return (GitLabIssueFilters::default(), Vec::new());
     }
 
     // Detect URL-param format: contains '=' with no whitespace before the first '='
@@ -600,39 +605,44 @@ pub fn convert_query_to_gitlab_params(query: &str) -> (String, Option<String>, O
     if is_url_param {
         parse_url_params(trimmed)
     } else {
-        parse_token_query(trimmed)
+        (parse_token_query(trimmed), Vec::new())
     }
 }
 
 /// Parse URL-param format: `key=value&key=value`
-fn parse_url_params(query: &str) -> (String, Option<String>, Option<String>) {
+fn parse_url_params(query: &str) -> (GitLabIssueFilters, Vec<String>) {
+    let mut filters = GitLabIssueFilters::default();
     let mut search_parts = Vec::new();
-    let mut state: Option<String> = None;
-    let mut labels: Option<String> = None;
+    let mut unsupported = Vec::new();
 
     for pair in query.split('&') {
         if let Some((key, value)) = pair.split_once('=') {
             match key {
-                "state" => state = Some(value.to_string()),
-                "labels" => labels = Some(value.to_string()),
+                "state" => filters.state = Some(value.to_string()),
+                "labels" => filters.labels = Some(value.to_string()),
+                "assignee_username" => filters.assignee_username = Some(value.to_string()),
+                "author_username" => filters.author_username = Some(value.to_string()),
+                "milestone" => filters.milestone = Some(value.to_string()),
+                "order_by" => filters.order_by = Some(value.to_string()),
+                "sort" => filters.sort = Some(value.to_string()),
                 "search" => {
                     if !value.is_empty() {
                         search_parts.push(value.to_string());
                     }
                 }
-                _ => {} // ignore order_by, sort, assignee_username, etc.
+                other => unsupported.push(other.to_string()),
             }
         }
     }
 
-    (search_parts.join(" "), state, labels)
+    filters.search = search_parts.join(" ");
+    (filters, unsupported)
 }
 
 /// Parse token-based format: `#open label:bug some text`
-fn parse_token_query(query: &str) -> (String, Option<String>, Option<String>) {
+fn parse_token_query(query: &str) -> GitLabIssueFilters {
+    let mut filters = GitLabIssueFilters::default();
     let mut search_parts = Vec::new();
-    let mut state: Option<String> = None;
-    let mut labels: Option<String> = None;
 
     let tokens: Vec<&str> = query.split_whitespace().collect();
     for token in &tokens {
@@ -641,11 +651,11 @@ fn parse_token_query(query: &str) -> (String, Option<String>, Option<String>) {
                 || hash_tag.eq_ignore_ascii_case("open")
                 || hash_tag.eq_ignore_ascii_case("opened")
             {
-                state = Some("opened".to_string());
+                filters.state = Some("opened".to_string());
             } else if hash_tag.eq_ignore_ascii_case("resolved")
                 || hash_tag.eq_ignore_ascii_case("closed")
             {
-                state = Some("closed".to_string());
+                filters.state = Some("closed".to_string());
             } else {
                 search_parts.push(*token);
             }
@@ -653,13 +663,14 @@ fn parse_token_query(query: &str) -> (String, Option<String>, Option<String>) {
             // Skip project: prefix for GitLab (project is already scoped via project_id)
             let _ = rest;
         } else if let Some(rest) = token.strip_prefix("label:") {
-            labels = Some(rest.to_string());
+            filters.labels = Some(rest.to_string());
         } else {
             search_parts.push(*token);
         }
     }
 
-    (search_parts.join(" "), state, labels)
+    filters.search = search_parts.join(" ");
+    filters
 }
 
 #[cfg(test)]
@@ -670,77 +681,131 @@ mod tests {
 
     #[test]
     fn url_param_state_only() {
-        let (search, state, labels) = convert_query_to_gitlab_params("state=opened");
-        assert_eq!(search, "");
-        assert_eq!(state, Some("opened".to_string()));
-        assert_eq!(labels, None);
+        let (filters, unsupported) = convert_query_to_gitlab_params("state=opened");
+        assert_eq!(filters.search, "");
+        assert_eq!(filters.state, Some("opened".to_string()));
+        assert_eq!(filters.labels, None);
+        assert!(unsupported.is_empty());
     }
 
     #[test]
     fn url_param_state_and_labels() {
-        let (search, state, labels) = convert_query_to_gitlab_params("state=opened&labels=bug");
-        assert_eq!(search, "");
-        assert_eq!(state, Some("opened".to_string()));
-        assert_eq!(labels, Some("bug".to_string()));
+        let (filters, unsupported) =
+            convert_query_to_gitlab_params("state=opened&labels=bug");
+        assert_eq!(filters.search, "");
+        assert_eq!(filters.state, Some("opened".to_string()));
+        assert_eq!(filters.labels, Some("bug".to_string()));
+        assert!(unsupported.is_empty());
     }
 
     #[test]
     fn url_param_with_search() {
-        let (search, state, labels) = convert_query_to_gitlab_params("state=opened&search=foo");
-        assert_eq!(search, "foo");
-        assert_eq!(state, Some("opened".to_string()));
-        assert_eq!(labels, None);
+        let (filters, unsupported) = convert_query_to_gitlab_params("state=opened&search=foo");
+        assert_eq!(filters.search, "foo");
+        assert_eq!(filters.state, Some("opened".to_string()));
+        assert_eq!(filters.labels, None);
+        assert!(unsupported.is_empty());
     }
 
     #[test]
-    fn url_param_ignores_unknown_keys() {
-        let (search, state, labels) =
-            convert_query_to_gitlab_params("state=opened&order_by=updated_at");
-        assert_eq!(search, "");
-        assert_eq!(state, Some("opened".to_string()));
-        assert_eq!(labels, None);
+    fn url_param_reports_unsupported_keys() {
+        let (filters, unsupported) =
+            convert_query_to_gitlab_params("state=opened&totally_bogus_key=updated_at");
+        assert_eq!(filters.search, "");
+        assert_eq!(filters.state, Some("opened".to_string()));
+        assert_eq!(filters.labels, None);
+        assert_eq!(unsupported, vec!["totally_bogus_key".to_string()]);
+    }
+
+    #[test]
+    fn url_param_assignee_username() {
+        let (filters, unsupported) = convert_query_to_gitlab_params("assignee_username=@me");
+        assert_eq!(filters.assignee_username, Some("@me".to_string()));
+        assert!(unsupported.is_empty());
+    }
+
+    #[test]
+    fn url_param_author_username() {
+        let (filters, unsupported) = convert_query_to_gitlab_params("author_username=octocat");
+        assert_eq!(filters.author_username, Some("octocat".to_string()));
+        assert!(unsupported.is_empty());
+    }
+
+    #[test]
+    fn url_param_milestone() {
+        let (filters, unsupported) = convert_query_to_gitlab_params("milestone=v1.0");
+        assert_eq!(filters.milestone, Some("v1.0".to_string()));
+        assert!(unsupported.is_empty());
+    }
+
+    #[test]
+    fn url_param_order_by_and_sort() {
+        let (filters, unsupported) =
+            convert_query_to_gitlab_params("order_by=updated_at&sort=desc");
+        assert_eq!(filters.order_by, Some("updated_at".to_string()));
+        assert_eq!(filters.sort, Some("desc".to_string()));
+        assert!(unsupported.is_empty());
+    }
+
+    /// Regression test for issue #255: the built-in `my_issues` GitLab cache
+    /// template (see `crates/track/src/cache.rs`) uses this exact query
+    /// string. Previously `assignee_username` was silently dropped, so the
+    /// template returned every open issue instead of just the current
+    /// user's.
+    #[test]
+    fn my_issues_template_query_is_fully_supported() {
+        let (filters, unsupported) =
+            convert_query_to_gitlab_params("state=opened&assignee_username=@me");
+        assert_eq!(filters.state, Some("opened".to_string()));
+        assert_eq!(filters.assignee_username, Some("@me".to_string()));
+        assert!(unsupported.is_empty());
     }
 
     // Token-based format tests
 
     #[test]
     fn token_hash_open() {
-        let (search, state, labels) = convert_query_to_gitlab_params("#open");
-        assert_eq!(search, "");
-        assert_eq!(state, Some("opened".to_string()));
-        assert_eq!(labels, None);
+        let (filters, unsupported) = convert_query_to_gitlab_params("#open");
+        assert_eq!(filters.search, "");
+        assert_eq!(filters.state, Some("opened".to_string()));
+        assert_eq!(filters.labels, None);
+        assert!(unsupported.is_empty());
     }
 
     #[test]
     fn token_hash_unresolved() {
-        let (search, state, labels) = convert_query_to_gitlab_params("#unresolved");
-        assert_eq!(search, "");
-        assert_eq!(state, Some("opened".to_string()));
-        assert_eq!(labels, None);
+        let (filters, unsupported) = convert_query_to_gitlab_params("#unresolved");
+        assert_eq!(filters.search, "");
+        assert_eq!(filters.state, Some("opened".to_string()));
+        assert_eq!(filters.labels, None);
+        assert!(unsupported.is_empty());
     }
 
     #[test]
     fn token_label() {
-        let (search, state, labels) = convert_query_to_gitlab_params("label:bug");
-        assert_eq!(search, "");
-        assert_eq!(state, None);
-        assert_eq!(labels, Some("bug".to_string()));
+        let (filters, unsupported) = convert_query_to_gitlab_params("label:bug");
+        assert_eq!(filters.search, "");
+        assert_eq!(filters.state, None);
+        assert_eq!(filters.labels, Some("bug".to_string()));
+        assert!(unsupported.is_empty());
     }
 
     #[test]
     fn token_free_text() {
-        let (search, state, labels) = convert_query_to_gitlab_params("hello world");
-        assert_eq!(search, "hello world");
-        assert_eq!(state, None);
-        assert_eq!(labels, None);
+        let (filters, unsupported) = convert_query_to_gitlab_params("hello world");
+        assert_eq!(filters.search, "hello world");
+        assert_eq!(filters.state, None);
+        assert_eq!(filters.labels, None);
+        assert!(unsupported.is_empty());
     }
 
     #[test]
     fn empty_string() {
-        let (search, state, labels) = convert_query_to_gitlab_params("");
-        assert_eq!(search, "");
-        assert_eq!(state, None);
-        assert_eq!(labels, None);
+        let (filters, unsupported) = convert_query_to_gitlab_params("");
+        assert_eq!(filters.search, "");
+        assert_eq!(filters.state, None);
+        assert_eq!(filters.labels, None);
+        assert!(unsupported.is_empty());
     }
 
     // gitlab_link_to_core tests
@@ -763,7 +828,7 @@ mod tests {
         assert_eq!(core_link.direction, Some("outward".to_string()));
         assert_eq!(core_link.link_type.id, "blocks");
         assert_eq!(core_link.link_type.name, "Blocks");
-        assert_eq!(core_link.link_type.directed, true);
+        assert!(core_link.link_type.directed);
         assert_eq!(core_link.issues.len(), 1);
         assert_eq!(core_link.issues[0].id, "123");
         assert_eq!(core_link.issues[0].id_readable, Some("#456".to_string()));
@@ -789,7 +854,7 @@ mod tests {
         assert_eq!(core_link.direction, Some("inward".to_string()));
         assert_eq!(core_link.link_type.id, "is_blocked_by");
         assert_eq!(core_link.link_type.name, "Is Blocked By");
-        assert_eq!(core_link.link_type.directed, true);
+        assert!(core_link.link_type.directed);
         assert_eq!(core_link.issues.len(), 1);
         assert_eq!(core_link.issues[0].id, "124");
         assert_eq!(core_link.issues[0].id_readable, Some("#457".to_string()));
@@ -815,7 +880,7 @@ mod tests {
         assert_eq!(core_link.direction, Some("both".to_string()));
         assert_eq!(core_link.link_type.id, "relates_to");
         assert_eq!(core_link.link_type.name, "Relates");
-        assert_eq!(core_link.link_type.directed, false);
+        assert!(!core_link.link_type.directed);
         assert_eq!(core_link.issues.len(), 1);
         assert_eq!(core_link.issues[0].id, "125");
         assert_eq!(core_link.issues[0].id_readable, Some("#458".to_string()));
@@ -842,7 +907,7 @@ mod tests {
         assert_eq!(core_link.direction, Some("both".to_string()));
         assert_eq!(core_link.link_type.id, "relates_to");
         assert_eq!(core_link.link_type.name, "Relates");
-        assert_eq!(core_link.link_type.directed, false);
+        assert!(!core_link.link_type.directed);
         assert_eq!(core_link.issues.len(), 1);
         assert_eq!(core_link.issues[0].id, "126");
         assert_eq!(core_link.issues[0].id_readable, Some("#459".to_string()));

--- a/crates/gitlab-backend/src/filters.rs
+++ b/crates/gitlab-backend/src/filters.rs
@@ -1,0 +1,16 @@
+//! Unified GitLab issue-list filter representation.
+
+/// All GitLab issue-list filter dimensions the CLI query language can express.
+/// Both list/search and count go through this so a filter can never be
+/// supported on one code path and silently dropped on another.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GitLabIssueFilters {
+    pub search: String,
+    pub state: Option<String>,
+    pub labels: Option<String>,
+    pub assignee_username: Option<String>,
+    pub author_username: Option<String>,
+    pub milestone: Option<String>,
+    pub order_by: Option<String>,
+    pub sort: Option<String>,
+}

--- a/crates/gitlab-backend/src/lib.rs
+++ b/crates/gitlab-backend/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod client;
 mod convert;
 pub mod error;
+pub mod filters;
 pub mod models;
 mod trait_impl;
 
@@ -9,6 +10,7 @@ mod client_tests;
 
 pub use client::GitLabClient;
 pub use error::{GitLabError, Result};
+pub use filters::GitLabIssueFilters;
 pub use models::*;
 
 pub use tracker_core::{IssueTracker, KnowledgeBase, TrackerError};

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -40,7 +40,10 @@ impl IssueTracker for GitLabClient {
     }
 
     fn search_issues(&self, query: &str, limit: usize, skip: usize) -> Result<SearchResult<Issue>> {
-        let (search_text, state, labels) = convert_query_to_gitlab_params(query);
+        let (filters, unsupported) = convert_query_to_gitlab_params(query);
+        for key in &unsupported {
+            eprintln!("Warning: ignoring unsupported filter '{}'", key);
+        }
         let project_id = self.project_id_str();
 
         if limit == 0 {
@@ -54,18 +57,7 @@ impl IssueTracker for GitLabClient {
         let mut total = None;
 
         while issues.len() < limit {
-            // Use combined methods that read X-Total from the search response itself
-            let (page_issues, page_total) = if search_text.is_empty() {
-                self.list_issues_with_total(state.as_deref(), per_page, page)?
-            } else {
-                self.search_issues_with_total(
-                    &search_text,
-                    state.as_deref(),
-                    labels.as_deref(),
-                    per_page,
-                    page,
-                )?
-            };
+            let (page_issues, page_total) = self.list_issues_with_total(&filters, per_page, page)?;
 
             if total.is_none() {
                 total = page_total;
@@ -95,8 +87,11 @@ impl IssueTracker for GitLabClient {
     }
 
     fn get_issue_count(&self, query: &str) -> Result<Option<u64>> {
-        let (search_text, state, _labels) = convert_query_to_gitlab_params(query);
-        Ok(self.count_issues_by_query(&search_text, state.as_deref())?)
+        let (filters, unsupported) = convert_query_to_gitlab_params(query);
+        for key in &unsupported {
+            eprintln!("Warning: ignoring unsupported filter '{}'", key);
+        }
+        Ok(self.count_issues_by_query(&filters)?)
     }
 
     fn create_issue(&self, issue: &CreateIssue) -> Result<Issue> {


### PR DESCRIPTION
## Root cause

GitLab's query-param parser (`crates/gitlab-backend/src/convert.rs`, `parse_url_params`) only recognized the `state`, `labels`, and `search` URL-param keys. Every other key — `assignee_username`, `author_username`, `milestone`, `order_by`, `sort` — hit a bare `_ => {}` catch-all and was silently dropped with no warning.

This broke the built-in GitLab `my_issues` cache template (`crates/track/src/cache.rs`, query `state=opened&assignee_username=@me`): `assignee_username` was dropped, so the template returned every open issue instead of just the current user's.

There was a second, deeper instance of the same root cause: `search_issues` in `crates/gitlab-backend/src/trait_impl.rs` branched on whether the parsed query had free-text search. When it didn't — exactly the `my_issues` shape, since it has no `search=` key — it called `list_issues_with_total`, which didn't even accept a `labels` parameter at all (only `search_issues_with_total` did). So even the already-recognized `labels` key silently vanished on that branch. `get_issue_count` / `count_issues_by_query` had the same narrow-surface problem, so a count could silently disagree with the matching search.

## Fix

Root-cause unification instead of a point patch:

- New `GitLabIssueFilters` struct (`crates/gitlab-backend/src/filters.rs`) covering all 8 filter dimensions the CLI query language can express (`search`, `state`, `labels`, `assignee_username`, `author_username`, `milestone`, `order_by`, `sort`).
- `convert_query_to_gitlab_params` now returns `(GitLabIssueFilters, Vec<String>)` — the filters plus any URL-param keys that were present but genuinely unrecognized, so an unsupported key is surfaced as a warning instead of vanishing silently.
- `client.rs` collapses `list_issues_with_total` and `search_issues_with_total` (and the thin `search_issues` wrapper) into a single `list_issues_with_total(&GitLabIssueFilters, ...)` built from one `issues_url` helper. `count_issues_by_query` now uses the same helper, so a count can never apply a different filter set than the matching search.
- `trait_impl.rs`'s `search_issues` no longer branches on whether free-text search is present — that branch was the actual root-cause site. It now always goes through the unified filter struct and method, and emits a warning for any unsupported key.

Added regression tests, including one asserting the literal `my_issues` template query (`state=opened&assignee_username=@me`) round-trips correctly, and wiremock tests proving filters reach the outgoing HTTP request on both the search-text and no-search-text code paths (the latter is the one that would have caught the original bug).

Fixes #255