### PR TITLE
🧹 Fix taskItem state fallback logic in markdown-to-ADF conversion

### DIFF
--- a/crates/jira-backend/src/markdown/adf.rs
+++ b/crates/jira-backend/src/markdown/adf.rs
@@ -184,9 +184,9 @@ pub(crate) fn markdown_to_adf(text: &str) -> serde_json::Value {
             Event::End(TagEnd::Item) => {
                 flush_inline(&mut inline_buf, &mut block_stack, &mut doc_content);
                 if let Some((key, content)) = block_stack.pop() {
-                    let node = if key.starts_with("taskItem:") {
+                    let node = if let Some(state_suffix) = key.strip_prefix("taskItem:") {
                         // ADF taskItem takes inline content directly — no paragraph wrapper.
-                        let state = key.split_once(':').map(|x| x.1).unwrap_or("TODO");
+                        let state = Some(state_suffix).filter(|s| !s.is_empty()).unwrap_or("TODO");
                         json!({
                             "type": "taskItem",
                             "attrs": { "localId": next_id(), "state": state },

--- a/crates/jira-backend/src/markdown/adf.rs
+++ b/crates/jira-backend/src/markdown/adf.rs
@@ -186,7 +186,9 @@ pub(crate) fn markdown_to_adf(text: &str) -> serde_json::Value {
                 if let Some((key, content)) = block_stack.pop() {
                     let node = if let Some(state_suffix) = key.strip_prefix("taskItem:") {
                         // ADF taskItem takes inline content directly — no paragraph wrapper.
-                        let state = Some(state_suffix).filter(|s| !s.is_empty()).unwrap_or("TODO");
+                        let state = Some(state_suffix)
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or("TODO");
                         json!({
                             "type": "taskItem",
                             "attrs": { "localId": next_id(), "state": state },


### PR DESCRIPTION
🎯 **What:** Modified ADF taskItem parsing to use `strip_prefix` and explicitly check for empty state values, falling back to "TODO".
💡 **Why:** `key.split_once(':').map(|x| x.1).unwrap_or("TODO")` evaluated to an empty string `""` when the state was missing (`"taskItem:"`), rather than utilizing the fallback default `"TODO"`. This led to invalid statuses propagating through the markdown to ADF conversion. The new implementation cleanly extracts the state suffix and correctly delegates empty values.
✅ **Verification:** Verified by executing a dedicated ad-hoc validation script for the string matching behavior and passing the `jira-backend` test suite (including ADF tests) successfully.
✨ **Result:** Improved correctness and robustness of the markdown parsing when handling checklists, avoiding mapping to invalid empty states.

---
*PR created automatically by Jules for task [6395367387854826282](https://jules.google.com/task/6395367387854826282) started by @johnsdav*