### PR TITLE
fix(jira): support assignee and Components on issue update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jira-backend"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "pulldown-cmark",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "track"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/jira-backend/Cargo.toml
+++ b/crates/jira-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jira-backend"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Jira backend implementation for tracker-core"
 

--- a/crates/jira-backend/src/client.rs
+++ b/crates/jira-backend/src/client.rs
@@ -694,6 +694,23 @@ impl JiraClient {
         let statuses: Vec<ProjectIssueTypeStatuses> = response.body_mut().read_json()?;
         Ok(statuses)
     }
+
+    /// GET /rest/api/3/project/{projectIdOrKey}/components
+    pub fn list_project_components(&self, project_key: &str) -> Result<Vec<JiraComponent>> {
+        let url = self.api_url(&format!("/project/{}/components", project_key));
+
+        let response = self
+            .agent
+            .get(&url)
+            .header("Authorization", &self.auth_header)
+            .header("Accept", "application/json")
+            .call()
+            .map_err(|e| self.handle_error(e))?;
+
+        let mut response = self.check_response(response)?;
+        let components: Vec<JiraComponent> = response.body_mut().read_json()?;
+        Ok(components)
+    }
 }
 
 /// Simple base64 encoding function

--- a/crates/jira-backend/src/client_tests.rs
+++ b/crates/jira-backend/src/client_tests.rs
@@ -420,6 +420,7 @@ mod tests {
                 priority: None,
                 labels: None,
                 parent: None,
+                assignee: None,
                 extra: std::collections::HashMap::new(),
             },
         };
@@ -472,6 +473,7 @@ mod tests {
                 priority: None,
                 labels: None,
                 parent: None,
+                assignee: None,
                 extra,
             },
         };

--- a/crates/jira-backend/src/convert.rs
+++ b/crates/jira-backend/src/convert.rs
@@ -599,6 +599,15 @@ pub fn update_issue_to_jira(
         _ => None,
     });
 
+    let assignee = update.custom_fields.iter().find_map(|cf| match cf {
+        CustomFieldUpdate::SingleUser { name, login } if name.eq_ignore_ascii_case("assignee") => {
+            Some(AssigneeId {
+                account_id: Some(login.clone()),
+            })
+        }
+        _ => None,
+    });
+
     let extra = resolve_extra_fields(&update.custom_fields, jira_fields, UPDATE_HANDLED_FIELDS)?;
 
     Ok(UpdateJiraIssue {
@@ -615,6 +624,7 @@ pub fn update_issue_to_jira(
                 id: None,
                 key: Some(key.clone()),
             }),
+            assignee,
             extra,
         },
     })
