### PR TITLE
fix: correct YouTrack search totals and GitLab wiki --all pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.15.2"
+version = "1.15.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/gitlab-backend/src/client.rs
+++ b/crates/gitlab-backend/src/client.rs
@@ -789,9 +789,15 @@ impl GitLabClient {
     // ==================== Wiki Operations ====================
 
     /// List project wiki pages.
+    ///
+    /// GitLab's `GET /projects/:id/wikis` endpoint does not support
+    /// pagination (`per_page`/`page` are not documented parameters and are
+    /// silently ignored -- confirmed against the live API, which returns
+    /// the full collection in a single response regardless). Callers that
+    /// need a subset should slice the returned `Vec` themselves.
     pub fn list_wiki_pages(&self, with_content: bool) -> Result<Vec<GitLabWikiPage>> {
         let url = self.project_url(&format!(
-            "/wikis?with_content={}&per_page=100",
+            "/wikis?with_content={}",
             if with_content { 1 } else { 0 }
         ))?;
 

--- a/crates/gitlab-backend/src/client_tests.rs
+++ b/crates/gitlab-backend/src/client_tests.rs
@@ -932,55 +932,100 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_all_articles_fetches_wiki_once_and_truncates() {
+    async fn test_list_articles_slices_full_wiki_response_past_first_hundred() {
         let mock_server = MockServer::start().await;
+
+        // GitLab's GET /projects/:id/wikis does not support pagination --
+        // `per_page`/`page` aren't documented parameters and are ignored;
+        // the endpoint always returns the full collection in one response
+        // (confirmed against the live API). `with_content` is the only
+        // supported query param, so the mock must not require per_page/page.
+        let wiki_pages: Vec<_> = (1..=105)
+            .map(|n| mock_wiki_page(&format!("wiki-{n}"), &format!("Page {n}"), "body"))
+            .collect();
 
         Mock::given(method("GET"))
             .and(path("/projects/123/wikis"))
             .and(header("PRIVATE-TOKEN", "test-token"))
             .and(query_param("with_content", "1"))
-            .and(query_param("per_page", "100"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
-                mock_wiki_page("first", "First", "alpha"),
-                mock_wiki_page("second", "Second", "beta"),
-                mock_wiki_page("third", "Third", "gamma")
-            ])))
+            .respond_with(ResponseTemplate::new(200).set_body_json(wiki_pages))
             .expect(1)
             .mount(&mock_server)
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let articles = client.list_all_articles(Some("123"), 2).unwrap();
+        // skip=99 starts past the first 100 items that a (nonexistent) 100-
+        // item page cap would have returned.
+        let articles = client.list_articles(Some("123"), 5, 99).unwrap();
 
-        assert_eq!(articles.len(), 2);
-        assert_eq!(articles[0].id, "first");
-        assert_eq!(articles[1].id, "second");
+        assert_eq!(articles.len(), 5);
+        assert_eq!(articles[0].id, "wiki-100");
+        assert_eq!(articles[4].id, "wiki-104");
     }
 
     #[tokio::test]
-    async fn test_search_all_articles_fetches_wiki_once_filters_and_truncates() {
+    async fn test_list_all_articles_returns_articles_past_first_hundred() {
         let mock_server = MockServer::start().await;
+
+        // Every call returns the same full 105-item collection (GitLab's
+        // wiki-list endpoint has no pagination); `list_all_articles`'s
+        // default windowed implementation calls `list_articles` twice
+        // (offset 0 and offset 100) and must combine them without dropping
+        // or duplicating anything.
+        let wiki_pages: Vec<_> = (1..=105)
+            .map(|n| mock_wiki_page(&format!("wiki-{n}"), &format!("Page {n}"), "body"))
+            .collect();
 
         Mock::given(method("GET"))
             .and(path("/projects/123/wikis"))
             .and(header("PRIVATE-TOKEN", "test-token"))
             .and(query_param("with_content", "1"))
-            .and(query_param("per_page", "100"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
-                mock_wiki_page("install", "Install Guide", "alpha"),
-                mock_wiki_page("deploy", "Deploy", "contains guide details"),
-                mock_wiki_page("other", "Other", "guide appendix")
-            ])))
+            .respond_with(ResponseTemplate::new(200).set_body_json(wiki_pages))
+            .expect(2)
+            .mount(&mock_server)
+            .await;
+
+        let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
+        let articles = client.list_all_articles(Some("123"), 1000).unwrap();
+
+        assert_eq!(articles.len(), 105);
+        assert_eq!(articles[0].id, "wiki-1");
+        // The 101st-105th wiki pages only surface once the second windowed
+        // call slices past offset 100 -- exactly what silently dropping the
+        // rest of the collection would have missed.
+        assert_eq!(articles[100].id, "wiki-101");
+        assert_eq!(articles[104].id, "wiki-105");
+    }
+
+    #[tokio::test]
+    async fn test_search_all_articles_finds_match_past_first_hundred_wiki_pages() {
+        let mock_server = MockServer::start().await;
+
+        // The only match ("needle") sits at the end of a 105-item
+        // collection returned in a single response.
+        let mut wiki_pages: Vec<_> = (1..=104)
+            .map(|n| mock_wiki_page(&format!("wiki-{n}"), &format!("Page {n}"), "haystack"))
+            .collect();
+        wiki_pages.push(mock_wiki_page(
+            "wiki-105",
+            "Needle Page",
+            "contains the needle",
+        ));
+
+        Mock::given(method("GET"))
+            .and(path("/projects/123/wikis"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(query_param("with_content", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(wiki_pages))
             .expect(1)
             .mount(&mock_server)
             .await;
 
         let client = GitLabClient::new(&mock_server.uri(), "test-token", Some("123"));
-        let articles = client.search_all_articles("guide", 2).unwrap();
+        let articles = client.search_all_articles("needle", 1000).unwrap();
 
-        assert_eq!(articles.len(), 2);
-        assert_eq!(articles[0].id, "install");
-        assert_eq!(articles[1].id, "deploy");
+        assert_eq!(articles.len(), 1);
+        assert_eq!(articles[0].id, "wiki-105");
     }
 
     // ==================== Issue History (3-endpoint merge) Tests ====================

--- a/crates/gitlab-backend/src/trait_impl.rs
+++ b/crates/gitlab-backend/src/trait_impl.rs
@@ -502,6 +502,9 @@ impl KnowledgeBase for GitLabClient {
         {
             return Ok(Vec::new());
         }
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
 
         Ok(self
             .list_wiki_pages(true)?
@@ -513,6 +516,10 @@ impl KnowledgeBase for GitLabClient {
     }
 
     fn search_articles(&self, query: &str, limit: usize, skip: usize) -> Result<Vec<Article>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
         let query = query.to_lowercase();
         Ok(self
             .list_wiki_pages(true)?
@@ -528,51 +535,6 @@ impl KnowledgeBase for GitLabClient {
             })
             .skip(skip)
             .take(limit)
-            .map(|page| gitlab_wiki_page_to_article(page, &self.project_id_str()))
-            .collect())
-    }
-
-    fn list_all_articles(
-        &self,
-        project_id: Option<&str>,
-        max_results: usize,
-    ) -> Result<Vec<Article>> {
-        if let Some(project) = project_id
-            && project != self.project_id_str()
-        {
-            return Ok(Vec::new());
-        }
-        if max_results == 0 {
-            return Ok(Vec::new());
-        }
-
-        Ok(self
-            .list_wiki_pages(true)?
-            .into_iter()
-            .take(max_results)
-            .map(|page| gitlab_wiki_page_to_article(page, &self.project_id_str()))
-            .collect())
-    }
-
-    fn search_all_articles(&self, query: &str, max_results: usize) -> Result<Vec<Article>> {
-        if max_results == 0 {
-            return Ok(Vec::new());
-        }
-
-        let query = query.to_lowercase();
-        Ok(self
-            .list_wiki_pages(true)?
-            .into_iter()
-            .filter(|page| {
-                page.title.to_lowercase().contains(&query)
-                    || page
-                        .content
-                        .as_deref()
-                        .unwrap_or_default()
-                        .to_lowercase()
-                        .contains(&query)
-            })
-            .take(max_results)
             .map(|page| gitlab_wiki_page_to_article(page, &self.project_id_str()))
             .collect())
     }

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.15.2"
+version = "1.15.3"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 

--- a/crates/youtrack-backend/src/client_tests.rs
+++ b/crates/youtrack-backend/src/client_tests.rs
@@ -164,7 +164,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_trait_search_short_page_infers_total_without_counting() {
+    async fn test_trait_search_nonempty_short_page_infers_total_without_counting() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -194,6 +194,103 @@ mod tests {
 
         assert_eq!(result.items.len(), 2);
         assert_eq!(result.total, Some(7));
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_empty_page_after_skip_uses_count_not_skip() {
+        let mock_server = MockServer::start().await;
+
+        // Items matching the query were deleted since an earlier page
+        // suggested more results existed, so skip=10 now lands past the
+        // (now smaller) true total -- the page comes back empty.
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .and(query_param("query", "project: PROJ"))
+            .and(query_param("$top", "5"))
+            .and(query_param("$skip", "10"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/issuesGetter/count"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "count": 7
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let result = IssueTracker::search_issues(&client, "project: PROJ", 5, 10).unwrap();
+
+        assert!(result.items.is_empty());
+        // Must reflect the real count (7), not the skip value (10).
+        assert_eq!(result.total, Some(7));
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_empty_page_after_skip_count_fails_returns_none() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .and(query_param("query", "project: PROJ"))
+            .and(query_param("$top", "5"))
+            .and(query_param("$skip", "10"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // count == -1 means YouTrack is still counting; the interactive
+        // search path only gets one no-sleep attempt, so this resolves to
+        // "count unavailable" rather than retrying.
+        Mock::given(method("POST"))
+            .and(path("/api/issuesGetter/count"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "count": -1
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let result = IssueTracker::search_issues(&client, "project: PROJ", 5, 10).unwrap();
+
+        assert!(result.items.is_empty());
+        assert_eq!(result.total, None);
+    }
+
+    #[tokio::test]
+    async fn test_trait_search_empty_page_no_skip_infers_zero_total() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/issues"))
+            .and(query_param("query", "project: PROJ"))
+            .and(query_param("$top", "5"))
+            .and(query_param("$skip", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/issuesGetter/count"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "count": 0
+            })))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let client = YouTrackClient::new(&mock_server.uri(), "test-token");
+        let result = IssueTracker::search_issues(&client, "project: PROJ", 5, 0).unwrap();
+
+        assert!(result.items.is_empty());
+        assert_eq!(result.total, Some(0));
     }
 
     #[tokio::test]

--- a/crates/youtrack-backend/src/trait_impl.rs
+++ b/crates/youtrack-backend/src/trait_impl.rs
@@ -30,6 +30,22 @@ impl IssueTracker for YouTrackClient {
         let item_count = items.len();
 
         if item_count < limit {
+            // An empty page after a nonzero skip doesn't reliably mean the
+            // true total equals skip -- matching issues may have been
+            // deleted or reprioritized since an earlier page suggested more
+            // results existed. Fall back to a best-effort count rather than
+            // asserting total == skip.
+            if skip > 0 && item_count == 0 {
+                let total = self
+                    .count_issues_with_retry(query, 1, std::time::Duration::ZERO)
+                    .ok()
+                    .flatten();
+                return Ok(match total {
+                    Some(count) => SearchResult::with_total(items, count),
+                    None => SearchResult::from_items(items),
+                });
+            }
+
             return Ok(SearchResult::with_total(items, (skip + item_count) as u64));
         }
 


### PR DESCRIPTION
## Summary

Fixes two review findings:

- **YouTrack search totals**: an empty page after a nonzero `skip` no longer reports `total == skip`. Matching issues can be deleted between an earlier page suggesting more results exist and a later page landing past the (now smaller) true total; that case falls back to a best-effort count instead of asserting the total equals skip. `skip == 0` and non-empty short pages keep the existing exact `skip + item_count` inference unchanged.
- **GitLab wiki `--all`**: `list_articles`/`search_articles` (and `list_all_articles`/`search_all_articles` via the trait default) previously fetched only the first 100 wiki pages and paginated/filtered over that truncated set, silently dropping anything past it.

## GitLab wiki finding — plan revised after live testing

The original plan called for adding real `per_page`/`page` pagination to `GitLabClient::list_wiki_pages`. I implemented that, but live-testing it against the real `gitlab.com` API (in the local `.track.toml` test project) surfaced that `GET /projects/:id/wikis` does **not** support pagination at all — `per_page`/`page` aren't documented parameters ([GitLab API docs](https://docs.gitlab.com/api/wikis/#list-all-wiki-pages) list only `id` and `with_content`), and empirically the endpoint always returns the full collection in one response regardless of what's passed (confirmed with `per_page=1` still returning all 106 test pages, and no `Link`/`X-Total` pagination headers at all). The page-based approach caused a real `PaginationStalled` error live (page 2 re-fetched the identical full list, which the dedup-and-fail-loudly helper correctly treated as a stalled backend).

The corrected fix fetches the full wiki collection in a single call (matching how the API actually behaves) and slices/filters it in memory for `limit`/`skip`. `list_all_articles`/`search_all_articles` no longer have GitLab-specific overrides, so the `KnowledgeBase` trait's default `fetch_all_pages_keyed`-based implementation applies — each windowed call re-fetches the full collection and correctly slices past offset 100, so `--all` now returns everything instead of silently truncating at 100.

## Live validation

Using the local `.track.toml` GitLab test project (project 77945341):
- Created 105 real wiki pages, confirmed `track article list --all` and `track article search ... --all` both returned all 105 (including pages 101-105, past the old artificial cutoff), then deleted all 105 test pages and verified the project was restored to its original single article.
- Spot-checked the YouTrack totals fix against the real YouTrack instance (`skip` at and past a project's true issue count) — executes cleanly with no errors; exact total-value correctness is covered by the new wiremock unit tests since the CLI doesn't surface `total` for empty result pages.

## Tests

- `cargo test -p youtrack-backend` — 3 new tests: empty page past skip uses count (not skip), count-unavailable falls back to `None`, and a renamed test confirming non-empty short pages still use `skip + item_count`.
- `cargo test -p gitlab-backend` — 3 new/replaced tests reflecting the real single-response API behavior: `list_articles` slicing past the old 100 cutoff, `list_all_articles` combining two windowed calls without dropping/duplicating, and `search_all_articles` finding a match placed at the end of a 105-item collection.
- `cargo test --workspace`, `cargo fmt --all -- --check` — all pass. `cargo clippy --workspace --all-targets -- -D warnings` has 4 pre-existing failures in `gitlab-backend/src/convert.rs` (unrelated `assert_eq!(x, false)` lint, confirmed present on a clean `main` before this change) — none in the files this PR touches.