### PR TITLE
⚡ Bolt: Replace O(n^2) Vec lookup with O(1) HashSet

### DIFF
--- a/crates/track/src/commands/context.rs
+++ b/crates/track/src/commands/context.rs
@@ -234,10 +234,10 @@ pub fn handle_context(
                 println!();
                 println!("{}:", "Issue Counts".white().bold());
                 // Group by project
-                let mut projects_seen: Vec<String> = Vec::new();
+                // ⚡ Bolt: Use a HashSet to avoid O(n^2) Vec lookup and borrow string references to remove redundant clones on the hot path
+                let mut projects_seen = std::collections::HashSet::new();
                 for ic in &context.issue_counts {
-                    if !projects_seen.contains(&ic.project_short_name) {
-                        projects_seen.push(ic.project_short_name.clone());
+                    if projects_seen.insert(&ic.project_short_name) {
                         let counts: Vec<String> = context
                             .issue_counts
                             .iter()


### PR DESCRIPTION
💡 **What:** Replaced the `Vec<String>` used for deduplicating projects in the `handle_context` function with a `HashSet<&String>`. Also removed a redundant `.clone()` call.

🎯 **Why:** The previous implementation used an O(n²) algorithm to check if a project had been seen by calling `.contains()` on a `Vec` inside a loop. By using a `HashSet`, we reduce this to an O(n) algorithm. Additionally, using a `HashSet` allows us to borrow the string reference (`&String`) directly from the struct rather than redundantly `.clone()`ing it on the hot path.

📊 **Measured Improvement:** Reduces time complexity of deduplication from O(n²) to O(n) and avoids unnecessary string allocations.

---
*PR created automatically by Jules for task [14695789324420909611](https://jules.google.com/task/14695789324420909611) started by @johnsdav*