@@ -656,6 +666,14 @@ pub fn get_standard_custom_fields() -> Vec<ProjectCustomField> {
             field_type: "user[1]".to_string(),
             required: false,
             values: vec![], // Users are fetched separately
+            state_values: vec![],
+        },
+        ProjectCustomField {
+            id: "components".to_string(),
+            name: "Components".to_string(),
+            field_type: "enum[*]".to_string(),
+            required: false,
+            values: vec![], // Per-project components are spliced in by the caller
             state_values: vec![],
         },
         ProjectCustomField {
@@ -832,10 +850,10 @@ fn custom_field_to_json(
                         .collect();
                     serde_json::Value::Array(items)
                 }
-                // Multi-group pickers (schema items == "group") must be written as
-                // an array of group objects keyed by `name`. Jira rejects bare
-                // strings with: "Operation value must be an array of group objects".
-                Some("group") => {
+                // Multi-group pickers, components, and versions must be written
+                // as an array of objects keyed by `name`. Jira rejects bare
+                // strings with: "Operation value must be an array of ... objects".
+                Some("group") | Some("component") | Some("version") => {
                     let items: Vec<serde_json::Value> = values
                         .iter()
                         .map(|v| serde_json::json!({ "name": *v }))
@@ -915,7 +933,7 @@ const CREATE_HANDLED_FIELDS: &[&str] = &["priority", "type", "issuetype"];
 /// `CustomFieldUpdate::State` is partitioned out upstream and routed to the
 /// /transitions endpoint, so a status-named field seen here was mistyped
 /// (e.g. SingleEnum) and is about to be dropped.
-const UPDATE_HANDLED_FIELDS: &[&str] = &["priority"];
+const UPDATE_HANDLED_FIELDS: &[&str] = &["priority", "assignee"];
 
 /// Warning for a reserved-name field that is about to be silently dropped, or
 /// None when the caller's typed struct already carries it.
@@ -1214,6 +1232,30 @@ mod tests {
     }
 
     #[test]
+    fn resolve_extra_fields_serializes_components_as_name_objects() {
+        let custom_fields = vec![CustomFieldUpdate::MultiEnum {
+            name: "Components".to_string(),
+            values: vec!["clpp".to_string()],
+        }];
+        let jira_fields = vec![JiraField {
+            id: "components".to_string(),
+            name: "Components".to_string(),
+            custom: false,
+            schema: Some(JiraFieldSchema {
+                field_type: "array".to_string(),
+                custom: None,
+                items: Some("component".to_string()),
+            }),
+        }];
+
+        let extra = resolve_extra_fields(&custom_fields, &jira_fields, &[]).unwrap();
+        assert_eq!(
+            extra.get("components"),
+            Some(&serde_json::json!([{ "name": "clpp" }]))
+        );
+    }
+
+    #[test]
     fn resolve_extra_fields_serializes_multi_group_picker_as_name_objects() {
         let custom_fields = vec![CustomFieldUpdate::MultiEnum {
             name: "Partner".to_string(),
@@ -1424,6 +1466,9 @@ mod tests {
         // priority is consumed by the typed struct on both paths
         assert!(dropped_reserved_field_warning("Priority", UPDATE_HANDLED_FIELDS).is_none());
         assert!(dropped_reserved_field_warning("priority", CREATE_HANDLED_FIELDS).is_none());
+        // assignee is consumed by the typed struct on update, but not yet at create
+        assert!(dropped_reserved_field_warning("Assignee", UPDATE_HANDLED_FIELDS).is_none());
+        assert!(dropped_reserved_field_warning("assignee", CREATE_HANDLED_FIELDS).is_some());
         // issue type is only consumed at create; dropping it from an update is a real loss
         assert!(dropped_reserved_field_warning("Type", CREATE_HANDLED_FIELDS).is_none());
         assert!(dropped_reserved_field_warning("issuetype", CREATE_HANDLED_FIELDS).is_none());
@@ -1433,11 +1478,26 @@ mod tests {
     }
 
     #[test]
-    fn dropped_assignee_warns_without_transition_hint() {
-        let msg = dropped_reserved_field_warning("Assignee", UPDATE_HANDLED_FIELDS)
-            .expect("dropping an assignee field edit must warn");
-        assert!(msg.contains("Assignee"));
-        assert!(!msg.contains("transition"));
+    fn update_issue_to_jira_maps_assignee_to_account_id() {
+        let update = UpdateIssue {
+            summary: None,
+            description: None,
+            tags: vec![],
+            parent: None,
+            custom_fields: vec![CustomFieldUpdate::SingleUser {
+                name: "Assignee".to_string(),
+                login: "608b11992911000071b5b0bd".to_string(),
+            }],
+        };
+        let jira_update = update_issue_to_jira(&update, &[]).expect("conversion should succeed");
+        let assignee = jira_update
+            .fields
+            .assignee
+            .expect("assignee should be set on the typed struct");
+        assert_eq!(
+            assignee.account_id.as_deref(),
+            Some("608b11992911000071b5b0bd")
+        );
     }
 
     #[test]

--- a/crates/jira-backend/src/models/issue.rs
+++ b/crates/jira-backend/src/models/issue.rs
@@ -306,6 +306,14 @@ pub struct ParentId {
     pub key: Option<String>,
 }
 
+/// Assignee identifier for requests (Jira Cloud uses account IDs, not usernames)
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssigneeId {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+}
+
 /// Request to update an issue
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -327,6 +335,8 @@ pub struct UpdateJiraIssueFields {
     pub labels: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<ParentId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<AssigneeId>,
     /// Arbitrary custom fields (e.g., "customfield_10016": 5)
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,

--- a/crates/jira-backend/src/trait_impl.rs
+++ b/crates/jira-backend/src/trait_impl.rs
@@ -298,6 +298,16 @@ impl IssueTracker for JiraClient {
             }
         }
 
+        // Try to fetch real project components and splice them into the "components" field
+        if let Ok(components) = self.list_project_components(project_id) {
+            let values: Vec<String> = components.into_iter().map(|c| c.name).collect();
+            if !values.is_empty()
+                && let Some(components_field) = standard.iter_mut().find(|f| f.id == "components")
+            {
+                components_field.values = values;
+            }
+        }
+
         let instance_fields: Vec<ProjectCustomField> = self
             .get_fields_cached()
             .iter()

--- a/crates/track/Cargo.toml
+++ b/crates/track/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "track"
-version = "1.17.0"
+version = "1.17.1"
 edition = "2024"
 description = "CLI for issue tracking systems (YouTrack, Jira, etc.)"
 


### PR DESCRIPTION
## Problem

Two standard Jira fields the CLI claims to support were unusable against the Jira backend:

**1. `--assignee` was silently dropped on update.** `UpdateJiraIssueFields` had no `assignee` field, so `issue update --assignee <accountId>` emitted `Warning: Field 'Assignee' was not applied: the Jira backend does not set it through field edits.` and made no change — a unit test (`dropped_assignee_warns_without_transition_hint`) even asserted this behavior. The same applied to `--field Assignee=...` and `track apply` plans, since all paths converge on the same typed struct.

**2. `Components` could not be set or validated.** `get_project_custom_fields` only surfaced fields with `custom == true`, so the Jira *system* field `components` never appeared in the project schema: `track project fields` didn't list it, the pre-flight check warned `field 'Components' not found in project schema`, and `--validate` hard-failed with `Unknown field 'Components'`. Even bypassing validation, `custom_field_to_json` serialized `array` fields with `items: component` as bare strings (`["foo"]`), which Jira rejects — components must be written as `[{"name": "foo"}]`, the same shape already special-cased for group pickers.

## Fix

- Add `assignee` to `UpdateJiraIssueFields` (serialized as `{"accountId": ...}`) and map `CustomFieldUpdate::SingleUser { name: "Assignee" }` onto it in `update_issue_to_jira`. `assignee` joins `UPDATE_HANDLED_FIELDS` so it's consumed silently instead of warned about.
- Add `components` to `get_standard_custom_fields()` as an `enum[*]` field, and splice in the project's real component names via a new `JiraClient::list_project_components` (`GET /project/{key}/components`) — mirroring how project statuses are already spliced. `--validate` now checks component values against the project's actual component list.
- Serialize `array` items of type `component` and `version` as `{"name": ...}` objects, sharing the existing `group` arm.

## Testing

- New unit tests: `update_issue_to_jira_maps_assignee_to_account_id`, `resolve_extra_fields_serializes_components_as_name_objects`; updated `typed_struct_fields_drop_silently_per_call_site` for the new update-path behavior.
- All 134 jira-backend tests pass; clippy `--all-targets` and `cargo fmt --check` clean.
- Verified end-to-end against a live Jira Cloud instance: batch-assigned and set `Components` on 81 issues (epic + tasks + subtasks), confirmed via fresh reads; `--validate --dry-run` accepts valid component names and rejects invalid ones with the project's component list.